### PR TITLE
Make connect() optional

### DIFF
--- a/python/hopsworks/connection.py
+++ b/python/hopsworks/connection.py
@@ -39,6 +39,8 @@ class Connection:
         self._connected = False
         self._client = None
 
+        self.connect()
+
     @classmethod
     def connection(
         cls,
@@ -64,6 +66,7 @@ class Connection:
             api_key_file,
         )
 
+    @util.not_connected
     def connect(self):
         self._connected = True
         try:
@@ -89,14 +92,14 @@ class Connection:
         except (TypeError, ConnectionError):
             self._connected = False
             raise
-        print("CONNECTED")
+        print("Connected. Call `.close()` to terminate connection gracefully.")
 
     def close(self):
         self._client._close()
         self._feature_store_api = None
         engine.stop()
         self._connected = False
-        print("CONNECTION CLOSED")
+        print("Connection closed.")
 
     @util.connected
     def get_feature_store(self, name=None):


### PR DESCRIPTION
Makes the connect call optional.

When `hopsworks.connection()` is called with all necessary arguments for the given environment, it will connect immediately. If arguments such as host or project are missing, the user has the possibility to change them on the connection object and then call `connect()` again.
Or the user can simply add the missing argument to the `connection()` call.