### PR TITLE
Training Dataset set Id from backend after creation

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/engine/TrainingDatasetEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/TrainingDatasetEngine.java
@@ -67,6 +67,7 @@ public class TrainingDatasetEngine {
     // Update the original object - Hopsworks returns the full location and incremented version
     trainingDataset.setLocation(apiTD.getLocation());
     trainingDataset.setVersion(apiTD.getVersion());
+    trainingDataset.setId(apiTD.getId());
 
     // Build write options map
     Map<String, String> writeOptions =


### PR DESCRIPTION
never encountered this since I was always testing with a training dataset that was already created.