### PR TITLE
HSFS is defaulting to PyHive instead of Spark on EMR

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/HopsworksConnection.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/HopsworksConnection.java
@@ -85,10 +85,9 @@ public class HopsworksConnection implements Closeable {
     this.apiKeyFilePath = apiKeyFilePath;
     this.apiKeyValue = apiKeyValue;
 
-    HopsworksClient hopsworksClient = HopsworksClient.setupHopsworksClient(host, port, region, secretStore,
+    HopsworksClient.setupHopsworksClient(host, port, region, secretStore,
         hostnameVerification, trustStorePath, this.apiKeyFilePath, this.apiKeyValue);
     projectObj = getProject();
-    hopsworksClient.downloadCredentials(projectObj, certPath);
   }
 
   /**

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksClient.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksClient.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.logicalclocks.hsfs.FeatureStoreException;
-import com.logicalclocks.hsfs.Project;
 import com.logicalclocks.hsfs.SecretStore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -154,9 +153,5 @@ public class HopsworksClient {
 
   public <T> T handleRequest(HttpRequest request) throws IOException, FeatureStoreException {
     return hopsworksHttpClient.handleRequest(request, null);
-  }
-
-  public void downloadCredentials(Project project, String certPath) throws IOException, FeatureStoreException {
-    certPwd = hopsworksHttpClient.downloadCredentials(project, certPath);
   }
 }

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksExternalClient.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksExternalClient.java
@@ -18,10 +18,8 @@ package com.logicalclocks.hsfs.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.logicalclocks.hsfs.FeatureStoreException;
-import com.logicalclocks.hsfs.Project;
 import com.logicalclocks.hsfs.SecretStore;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.net.util.Base64;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
@@ -242,18 +240,5 @@ public class HopsworksExternalClient implements HopsworksHttpClient {
       // Internal exception, try one more time
       return httpClient.execute(httpHost, request, authHandler);
     }
-  }
-
-  @Override
-  public String downloadCredentials(Project project, String certPath) throws IOException, FeatureStoreException {
-    LOGGER.info("Fetching certificates for the project");
-    ProjectApi projectApi = new ProjectApi();
-    Credentials credentials = projectApi.downloadCredentials(project);
-
-    FileUtils.writeByteArrayToFile(Paths.get(certPath, "keyStore.jks").toFile(),
-        Base64.decodeBase64(credentials.getkStore()));
-    FileUtils.writeByteArrayToFile(Paths.get(certPath, "trustStore.jks").toFile(),
-        Base64.decodeBase64(credentials.gettStore()));
-    return credentials.getPassword();
   }
 }

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksHttpClient.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksHttpClient.java
@@ -17,7 +17,6 @@
 package com.logicalclocks.hsfs.metadata;
 
 import com.logicalclocks.hsfs.FeatureStoreException;
-import com.logicalclocks.hsfs.Project;
 import org.apache.http.HttpRequest;
 import org.apache.http.client.ResponseHandler;
 
@@ -26,6 +25,4 @@ import java.io.IOException;
 public interface HopsworksHttpClient {
   <T> T handleRequest(HttpRequest request, ResponseHandler<T> responseHandler)
       throws IOException, FeatureStoreException;
-
-  String downloadCredentials(Project project, String certPath) throws IOException, FeatureStoreException;
 }

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksInternalClient.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/HopsworksInternalClient.java
@@ -17,7 +17,6 @@
 package com.logicalclocks.hsfs.metadata;
 
 import com.logicalclocks.hsfs.FeatureStoreException;
-import com.logicalclocks.hsfs.Project;
 import jdk.nashorn.internal.runtime.regexp.joni.exception.InternalException;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
@@ -156,11 +155,5 @@ public class HopsworksInternalClient implements HopsworksHttpClient {
       // Internal exception, try one more time
       return httpClient.execute(httpHost, request, authHandler);
     }
-  }
-
-  @Override
-  public String downloadCredentials(Project project, String certPath) {
-    // In Hopsworks internal client credentials are already setup.
-    return null;
   }
 }

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/ProjectApi.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/ProjectApi.java
@@ -30,7 +30,6 @@ public class ProjectApi {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProjectApi.class);
 
   private static final String PROJECT_INFO_PATH = "/project/getProjectInfo{/projectName}";
-  private static final String CREDENTIALS_PATH = "/project{/projectId}/credentials";
 
   public Project get(String name) throws IOException, FeatureStoreException {
     HopsworksClient hopsworksClient = HopsworksClient.getInstance();
@@ -39,14 +38,5 @@ public class ProjectApi {
         .expand();
     LOGGER.info("Sending metadata request: " + uri);
     return hopsworksClient.handleRequest(new HttpGet(uri), Project.class);
-  }
-
-  public Credentials downloadCredentials(Project project) throws IOException, FeatureStoreException {
-    HopsworksClient hopsworksClient = HopsworksClient.getInstance();
-    String uri = UriTemplate.fromTemplate(HopsworksClient.API_PATH + CREDENTIALS_PATH)
-        .set("projectId", project.getProjectId())
-        .expand();
-    LOGGER.info("Sending metadata request: " + uri);
-    return hopsworksClient.handleRequest(new HttpGet(uri), Credentials.class);
   }
 }

--- a/java/src/test/java/com/logicalclocks/hsfs/TestHopsworksExternalClient.java
+++ b/java/src/test/java/com/logicalclocks/hsfs/TestHopsworksExternalClient.java
@@ -16,7 +16,6 @@
 package com.logicalclocks.hsfs;
 
 import com.logicalclocks.hsfs.metadata.Credentials;
-import com.logicalclocks.hsfs.metadata.HopsworksClient;
 import com.logicalclocks.hsfs.metadata.HopsworksExternalClient;
 import io.specto.hoverfly.junit.core.SimulationSource;
 import io.specto.hoverfly.junit.dsl.HttpBodyConverter;
@@ -53,21 +52,6 @@ public class TestHopsworksExternalClient {
         .willReturn(success().body(HttpBodyConverter.json(credentials)))
     ));
 
-  // @Test
-  // public void testReadAPIKey() throws IOException, FeatureStoreException {
-  //   CloseableHttpClient httpClient = HttpClients.createSystem();
-  //   try {
-  //     HopsworksConnection hc = HopsworksConnection.builder().host("35.241.253.100").hostnameVerification(false)
-  //             .project("demo_featurestore_admin000")
-  //             .apiKeyValue("ovVQksgJezSckjyK.ftO2YywCI6gZp4btlvWRnSDjSgyAQgCTRAoQTTSXBxPRMo0Dq029eAf3HVq3I6JO").build();
-  //     System.out.println("Connected");
-  //     FeatureStore fs = hc.getFeatureStore();
-  //     Assert.assertTrue(fs != null);
-  //   } catch (Exception e) {
-  // 	// Do not assert an error as this unit test method needs an external cluster
-  //   }
-  // }
-
   @Test
   public void testReadAPIKeyFromFile() throws IOException, FeatureStoreException {
     Path apiFilePath = Paths.get(System.getProperty("java.io.tmpdir"), "test.api");
@@ -78,20 +62,5 @@ public class TestHopsworksExternalClient {
         httpClient, httpHost);
     String apiKey = hopsworksExternalClient.readApiKey(null, null, apiFilePath.toString());
     Assert.assertEquals("hello", apiKey);
-  }
-
-  @Test
-  public void testDownloadCredential() throws Exception {
-    Project project = new Project(1);
-
-    CloseableHttpClient httpClient = HttpClients.createSystem();
-    HttpHost httpHost = new HttpHost("test");
-
-    HopsworksExternalClient hopsworksExternalClient = new HopsworksExternalClient(
-        httpClient, httpHost);
-
-    HopsworksClient.setInstance(new HopsworksClient(hopsworksExternalClient));
-    String password = hopsworksExternalClient.downloadCredentials(project, System.getProperty("java.io.tmpdir"));
-    Assert.assertEquals(certPwd, password);
   }
 }

--- a/python/hsfs/connection.py
+++ b/python/hsfs/connection.py
@@ -180,8 +180,6 @@ class Connection:
                         self._secrets_store,
                         self._hostname_verification,
                         self._trust_store_path
-                        if self._trust_store_path is not None
-                        else None,
                         None,
                         self._api_key_file,
                         self._api_key_value,

--- a/python/hsfs/connection.py
+++ b/python/hsfs/connection.py
@@ -170,7 +170,7 @@ class Connection:
         try:
             if client.base.Client.REST_ENDPOINT not in os.environ:
                 if importlib.util.find_spec("pyspark"):
-                    # databricks, emr, external spark clusters 
+                    # databricks, emr, external spark clusters
                     client.init(
                         "external",
                         self._host,

--- a/python/hsfs/connection.py
+++ b/python/hsfs/connection.py
@@ -179,7 +179,7 @@ class Connection:
                         self._region_name,
                         self._secrets_store,
                         self._hostname_verification,
-                        self._trust_store_path
+                        self._trust_store_path,
                         None,
                         self._api_key_file,
                         self._api_key_value,

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-import os
+import importlib.util
 
 import pandas as pd
 import numpy as np
@@ -45,7 +45,7 @@ class Engine:
         self._spark_session.conf.set("hive.exec.dynamic.partition.mode", "nonstrict")
         self._spark_session.conf.set("spark.sql.hive.convertMetastoreParquet", "false")
 
-        if not os.path.exists("/dbfs/"):
+        if importlib.util.find_spec("pydoop"):
             # If we are on Databricks don't setup Pydoop as it's not available and cannot be easily installed.
             self._setup_pydoop()
 


### PR DESCRIPTION
Also remove downloading of the certificates in the connect method for
PySpark clients. Certificates should already be present when the
application is started.

Closes #170