### PR TITLE
JDBC connector spark_options should provide all the properties

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -135,7 +135,7 @@ public class StorageConnector {
   }
 
   @JsonIgnore
-  private Map<String, String> getJdbcOptions() throws FeatureStoreException {
+  private Map<String, String> getJdbcOptions() {
     Map<String, String> options = Arrays.stream(arguments.split(","))
         .map(arg -> arg.split("="))
         .collect(Collectors.toMap(a -> a[0], a -> a[1]));

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -322,8 +322,7 @@ class StorageConnector:
 
     @property
     def path(self):
-        """If the connector refers to a path (e.g. S3) - return the path of the connector
-        """
+        """If the connector refers to a path (e.g. S3) - return the path of the connector"""
         if self._storage_connector_type.upper() == "S3":
             return "s3://" + self._bucket
         else:
@@ -338,11 +337,10 @@ class StorageConnector:
         if self._storage_connector_type.upper() == "JDBC":
             args = [arg.split("=") for arg in self._arguments.split(",")]
 
-            return {
-                "url": self._connection_string,
-                "user": [arg[1] for arg in args if arg[0] == "user"][0],
-                "password": [arg[1] for arg in args if arg[0] == "password"][0],
-            }
+            options = {a[0]: a[1] for a in args}
+            options["url"] = self._connection_string
+
+            return options
         elif self._storage_connector_type.upper() == "REDSHIFT":
             connstr = (
                 "jdbc:redshift://"


### PR DESCRIPTION
We allow users to configure additional properties for their JDBC
storage connector to control performance, driver and so on.

These properties needs to be included in the spark_options method

(This was already fixed in https://github.com/logicalclocks/feature-store-api/pull/172 - but a bad merge rolled back the change)