### PR TITLE
Better Job handling for Hive engine

### DIFF
--- a/auto_doc.py
+++ b/auto_doc.py
@@ -350,6 +350,9 @@ PAGES = {
             "hsfs.feature_store.FeatureStore.get_transformation_functions"
         ],
     },
+    "api/job_configuration.md": {
+        "job_configuration": ["hsfs.core.job_configuration.JobConfiguration"]
+    },
 }
 
 hsfs_dir = pathlib.Path(__file__).resolve().parents[0]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Expectation: generated/api/expectation_api.md
       - Validation: generated/api/validation_api.md
       - Transformation functions: generated/api/transformation_functions_api.md
+      - Job configuration: generated/api/job_configuration.md
     - Contributing: CONTRIBUTING.md
   - Hopsworks.ai:
     - Introduction: hopsworksai/index.md

--- a/python/hsfs/core/execution.py
+++ b/python/hsfs/core/execution.py
@@ -44,7 +44,6 @@ class Execution:
 
     @classmethod
     def from_response_json(cls, json_dict):
-        print(json_dict)
         json_decamelized = humps.decamelize(json_dict)
         if json_decamelized["count"] == 0:
             return []

--- a/python/hsfs/core/execution.py
+++ b/python/hsfs/core/execution.py
@@ -1,5 +1,5 @@
 #
-#   Copyright 2020 Logical Clocks AB
+#   Copyright 2021 Logical Clocks AB
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -17,44 +17,47 @@
 import humps
 
 
-class Job:
+class Execution:
     def __init__(
         self,
         id,
-        name,
-        creation_time,
-        config,
-        job_type,
-        creator,
-        executions=None,
+        state,
+        final_status,
+        submission_time=None,
+        stdout_path=None,
+        stderr_path=None,
+        app_id=None,
+        hdfs_user=None,
+        args=None,
+        progress=None,
+        user=None,
+        files_to_remove=None,
+        duration=None,
+        flink_master_url=None,
+        monitoring=None,
         type=None,
         href=None,
-        expand=None,
-        items=None,
-        count=None,
     ):
         self._id = id
-        self._name = name
-        self._executions = executions
-        self._href = href
+        self._final_status = final_status
+        self._state = state
 
     @classmethod
     def from_response_json(cls, json_dict):
+        print(json_dict)
         json_decamelized = humps.decamelize(json_dict)
-        return cls(**json_decamelized)
-
-    @property
-    def name(self):
-        return self._name
+        if json_decamelized["count"] == 0:
+            return []
+        return [cls(**execution) for execution in json_decamelized["items"]]
 
     @property
     def id(self):
         return self._id
 
     @property
-    def executions(self):
-        return self._executions
+    def final_status(self):
+        return self._final_status
 
     @property
-    def href(self):
-        return self._href
+    def state(self):
+        return self._state

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -52,7 +52,7 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
         offline_write_options = write_options
         online_write_options = self.get_kafka_config(write_options)
 
-        engine.get_instance().save_dataframe(
+        return engine.get_instance().save_dataframe(
             feature_group,
             feature_dataframe,
             hudi_engine.HudiEngine.HUDI_BULK_INSERT
@@ -90,7 +90,7 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
         if overwrite:
             self._feature_group_api.delete_content(feature_group)
 
-        engine.get_instance().save_dataframe(
+        return engine.get_instance().save_dataframe(
             feature_group,
             feature_dataframe,
             "bulk_insert" if overwrite else operation,

--- a/python/hsfs/core/job_api.py
+++ b/python/hsfs/core/job_api.py
@@ -15,7 +15,7 @@
 #
 
 from hsfs import client
-from hsfs.core import job
+from hsfs.core import job, execution
 
 
 class JobApi:
@@ -35,3 +35,16 @@ class JobApi:
         path_params = ["project", _client._project_id, "jobs", name, "executions"]
 
         _client._send_request("POST", path_params)
+
+    def last_execution(self, job):
+        _client = client.get_instance()
+        path_params = ["project", _client._project_id, "jobs", job.name, "executions"]
+
+        query_params = {"limit": 1, "sort_by": "submissiontime:desc"}
+
+        headers = {"content-type": "application/json"}
+        return execution.Execution.from_response_json(
+            _client._send_request(
+                "GET", path_params, headers=headers, query_params=query_params
+            )
+        )

--- a/python/hsfs/core/training_dataset_engine.py
+++ b/python/hsfs/core/training_dataset_engine.py
@@ -79,12 +79,12 @@ class TrainingDatasetEngine:
                 )
 
         self._training_dataset_api.post(training_dataset)
-        engine.get_instance().write_training_dataset(
+        return engine.get_instance().write_training_dataset(
             training_dataset, features, user_write_options, self.OVERWRITE
         )
 
     def insert(self, training_dataset, dataset, user_write_options, overwrite):
-        engine.get_instance().write_training_dataset(
+        return engine.get_instance().write_training_dataset(
             training_dataset,
             dataset,
             user_write_options,

--- a/python/hsfs/engine/hive.py
+++ b/python/hsfs/engine/hive.py
@@ -17,6 +17,7 @@
 import pandas as pd
 import numpy as np
 import boto3
+import time
 
 from pyhive import hive
 from urllib.parse import urlparse
@@ -32,6 +33,7 @@ from hsfs.core import (
     training_dataset_job_conf,
 )
 from hsfs.constructor import query
+from hsfs.client import exceptions
 
 
 class Engine:
@@ -183,6 +185,8 @@ class Engine:
             )
         )
 
+        self._wait_for_job(job)
+
     def set_job_group(self, group_id, description):
         pass
 
@@ -249,45 +253,19 @@ class Engine:
 
         # Launch job
         print("Launching ingestion job...")
-        self._job_api.launch(ingestion_job.job.name)
+        fg_job = self._job_api.launch(ingestion_job.job.name)
         print(
             "Ingestion Job started successfully, you can follow the progress at {}".format(
                 self._get_job_url(ingestion_job.job.href)
             )
         )
 
-    def _get_job_url(self, href: str):
-        """Use the endpoint returned by the API to construct the UI url for jobs
+        # If the user passed the wait_for_job option consider it,
+        # otherwise use the default True
+        if offline_write_options.pop("wait_for_job", True):
+            self._wait_for_job(fg_job)
 
-        Args:
-            href (str): the endpoint returned by the API
-        """
-        url_splits = urlparse(href)
-        project_id = url_splits.path.split("/")[4]
-        ui_url = url_splits._replace(
-            path="hopsworks/#!/project/{}/jobs".format(project_id)
-        )
-        return ui_url.geturl()
-
-    def _get_app_options(self, user_write_options={}):
-        """
-        Generate the options that should be passed to the application doing the ingestion.
-        Options should be data format, data options to read the input dataframe and
-        insert options to be passed to the insert method
-
-        Users can pass Spark configurations to the save/insert method
-        Property name should match the value in the JobConfiguration.__init__
-        """
-        spark_job_configuration = user_write_options.pop("spark", None)
-        return ingestion_job_conf.IngestionJobConf(
-            data_format="CSV",
-            data_options=[
-                {"name": "header", "value": "true"},
-                {"name": "inferSchema", "value": "true"},
-            ],
-            write_options=user_write_options,
-            spark_job_configuration=spark_job_configuration,
-        )
+        return fg_job
 
     def write_training_dataset(
         self, training_dataset, dataset, user_write_options, save_mode
@@ -316,6 +294,13 @@ class Engine:
                 self._get_job_url(td_job.href)
             )
         )
+
+        # If the user passed the wait_for_job option consider it,
+        # otherwise use the default True
+        if user_write_options.pop("wait_for_job", True):
+            self._wait_for_job(td_job)
+
+        return td_job
 
     def _create_hive_connection(self, feature_store):
         return hive.Connection(
@@ -357,3 +342,55 @@ class Engine:
         raise NotImplementedError(
             "Stream ingestion is not available on Python environments, because it requires Spark as engine."
         )
+
+    def _get_job_url(self, href: str):
+        """Use the endpoint returned by the API to construct the UI url for jobs
+
+        Args:
+            href (str): the endpoint returned by the API
+        """
+        url_splits = urlparse(href)
+        project_id = url_splits.path.split("/")[4]
+        ui_url = url_splits._replace(
+            path="hopsworks/#!/project/{}/jobs".format(project_id)
+        )
+        return ui_url.geturl()
+
+    def _get_app_options(self, user_write_options={}):
+        """
+        Generate the options that should be passed to the application doing the ingestion.
+        Options should be data format, data options to read the input dataframe and
+        insert options to be passed to the insert method
+
+        Users can pass Spark configurations to the save/insert method
+        Property name should match the value in the JobConfiguration.__init__
+        """
+        spark_job_configuration = user_write_options.pop("spark", None)
+        return ingestion_job_conf.IngestionJobConf(
+            data_format="CSV",
+            data_options=[
+                {"name": "header", "value": "true"},
+                {"name": "inferSchema", "value": "true"},
+            ],
+            write_options=user_write_options,
+            spark_job_configuration=spark_job_configuration,
+        )
+
+    def _wait_for_job(self, job):
+        while True:
+            executions = self._job_api.last_execution(job)
+            if len(executions) > 0:
+                execution = executions[0]
+            else:
+                return
+
+            if execution.final_status.lower() == "succeeded":
+                return
+            elif execution.final_status.lower() == "failed":
+                raise exceptions.FeatureStoreException(
+                    "The Hopsworks Job failed, use the Hopsworks UI to access the job logs"
+                )
+            else:
+                raise exceptions.FeatureStoreException("The Hopsworks Job was stopped")
+
+            time.sleep(3)

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -626,7 +626,7 @@ class FeatureGroup(FeatureGroupBase):
                   feature group.
                 * key `wait_for_job` and value `True` or `False` to configure
                   whether or not to the save call should return only
-                  after the Hopsworks Job has finished.
+                  after the Hopsworks Job has finished. By default it waits.
 
 
         # Returns
@@ -712,7 +712,7 @@ class FeatureGroup(FeatureGroupBase):
                   feature group.
                 * key `wait_for_job` and value `True` or `False` to configure
                   whether or not to the insert call should return only
-                  after the Hopsworks Job has finished.
+                  after the Hopsworks Job has finished. By default it waits.
 
         # Returns
             `FeatureGroup`. Updated feature group metadata object.

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -151,7 +151,7 @@ class TrainingDataset:
                   to configure the Hopsworks Job used to compute the training dataset.
                 * key `wait_for_job` and value `True` or `False` to configure
                   whether or not to the save call should return only
-                  after the Hopsworks Job has finished.
+                  after the Hopsworks Job has finished. By default it waits.
 
         # Returns
             `Job`: When using the `hive` engine, it returns the Hopsworks Job
@@ -210,7 +210,7 @@ class TrainingDataset:
                   to configure the Hopsworks Job used to compute the training dataset.
                 * key `wait_for_job` and value `True` or `False` to configure
                   whether or not to the insert call should return only
-                  after the Hopsworks Job has finished.
+                  after the Hopsworks Job has finished. By default it waits.
 
         # Returns
             `Job`: When using the `hive` engine, it returns the Hopsworks Job

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -224,8 +224,7 @@ class TrainingDataset:
             self, features, write_options, overwrite
         )
 
-        if engine.get_type() == "spark":
-            self.compute_statistics()
+        self.compute_statistics()
 
         return td_job
 

--- a/python/hsfs/training_dataset.py
+++ b/python/hsfs/training_dataset.py
@@ -143,20 +143,27 @@ class TrainingDataset:
 
         # Arguments
             features: Feature data to be materialized.
-            write_options: Additional write options as key/value pairs.
-                Defaults to `{}`.
+            write_options: Additional write options as key-value pairs, defaults to `{}`.
+                When using the `hive` engine, write_options can contain the
+                following entries:
+                * key `spark` and value an object of type
+                [hsfs.core.job_configuration.JobConfiguration](../job_configuration)
+                  to configure the Hopsworks Job used to compute the training dataset.
+                * key `wait_for_job` and value `True` or `False` to configure
+                  whether or not to the save call should return only
+                  after the Hopsworks Job has finished.
 
         # Returns
-            `TrainingDataset`: The updated training dataset metadata object, the
-                previous `TrainingDataset` object on which you call `save` is also
-                updated.
+            `Job`: When using the `hive` engine, it returns the Hopsworks Job
+                that was launched to create the training dataset.
 
         # Raises
             `RestAPIError`: Unable to create training dataset metadata.
         """
         user_version = self._version
         user_stats_config = self._statistics_config
-        self._training_dataset_engine.save(self, features, write_options)
+        # td_job is used only if the hive engine is used
+        td_job = self._training_dataset_engine.save(self, features, write_options)
         # currently we do not save the training dataset statistics config for training datasets
         self.statistics_config = user_stats_config
         if self.statistics_config.enabled and engine.get_type() == "spark":
@@ -168,7 +175,8 @@ class TrainingDataset:
                 ),
                 util.VersionWarning,
             )
-        return self
+
+        return td_job
 
     def insert(
         self,
@@ -194,20 +202,32 @@ class TrainingDataset:
         # Arguments
             features: Feature data to be materialized.
             overwrite: Whether to overwrite the entire data in the training dataset.
-            write_options: Additional write options as key/value pairs.
-                Defaults to `{}`.
+            write_options: Additional write options as key-value pairs, defaults to `{}`.
+                When using the `hive` engine, write_options can contain the
+                following entries:
+                * key `spark` and value an object of type
+                [hsfs.core.job_configuration.JobConfiguration](../job_configuration)
+                  to configure the Hopsworks Job used to compute the training dataset.
+                * key `wait_for_job` and value `True` or `False` to configure
+                  whether or not to the insert call should return only
+                  after the Hopsworks Job has finished.
 
         # Returns
-            `TrainingDataset`: The updated training dataset metadata object, the
-                previous `TrainingDataset` object on which you call `save` is also
-                updated.
+            `Job`: When using the `hive` engine, it returns the Hopsworks Job
+                that was launched to create the training dataset.
 
         # Raises
             `RestAPIError`: Unable to create training dataset metadata.
         """
-        self._training_dataset_engine.insert(self, features, write_options, overwrite)
+        # td_job is used only if the hive engine is used
+        td_job = self._training_dataset_engine.insert(
+            self, features, write_options, overwrite
+        )
 
-        self.compute_statistics()
+        if engine.get_type() == "spark":
+            self.compute_statistics()
+
+        return td_job
 
     def read(self, split=None, read_options={}):
         """Read the training dataset into a dataframe.


### PR DESCRIPTION
* When calling save or insert on training datasets/feature groups
  return the object to the user so that they can monitor the execution

* Add an option (wait_for_job, default True) to wait for the execution
  to be finished before save or insert returns

* Update the documentation