### PR TITLE
fix tfdata pattern glob if split is none

### DIFF
--- a/python/hsfs/core/tfdata_engine.py
+++ b/python/hsfs/core/tfdata_engine.py
@@ -402,12 +402,7 @@ class TFDataEngine:
     def _get_hopsfs_dataset_files(self, training_dataset_location, split):
         path = training_dataset_location.replace("hopsfs", "hdfs")
         if split is None:
-            if self._training_dataset.splits:
-                input_files = tf.io.gfile.glob(
-                    path + "/" + "*" + "/" + self._file_pattern
-                )
-            else:
-                input_files = tf.io.gfile.glob(path + "/" + self._file_pattern)
+            input_files = tf.io.gfile.glob(path + "/" + "*" + "/" + self._file_pattern)
         else:
             input_files = tf.io.gfile.glob(
                 path + "/" + split + "/" + self._file_pattern


### PR DESCRIPTION
Bug fix for tfdata listing files correctly. This PR is amendment for  https://github.com/logicalclocks/feature-store-api/issues/405