### PR TITLE
Fix jdbc connector arguments split for no arguments

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs</artifactId>
-    <version>2.2.16</version>
+    <version>2.2.17</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -45,7 +45,12 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
 
         self._feature_group_api.save(feature_group)
         validation_id = None
-        if feature_group.validation_type != "NONE":
+        if (
+            feature_group.validation_type != "NONE"
+            and engine.get_instance().get_type() == "spark"
+        ):
+            # If the engine is Hive, the validation will be executed by
+            # the Hopsworks job ingesting the data
             validation = feature_group.validate(feature_dataframe)
             validation_id = validation.validation_id
 
@@ -75,7 +80,12 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
         write_options,
     ):
         validation_id = None
-        if feature_group.validation_type != "NONE":
+        if (
+            feature_group.validation_type != "NONE"
+            and engine.get_instance().get_type() == "spark"
+        ):
+            # If the engine is Hive, the validation will be executed by
+            # the Hopsworks job ingesting the data
             validation = feature_group.validate(feature_dataframe)
             validation_id = validation.validation_id
 

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -583,9 +583,15 @@ class StorageConnector:
         arguments.
         """
         if self._storage_connector_type.upper() == self.JDBC:
-            args = [arg.split("=") for arg in self._arguments.split(",")]
+            options = (
+                {
+                    a[0]: a[1]
+                    for a in [arg.split("=") for arg in self._arguments.split(",")]
+                }
+                if self._arguments
+                else {}
+            )
 
-            options = {a[0]: a[1] for a in args}
             options["url"] = self._connection_string
 
             return options

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "2.2.16"
+__version__ = "2.2.17"

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1,0 +1,76 @@
+#
+#   Copyright 2021 Logical Clocks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hsfs.storage_connector import StorageConnector
+
+
+class TestJdbcConnector:
+    def test_spark_options_arguments_none(self):
+        connection_string = (
+            "jdbc:mysql://mysql_server_ip:1433;database=test;loginTimeout=30;"
+        )
+
+        jdbc_connector = StorageConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=3,
+            storage_connector_type="JDBC",
+            connection_string=connection_string,
+            arguments=None,
+        )
+
+        spark_options = jdbc_connector.spark_options()
+
+        assert spark_options["url"] == connection_string
+
+    def test_spark_options_arguments_empty(self):
+        connection_string = (
+            "jdbc:mysql://mysql_server_ip:1433;database=test;loginTimeout=30;"
+        )
+
+        jdbc_connector = StorageConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=1,
+            storage_connector_type="JDBC",
+            connection_string=connection_string,
+            arguments="",
+        )
+
+        spark_options = jdbc_connector.spark_options()
+
+        assert spark_options["url"] == connection_string
+
+    def test_spark_options_arguments_arguments(self):
+        connection_string = (
+            "jdbc:mysql://mysql_server_ip:1433;database=test;loginTimeout=30;"
+        )
+        arguments = "arg1=value1,arg2=value2"
+
+        jdbc_connector = StorageConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=1,
+            storage_connector_type="JDBC",
+            connection_string=connection_string,
+            arguments=arguments,
+        )
+
+        spark_options = jdbc_connector.spark_options()
+
+        assert spark_options["url"] == connection_string
+        assert spark_options["arg1"] == "value1"
+        assert spark_options["arg2"] == "value2"


### PR DESCRIPTION
- Handle the case in which the jdbc arguments are empty
- Add tests