### PR TITLE
Fix jdbc connector arguments split for no arguments

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -714,9 +714,12 @@ class JdbcConnector(StorageConnector):
         """Return prepared options to be passed to Spark, based on the additional
         arguments.
         """
-        args = [arg.split("=") for arg in self._arguments.split(",")]
+        options = (
+            {a[0]: a[1] for a in [arg.split("=") for arg in self._arguments.split(",")]}
+            if self._arguments
+            else {}
+        )
 
-        options = {a[0]: a[1] for a in args}
         options["url"] = self._connection_string
 
         return options

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -1,0 +1,73 @@
+#
+#   Copyright 2021 Logical Clocks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hsfs.storage_connector import JdbcConnector
+
+
+class TestJdbcConnector:
+    def test_spark_options_arguments_none(self):
+        connection_string = (
+            "jdbc:mysql://mysql_server_ip:1433;database=test;loginTimeout=30;"
+        )
+
+        jdbc_connector = JdbcConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=1,
+            connection_string=connection_string,
+            arguments=None,
+        )
+
+        spark_options = jdbc_connector.spark_options()
+
+        assert spark_options["url"] == connection_string
+
+    def test_spark_options_arguments_empty(self):
+        connection_string = (
+            "jdbc:mysql://mysql_server_ip:1433;database=test;loginTimeout=30;"
+        )
+
+        jdbc_connector = JdbcConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=1,
+            connection_string=connection_string,
+            arguments="",
+        )
+
+        spark_options = jdbc_connector.spark_options()
+
+        assert spark_options["url"] == connection_string
+
+    def test_spark_options_arguments_arguments(self):
+        connection_string = (
+            "jdbc:mysql://mysql_server_ip:1433;database=test;loginTimeout=30;"
+        )
+        arguments = "arg1=value1,arg2=value2"
+
+        jdbc_connector = JdbcConnector(
+            id=1,
+            name="test_connector",
+            featurestore_id=1,
+            connection_string=connection_string,
+            arguments=arguments,
+        )
+
+        spark_options = jdbc_connector.spark_options()
+
+        assert spark_options["url"] == connection_string
+        assert spark_options["arg1"] == "value1"
+        assert spark_options["arg2"] == "value2"


### PR DESCRIPTION
Fix jdbc connector arguments split for no arguments

- Handle the case in which the jdbc arguments are empty
- Add tests

