### PR TITLE
Snowflake spark_options shouldn't contain dbtable if the table field …

### DIFF
--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -627,12 +627,12 @@ class SnowflakeConnector(StorageConnector):
             "database": self._database,
             "schema": self._schema,
         }
-        if self._password is not None:
+        if self._password:
             props["password"] = self._password
         else:
             props["authenticator"] = "oauth"
             props["token"] = self._token
-        if self._warehouse is not None:
+        if self._warehouse:
             props["warehouse"] = self._warehouse
         return props
 
@@ -645,16 +645,16 @@ class SnowflakeConnector(StorageConnector):
         props["sfSchema"] = self._schema
         props["sfDatabase"] = self._database
         props["sfUser"] = self._user
-        if self._password is not None:
+        if self._password:
             props["sfPassword"] = self._password
         else:
             props["sfAuthenticator"] = "oauth"
             props["sfToken"] = self._token
-        if self._warehouse is not None:
+        if self._warehouse:
             props["sfWarehouse"] = self._warehouse
-        if self._role is not None:
+        if self._role:
             props["sfRole"] = self._role
-        if self._table is not None:
+        if self._table:
             props["dbtable"] = self._table
 
         return props

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-from hsfs.storage_connector import JdbcConnector
+from hsfs.storage_connector import JdbcConnector, SnowflakeConnector
 
 
 class TestJdbcConnector:
@@ -71,3 +71,32 @@ class TestJdbcConnector:
         assert spark_options["url"] == connection_string
         assert spark_options["arg1"] == "value1"
         assert spark_options["arg2"] == "value2"
+
+
+class TestSnowflakeConnector:
+    def test_spark_options_db_table_none(self):
+        snowflake_connector = SnowflakeConnector(
+            id=1, name="test_connector", featurestore_id=1, table=None
+        )
+
+        spark_options = snowflake_connector.spark_options()
+
+        assert "dbtable" not in spark_options
+
+    def test_spark_options_db_table_empty(self):
+        snowflake_connector = SnowflakeConnector(
+            id=1, name="test_connector", featurestore_id=1, table=""
+        )
+
+        spark_options = snowflake_connector.spark_options()
+
+        assert "dbtable" not in spark_options
+
+    def test_spark_options_db_table_value(self):
+        snowflake_connector = SnowflakeConnector(
+            id=1, name="test_connector", featurestore_id=1, table="test"
+        )
+
+        spark_options = snowflake_connector.spark_options()
+
+        assert spark_options["dbtable"] == "test"


### PR DESCRIPTION
…is empty

Currently if the the Snowflake storage connector contains empty string
on the table field, the dbtable option is populated.
Spark does not allow specifying both dbtable and query at the same time
hence the storage connector cannot be used for on-demand feature groups.

This PR fixes it and adds tests.