### PR TITLE
Add failfast option when reading CSV for ingestion (#428)

### DIFF
--- a/python/hsfs/engine/hive.py
+++ b/python/hsfs/engine/hive.py
@@ -363,11 +363,14 @@ class Engine:
         Property name should match the value in the JobConfiguration.__init__
         """
         spark_job_configuration = user_write_options.pop("spark", None)
+        read_csv_mode = user_write_options.pop("mode", "FAILFAST")
+
         return ingestion_job_conf.IngestionJobConf(
             data_format="CSV",
             data_options=[
                 {"name": "header", "value": "true"},
                 {"name": "inferSchema", "value": "true"},
+                {"name": "mode", "value": read_csv_mode},
             ],
             write_options=user_write_options,
             spark_job_configuration=spark_job_configuration,

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -690,6 +690,8 @@ class FeatureGroup(FeatureGroupBase):
                 * key `wait_for_job` and value `True` or `False` to configure
                   whether or not to the save call should return only
                   after the Hopsworks Job has finished. By default it waits.
+                * key `mode` instruct the ingestion job on how to deal with corrupted
+                  data. Values are PERMISSIVE, DROPMALFORMED or FAILFAST. Default FAILFAST.
 
 
         # Returns
@@ -776,6 +778,8 @@ class FeatureGroup(FeatureGroupBase):
                 * key `wait_for_job` and value `True` or `False` to configure
                   whether or not to the insert call should return only
                   after the Hopsworks Job has finished. By default it waits.
+                * key `mode` instruct the ingestion job on how to deal with corrupted
+                  data. Values are PERMISSIVE, DROPMALFORMED or FAILFAST. Default FAILFAST.
 
         # Returns
             `FeatureGroup`. Updated feature group metadata object.


### PR DESCRIPTION
* Add dropmalformed option when reading CSV for ingestion

In Spark 2.4 there was a change on the mode of reading a CSV file when, for some reason you cannot parse one of the columns. In particular:

In version 2.3 and earlier, CSV rows are considered as malformed if at least one column value in the row is malformed. CSV parser dropped such rows in the DROPMALFORMED mode or outputs an error in the FAILFAST mode. Since Spark 2.4, CSV row is considered as malformed only when it contains malformed column values requested from CSV datasource, other values can be ignored. As an example, CSV file contains the "id,name" header and one row "1234". In Spark 2.4, selection of the id column consists of a row with one column value 1234 but in Spark 2.3 and earlier it is empty in the DROPMALFORMED mode. To restore the previous behavior, set spark.sql.csv.parser.columnPruning.enabled to false.

Which, tl;dr; means that in the newer version (Spark 3.1), if a column fails to parse, then only that column is set to null/NaN. While the previous version (Spark 2.3) all the row was set to null.
By setting the DROPMALFORMED mode we are basically removing all the rows which contain at least on column corrupted.

Another case  case is when an entire column is missing. In that case the reading of the data to be ingested gets all misaligned,
meaning that the values of the column missing will be replaced by the values of the next column.
This is the behavior of Spark 3.1. In Spark 2.3 instead, everything is set to null.
Having the mode DROPMALFORMED would in both Spark 3.1 and Spark 2.3 solve this case by removing all the rows and not ingesting anything.

* Change default to FAILFAST and add option for the user to overwrite it.