### PR TITLE
[HOPSWORKS-2948] Rewrite feature store name

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/HopsworksConnection.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/HopsworksConnection.java
@@ -103,7 +103,7 @@ public class HopsworksConnection implements Closeable {
    * @throws FeatureStoreException
    */
   public FeatureStore getFeatureStore() throws IOException, FeatureStoreException {
-    return getFeatureStore(project.toLowerCase() + Constants.FEATURESTORE_SUFFIX);
+    return getFeatureStore(rewriteFeatureStoreName(project));
   }
 
   /**
@@ -116,7 +116,16 @@ public class HopsworksConnection implements Closeable {
    * @throws FeatureStoreException
    */
   public FeatureStore getFeatureStore(String name) throws IOException, FeatureStoreException {
-    return featureStoreApi.get(projectObj.getProjectId(), name);
+    return featureStoreApi.get(projectObj.getProjectId(), rewriteFeatureStoreName(name));
+  }
+
+  private String rewriteFeatureStoreName(String name) {
+    name = name.toLowerCase();
+    if (name.endsWith(Constants.FEATURESTORE_SUFFIX)) {
+      return name;
+    } else {
+      return name + Constants.FEATURESTORE_SUFFIX;
+    }
   }
 
   /**

--- a/java/src/main/java/com/logicalclocks/hsfs/HopsworksConnection.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/HopsworksConnection.java
@@ -108,7 +108,7 @@ public class HopsworksConnection implements Closeable {
 
   /**
    * Retrieve a feature store based on name. The feature store needs to be shared with
-   * the connection's project.
+   * the connection's project. The name is the project name of the feature store.
    *
    * @param name the name of the feature store to get the handle for
    * @return FeatureStore

--- a/python/hsfs/connection.py
+++ b/python/hsfs/connection.py
@@ -155,8 +155,7 @@ class Connection:
         """
         if not name:
             name = client.get_instance()._project_name
-        return self._feature_store_api.get(
-            util.rewrite_feature_store_name(name))
+        return self._feature_store_api.get(util.rewrite_feature_store_name(name))
 
     @not_connected
     def connect(self):

--- a/python/hsfs/connection.py
+++ b/python/hsfs/connection.py
@@ -144,8 +144,8 @@ class Connection:
     def get_feature_store(self, name: str = None):
         """Get a reference to a feature store to perform operations on.
 
-        Defaulting to the project's default feature store. Shared feature stores can be
-        retrieved by passing the `name` argument.
+        Defaulting to the project name of default feature store. To get a
+        Shared feature stores, the project name of the feature store is required.
 
         # Arguments
             name: The name of the feature store, defaults to `None`.

--- a/python/hsfs/connection.py
+++ b/python/hsfs/connection.py
@@ -16,6 +16,7 @@
 
 import os
 import importlib.util
+import util
 
 from requests.exceptions import ConnectionError
 
@@ -153,8 +154,9 @@ class Connection:
             `FeatureStore`. A feature store handle object to perform operations on.
         """
         if not name:
-            name = client.get_instance()._project_name.lower() + "_featurestore"
-        return self._feature_store_api.get(name)
+            name = client.get_instance()._project_name
+        return self._feature_store_api.get(
+            util.rewrite_feature_store_name(name))
 
     @not_connected
     def connect(self):

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -53,6 +53,15 @@ def feature_group_name(feature_group):
     return feature_group.name + "_" + str(feature_group.version)
 
 
+def rewrite_feature_store_name(name):
+    FEATURE_STORE_NAME_SUFFIX = "_featurestore"
+    name = name.lower()
+    if name.endswith(FEATURE_STORE_NAME_SUFFIX):
+        return name
+    else:
+        return name + FEATURE_STORE_NAME_SUFFIX
+
+
 def create_mysql_engine(online_conn, external):
     online_options = online_conn.spark_options()
     # Here we are replacing the first part of the string returned by Hopsworks,


### PR DESCRIPTION
- `get_feature_store()` should require only the project name - the HSFS API should add `_featurestore` and lowercase the project name.
- we need to make it retrocompatible. As such, we should check if the user already provided the `_featurestore` part, and if so, not add it.