### PR TITLE
[HOPSWORKS-2918] Remove register builtin functions

### DIFF
--- a/python/hsfs/core/builtin_transformation_function.py
+++ b/python/hsfs/core/builtin_transformation_function.py
@@ -14,40 +14,12 @@
 #   limitations under the License.
 #
 
-import inspect
-
 from hsfs.client.exceptions import FeatureStoreException
 
 
 class BuiltInTransformationFunction:
     def __init__(self, method):
         self._method = method.lower()
-
-    def generate_source_code(self):
-        if self._method == "min_max_scaler":
-            source_code, output_type = self.generate_min_max_scaler()
-        elif self._method == "standard_scaler":
-            source_code, output_type = self.generate_standard_scaler()
-        elif self._method == "robust_scaler":
-            source_code, output_type = self.generate_robust_scaler()
-        elif self._method == "label_encoder":
-            source_code, output_type = self.generate_label_encoder()
-        else:
-            raise ValueError(
-                "Provided {method:} is not recognised. Supported mothods are min_max_scaler, "
-                "standard_scaler and robust_scaler".format(method=self._method)
-            )
-        return inspect.cleandoc(source_code), output_type
-
-    @staticmethod
-    def generate_min_max_scaler():
-        output_type = "double"
-        source_code = """
-            # Min-Max scaling
-            def min_max_scaler(value, min_value, max_value):
-                return (value - min_value) / (max_value - min_value)
-            """
-        return source_code, output_type
 
     @staticmethod
     def min_max_scaler_stats(content, feature_name):
@@ -70,16 +42,6 @@ class BuiltInTransformationFunction:
         return min_value, max_value
 
     @staticmethod
-    def generate_standard_scaler():
-        output_type = "double"
-        source_code = """
-            # Standardization / zcore
-            def standard_scaler(value, mean, std_dev):
-                return (value - mean) / std_dev
-            """
-        return source_code, output_type
-
-    @staticmethod
     def standard_scaler_stats(content, feature_name):
         mean = None
         std_dev = None
@@ -100,16 +62,6 @@ class BuiltInTransformationFunction:
         return mean, std_dev
 
     @staticmethod
-    def generate_robust_scaler():
-        output_type = "double"
-        source_code = """
-                # Robust scaling
-                def robust_scaler(value, p25, p50, p75):
-                    return (value - p50) / (p75 - p25)
-                """
-        return source_code, output_type
-
-    @staticmethod
     def robust_scaler_stats(content, feature_name):
         percentiles = None
         for col in content["columns"]:
@@ -125,17 +77,6 @@ class BuiltInTransformationFunction:
                 "standard_scaler method".format(feature_name=feature_name)
             )
         return percentiles
-
-    @staticmethod
-    def generate_label_encoder():
-        output_type = "int"
-        source_code = """
-            # label encoder
-            def label_encoder(value, value_to_index):
-                # define a mapping of values to integers
-                return value_to_index[value]
-            """
-        return source_code, output_type
 
     @staticmethod
     def encoder_stats(content, feature_name):

--- a/python/hsfs/core/transformation_function_engine.py
+++ b/python/hsfs/core/transformation_function_engine.py
@@ -18,9 +18,8 @@ import numpy
 import datetime
 from functools import partial
 
-from hsfs import training_dataset, training_dataset_feature, transformation_function
+from hsfs import training_dataset, training_dataset_feature
 from hsfs.core import transformation_function_api, statistics_api
-from hsfs.client.exceptions import RestAPIError
 from hsfs.core.builtin_transformation_function import BuiltInTransformationFunction
 
 
@@ -105,38 +104,6 @@ class TransformationFunctionEngine:
                         transformation_function=transformation_fn,
                     )
                 )
-
-    def register_builtin_transformation_fns(self):
-        for name in self.BUILTIN_FN_NAMES:
-            try:
-                self._transformation_function_api.get_transformation_fn(name, 1)[0]
-            except RestAPIError as e:
-                if (
-                    e.response.json().get("errorMsg")
-                    == "Transformation function does not exist"
-                ):
-                    builtin_fn = BuiltInTransformationFunction(name)
-                    (
-                        builtin_source_code,
-                        output_type,
-                    ) = builtin_fn.generate_source_code()
-                    transformation_fn_instance = (
-                        transformation_function.TransformationFunction(
-                            featurestore_id=self._feature_store_id,
-                            name=name,
-                            version=1,
-                            output_type=output_type,
-                            builtin_source_code=builtin_source_code,
-                        )
-                    )
-                    self._transformation_function_api.register_transformation_fn(
-                        transformation_fn_instance
-                    )
-                elif (
-                    e.response.json().get("errorMsg")
-                    == "The provided transformation function name and version already exists"
-                ):
-                    Warning(e.response.json().get("errorMsg"))
 
     def is_builtin(self, transformation_fn_instance):
         return (

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -758,10 +758,6 @@ class FeatureStore:
         """
         return self._transformation_function_engine.get_transformation_fns()
 
-    def register_builtin_transformation_functions(self):
-        """Register hsfs built-in transformation functions."""
-        self._transformation_function_engine.register_builtin_transformation_fns()
-
     @property
     def id(self):
         """Id of the feature store."""


### PR DESCRIPTION
On Master we are removing the function entirely, on the 2.5 release we will add a deprecation note that it's not needed anymore.﻿
