### PR TITLE
[HOPSWORKS-3054][Append] Call poll in producer loop to empty callback queue

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -681,6 +681,9 @@ class Engine:
                 topic=feature_group._online_topic_name, key=key, value=encoded_row
             )
 
+            # Trigger internal callbacks to empty op queue
+            producer.poll(0)
+
         # make sure producer blocks and everything is delivered
         producer.flush()
 


### PR DESCRIPTION
According to kafka docs, the poll is cheap when there is nothing to do. So we can call it after every produce call. The producer batches the messages anyway.