### PR TITLE
Add support for Python 3.9

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -15,6 +15,7 @@ def read(fname):
 setup(
     name="hsfs",
     version=__version__,
+    python_requires=">=3.8,<3.10",
     install_requires=[
         "pyhumps==1.6.1",
         "requests",
@@ -66,7 +67,8 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Intended Audience :: Developers",
     ],
 )


### PR DESCRIPTION
To install on M1 mac, make sure to `brew install librdkafka` and then:
```
C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/1.8.2/include LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/1.8.2/lib pip install confluent-kafka

```