### PR TITLE
Handle BufferErrors by backing off and retrying

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -716,6 +716,12 @@ class Engine:
         # setup row writer function
         writer = self._get_encoder_func(feature_group._get_encoded_avro_schema())
 
+        def acked(err, msg):
+            if err is not None:
+                print("Failed to deliver message: %s: %s" % (str(msg), str(err)))
+
+        print(feature_group._online_topic_name)
+
         # loop over rows
         for r in dataframe.itertuples(index=False):
             # itertuples returns Python NamedTyple, to be able to serialize it using
@@ -746,7 +752,10 @@ class Engine:
 
             # produce
             producer.produce(
-                topic=feature_group._online_topic_name, key=key, value=encoded_row
+                topic=feature_group._online_topic_name,
+                key=key,
+                value=encoded_row,
+                callback=acked,
             )
 
             # Trigger internal callbacks to empty op queue

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -720,8 +720,6 @@ class Engine:
             if err is not None:
                 print("Failed to deliver message: %s: %s" % (str(msg), str(err)))
 
-        print(feature_group._online_topic_name)
-
         # loop over rows
         for r in dataframe.itertuples(index=False):
             # itertuples returns Python NamedTyple, to be able to serialize it using


### PR DESCRIPTION
We are sending messages faster than librdkafka can get them delivered to kafka and the local queue is filling up.
Solution is to back off when this happens and retry the message where it happened. When the bufferError happens we can be sure that the message wasn't sent.

Adding hidden options: `debug_kafka` and `kafka_producer_config` for the future for debugging and to optimize producer loop.

https://github.com/confluentinc/confluent-kafka-python/issues/341#issuecomment-376067215
https://github.com/confluentinc/confluent-kafka-dotnet/issues/703