### PR TITLE
HOPSWORKS-3210 remove printing training dataset old URL

### DIFF
--- a/python/hsfs/core/training_dataset_engine.py
+++ b/python/hsfs/core/training_dataset_engine.py
@@ -16,14 +16,14 @@
 
 import warnings
 
-from hsfs import engine, training_dataset_feature, client, util
+from hsfs import engine, training_dataset_feature
+from hsfs.constructor import query
 from hsfs.core import (
     training_dataset_api,
     tags_api,
     storage_connector_api,
     transformation_function_engine,
 )
-from hsfs.constructor import query
 
 
 class TrainingDatasetEngine:
@@ -85,10 +85,6 @@ class TrainingDatasetEngine:
             )
 
         updated_instance = self._training_dataset_api.post(training_dataset)
-        print(
-            "Training dataset created successfully, explore it at "
-            + self._get_training_dataset_url(updated_instance)
-        )
         td_job = engine.get_instance().write_training_dataset(
             training_dataset, features, user_write_options, self.OVERWRITE
         )
@@ -164,14 +160,3 @@ class TrainingDatasetEngine:
         self._training_dataset_api.update_metadata(
             training_dataset, training_dataset, "updateStatsConfig"
         )
-
-    def _get_training_dataset_url(self, training_dataset):
-        path = (
-            "/p/"
-            + str(client.get_instance()._project_id)
-            + "/fs/"
-            + str(training_dataset.feature_store_id)
-            + "/td/"
-            + str(training_dataset.id)
-        )
-        return util.get_hostname_replaced_url(path)


### PR DESCRIPTION
training datasets UI navigation has changed under Feature View. The link points to old UI  navigation so removing the prints.