### PR TITLE
HOPSWORKS-3225 change throwing error to warning  while statistics on empty dataframe and add JDBC_FORMAT

### DIFF
--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -58,12 +58,13 @@ class StatisticsEngine:
             commit_time = int(float(datetime.datetime.now().timestamp()) * 1000)
 
             content_str = self.profile_statistics(metadata_instance, feature_dataframe)
-            stats = statistics.Statistics(
-                commit_time=commit_time,
-                content=content_str,
-                feature_group_commit_id=feature_group_commit_id,
-            )
-            self._save_statistics(stats, metadata_instance, feature_view_obj)
+            if content_str:
+                stats = statistics.Statistics(
+                    commit_time=commit_time,
+                    content=content_str,
+                    feature_group_commit_id=feature_group_commit_id,
+                )
+                self._save_statistics(stats, metadata_instance, feature_view_obj)
         else:
             # Python engine
             engine.get_instance().profile_by_spark(metadata_instance)
@@ -77,6 +78,7 @@ class StatisticsEngine:
                 "to the online storage of a feature group.",
                 category=util.StatisticsWarning,
             )
+            return None
         return engine.get_instance().profile(
             feature_dataframe,
             metadata_instance.statistics_config.columns,

--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -16,6 +16,7 @@
 
 import datetime
 import json
+import warnings
 
 from hsfs import engine, statistics, util, split_statistics
 from hsfs.client import exceptions
@@ -70,10 +71,11 @@ class StatisticsEngine:
     @staticmethod
     def profile_statistics(metadata_instance, feature_dataframe):
         if len(feature_dataframe.head(1)) == 0:
-            raise exceptions.FeatureStoreException(
+            warnings.warn(
                 "There is no data in the entity that you are trying to compute "
                 "statistics for. A possible cause might be that you inserted only data "
-                "to the online storage of a feature group."
+                "to the online storage of a feature group.",
+                category=util.FeatureGroupWarning,
             )
         return engine.get_instance().profile(
             feature_dataframe,

--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -75,7 +75,7 @@ class StatisticsEngine:
                 "There is no data in the entity that you are trying to compute "
                 "statistics for. A possible cause might be that you inserted only data "
                 "to the online storage of a feature group.",
-                category=util.FeatureGroupWarning,
+                category=util.StatisticsWarning,
             )
         return engine.get_instance().profile(
             feature_dataframe,

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -259,6 +259,7 @@ class S3Connector(StorageConnector):
 
 class RedshiftConnector(StorageConnector):
     type = StorageConnector.REDSHIFT
+    JDBC_FORMAT = "jdbc"
 
     def __init__(
         self,


### PR DESCRIPTION
- change throwing warning instead of error while running statistics on empty dataframe
- add missing variable `JDBC_FORMAT` in RedshiftConnector