### PR TITLE
Add latest docs alias to mkdocs-release action and hide major version alias in version select

### DIFF
--- a/.github/workflows/mkdocs-release.yml
+++ b/.github/workflows/mkdocs-release.yml
@@ -36,4 +36,6 @@ jobs:
           git config --global user.name Mike
           git config --global user.email mike@docs.hopsworks.ai
       - name: mike deploy docs
-        run: mike deploy ${{ env.RELEASE_VERSION }} ${{ env.MAJOR_VERSION }} -u --push
+        run: |
+          mike deploy ${{ env.RELEASE_VERSION }} ${{ env.MAJOR_VERSION }} -u --push
+          mike alias ${{ env.RELEASE_VERSION }} latest -u --push

--- a/docs/js/version-select.js
+++ b/docs/js/version-select.js
@@ -31,8 +31,9 @@ window.addEventListener("DOMContentLoaded", function() {
     }).version;
 
     var select = makeSelect(versions.map(function(i) {
+      var allowedAliases = ["dev", "latest"]
       if (i.aliases.length > 0) {
-        var aliasString = " [" + i.aliases.join(", ") + "]";
+        var aliasString = " [" + i.aliases.filter(function (str) { return allowedAliases.includes(str); }).join(", ") + "]";
       } else {
         var aliasString = "";
       }


### PR DESCRIPTION
Adding the latest docs alias only to the mkdocs-release action so it will be correct for future released versions on new release branches.