### PR TITLE
fix feature view features creation

### DIFF
--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -59,14 +59,12 @@ class FeatureViewEngine:
 
     def save(self, feature_view_obj):
         if feature_view_obj.labels:
-            feature_view_obj._features += (
-                [
-                    training_dataset_feature.TrainingDatasetFeature(
-                        name=label_name, label=True
-                    )
-                    for label_name in feature_view_obj.labels
-                ]
-            )
+            feature_view_obj._features += [
+                training_dataset_feature.TrainingDatasetFeature(
+                    name=label_name, label=True
+                )
+                for label_name in feature_view_obj.labels
+            ]
         self._transformation_function_engine.attach_transformation_fn(feature_view_obj)
         updated_fv = self._feature_view_api.post(feature_view_obj)
         print(

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -59,7 +59,7 @@ class FeatureViewEngine:
 
     def save(self, feature_view_obj):
         if feature_view_obj.labels:
-            feature_view_obj._features.append(
+            feature_view_obj._features += (
                 [
                     training_dataset_feature.TrainingDatasetFeature(
                         name=label_name, label=True


### PR DESCRIPTION
Currently, if `labels` has multiple entries, backend only take the last entry. This fixes it.