### PR TITLE
Set mergeSchema option to true to handle appended columns

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs</artifactId>
-    <version>2.5.15</version>
+    <version>2.5.16</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/python/hsfs/core/hudi_engine.py
+++ b/python/hsfs/core/hudi_engine.py
@@ -102,7 +102,7 @@ class HudiEngine:
         hudi_options = self._setup_hudi_read_opts(hudi_fg_alias, read_options)
         self._spark_session.read.format(self.HUDI_SPARK_FORMAT).options(
             **hudi_options
-        ).option("recursiveFileLookup", "true").load(
+        ).option("recursiveFileLookup", "true").option("mergeSchema", "true").load(
             self._feature_group.location
         ).createOrReplaceTempView(
             hudi_fg_alias.alias

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "2.5.15"
+__version__ = "2.5.16"


### PR DESCRIPTION
When we append a feature to a feature group, the new data being written
will have a different schema than the existing Parquet files.

The new files will have the additional column while the old Parquet
files will not.

This change make sure that the schemas of the different Parquet files is
merged to obtain the full schema with all the necessary features.

Keep in mind that in Hopsworks Feature Store we do not allow users to
remove columns from an existing feature group.

Also release 2.5.16