### PR TITLE
[HOPSWORKS-3327] Reorder split output

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/FeatureView.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/FeatureView.java
@@ -387,9 +387,15 @@ public class FeatureView {
   }
 
   private List<Dataset<Row>> getDataset(TrainingDatasetBundle trainingDatasetBundle, List<String> splits) {
-    return splits.stream()
-        .flatMap(split -> trainingDatasetBundle.getDataset(split, true).stream())
-        .collect(Collectors.toList());
+    List<Dataset<Row>> features = Lists.newArrayList();
+    List<Dataset<Row>> labels = Lists.newArrayList();
+    for (String split: splits) {
+      List<Dataset<Row>> featureLabel = trainingDatasetBundle.getDataset(split, true);
+      features.add(featureLabel.get(0));
+      labels.add(featureLabel.get(1));
+    }
+    features.addAll(labels);
+    return features;
   }
 
   public void recreateTrainingDataset(Integer version, Map<String, String> writeOptions)

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/FeatureViewEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/FeatureViewEngine.java
@@ -341,8 +341,8 @@ public class FeatureViewEngine {
         featureView.getFeatureStore(),
         featureView.getName(),
         featureView.getVersion(),
-        startTime == null ? null : startTime.getTime() / 1000,
-        endTime == null ? null : endTime.getTime() / 1000,
+        startTime == null ? null : startTime.getTime(),
+        endTime == null ? null : endTime.getTime(),
         withLabels
     );
     query.getLeftFeatureGroup().setFeatureStore(featureView.getQuery().getLeftFeatureGroup().getFeatureStore());

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -209,12 +209,17 @@ class FeatureViewEngine:
                 split_df[split_name] = engine.get_instance().split_labels(
                     split_df[split_name], feature_view_obj.labels
                 )
+            feature_dfs = []
+            label_dfs = []
+            for split in splits:
+                feature_dfs.append(split_df[split][0])
+                label_dfs.append(split_df[split][1])
+            return td_updated, feature_dfs + label_dfs
         else:
             split_df = engine.get_instance().split_labels(
                 split_df, feature_view_obj.labels
             )
-
-        return td_updated, split_df
+            return td_updated, split_df
 
     def _set_event_time(self, feature_view_obj, training_dataset_obj):
         event_time = feature_view_obj.query._left_feature_group.event_time

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -737,7 +737,7 @@ class FeatureView:
                   to configure the Hopsworks Job used to compute the training dataset.
 
         # Returns
-            (X_train, y_train, X_test, y_test):
+            (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
 
         """
@@ -772,7 +772,7 @@ class FeatureView:
             "Incremented version to `{}`.".format(td.version),
             util.VersionWarning,
         )
-        return df[TrainingDatasetSplit.TRAIN] + df[TrainingDatasetSplit.TEST]
+        return df
 
     @staticmethod
     def _validate_train_test_split(test_size, train_end, test_start):
@@ -837,7 +837,7 @@ class FeatureView:
                   to configure the Hopsworks Job used to compute the training dataset.
 
         # Returns
-            (X_train, y_train, X_val, y_val, X_test, y_test):
+            (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
 
         """
@@ -885,11 +885,7 @@ class FeatureView:
             "Incremented version to `{}`.".format(td.version),
             util.VersionWarning,
         )
-        return (
-            df[TrainingDatasetSplit.TRAIN]
-            + df[TrainingDatasetSplit.VALIDATION]
-            + df[TrainingDatasetSplit.TEST]
-        )
+        return df
 
     @staticmethod
     def _validate_train_validation_test_split(
@@ -962,7 +958,7 @@ class FeatureView:
                   to configure the Hopsworks Job used to compute the training dataset.
 
         # Returns
-            (X_train, y_train, X_test, y_test):
+            (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
 
         """
@@ -972,7 +968,7 @@ class FeatureView:
             training_dataset_version=training_dataset_version,
             splits=[TrainingDatasetSplit.TRAIN, TrainingDatasetSplit.TEST],
         )
-        return df[TrainingDatasetSplit.TRAIN] + df[TrainingDatasetSplit.TEST]
+        return df
 
     def get_train_validation_test_split(
         self,
@@ -996,7 +992,7 @@ class FeatureView:
                   to configure the Hopsworks Job used to compute the training dataset.
 
         # Returns
-            (X_train, y_train, X_val, y_val, X_test, y_test):
+            (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
 
         """
@@ -1010,11 +1006,7 @@ class FeatureView:
                 TrainingDatasetSplit.TEST,
             ],
         )
-        return (
-            df[TrainingDatasetSplit.TRAIN]
-            + df[TrainingDatasetSplit.VALIDATION]
-            + df[TrainingDatasetSplit.TEST]
-        )
+        return df
 
     def add_training_dataset_tag(self, training_dataset_version: int, name: str, value):
         return self._feature_view_engine.add_tag(


### PR DESCRIPTION
changes:
1. Modified python and java client so that all splits' output are features first followed by labels.
2. Minor fix in `getBatchQuery` 