### PR TITLE
[HOPSWORKS-3260][Append] Add python client tests

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -68,7 +68,7 @@ setup(
     url="https://github.com/logicalclocks/feature-store-api",
     download_url="https://github.com/logicalclocks/feature-store-api/releases/tag/"
     + __version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*']),
     long_description=read("../README.md"),
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
This PR excludes the `python/tests/` directory from the wheel built
- added `find_packages(exclude=['tests*'])` to `setup.py`

JIRA Issue: HOPSWORKS-3260

Priority for Review: medium

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on Dev Machine


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
