### PR TITLE
[HOPSWORKS-3152] Change Online FS ALTER table algorithm

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/DeltaStreamerAvroDeserializer.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/DeltaStreamerAvroDeserializer.java
@@ -65,8 +65,7 @@ public class DeltaStreamerAvroDeserializer implements Deserializer<GenericRecord
   public void configure(Map<String, ?> configs, boolean isKey) {
     GenericData.get().addLogicalTypeConversion(new Conversions.DecimalConversion());
     String featureGroupSchema = (String) configs.get(HudiEngine.FEATURE_GROUP_SCHEMA);
-    String encodedFeatureGroupSchema = configs.get(HudiEngine.FEATURE_GROUP_ENCODED_SCHEMA).toString()
-        .replace("\"type\":[\"bytes\",\"null\"]", "\"type\":[\"null\",\"bytes\"]");
+    String encodedFeatureGroupSchema = configs.get(HudiEngine.FEATURE_GROUP_ENCODED_SCHEMA).toString();
     String complexFeatureString = (String) configs.get(HudiEngine.FEATURE_GROUP_COMPLEX_FEATURES);
     try {
       String[] stringArray = objectMapper.readValue(complexFeatureString, String[].class);

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1448,7 +1448,7 @@ class FeatureGroup(FeatureGroupBase):
 
         for field in schema["fields"]:
             if field["name"] in complex_features:
-                field["type"] = ["null", "bytes"]
+                field["type"] = ["bytes", "null"]
 
         schema_s = json.dumps(schema)
         try:


### PR DESCRIPTION
This PR adds/fixes/changes...
This PR changes the order of types when encoding/decoding Avro schema. The reason for this is that in the current solution it is impossible to set default values (null types are considered the primary type). The assignment of default values allows to change Online FS ALTER table algorithm to use INPLACE (as it INPLACE doesn't support default values in MySQL: https://dev.mysql.com/doc/refman/5.7/en/innodb-online-ddl-operations.html).

JIRA Issue: https://hopsworks.atlassian.net/browse/HOPSWORKS-3152

Priority for Review: -

Related PRs: https://github.com/logicalclocks/clusterj-onlinefs/pull/26 and https://github.com/logicalclocks/hopsworks-ee/pull/1062

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
