### PR TITLE
[HOPSWORKS-3325] Parquet reading in hsfs client 

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -35,6 +35,7 @@ from urllib.parse import urlparse
 from typing import TypeVar, Optional, Dict, Any
 from confluent_kafka import Producer
 from tqdm.auto import tqdm
+from botocore.response import StreamingBody
 
 from hsfs import client, feature, util
 from hsfs.client.exceptions import FeatureStoreException
@@ -121,8 +122,10 @@ class Engine:
             return pd.read_csv(obj)
         elif data_format.lower() == "tsv":
             return pd.read_csv(obj, sep="\t")
-        elif data_format.lower() == "parquet":
+        elif data_format.lower() == "parquet" and isinstance(obj, StreamingBody):
             return pd.read_parquet(BytesIO(obj.read()))
+        elif data_format.lower() == "parquet":
+            return pd.read_parquet(obj)
         else:
             raise TypeError(
                 "{} training dataset format is not supported to read as pandas dataframe.".format(

--- a/python/setup.py
+++ b/python/setup.py
@@ -34,7 +34,7 @@ setup(
         "typing_extensions>=3.7.4", # GE issue 3: missing dependency https://github.com/great-expectations/great_expectations/pull/4082/files, set to 3.7.4 to be compatible with hopsworks base environment
     ],
     extras_require={
-        "dev": ["pytest==7.1.2", "pytest-mock==3.8.2", "flake8", "black", "pyspark==3.1.1"],
+        "dev": ["pytest==7.1.2", "pytest-mock==3.8.2", "flake8", "black", "pyspark==3.1.1", "moto[s3]"],
         "docs": [
             "mkdocs==1.3.0",
             "mkdocs-material==8.2.8",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -19,6 +19,7 @@ import sys
 
 pytest_plugins = [
     "tests.fixtures.backend_fixtures",
+    "tests.fixtures.dataframe_fixtures",
 ]
 
 os.environ["PYSPARK_PYTHON"] = sys.executable

--- a/python/tests/engine/test_python_reader.py
+++ b/python/tests/engine/test_python_reader.py
@@ -1,0 +1,148 @@
+#
+#   Copyright 2022 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import pandas as pd
+from hsfs.core import inode
+
+from hsfs.engine import python
+
+import boto3
+from moto import mock_s3
+from hsfs.storage_connector import S3Connector
+
+
+class TestPythonReader:
+
+    def test_read_s3_parquet(self, mocker, dataframe_fixture_basic):
+        python_engine = python.Engine()
+
+        with mock_s3():
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id="",
+                aws_secret_access_key="",
+            )
+            conn = boto3.resource('s3', region_name='us-east-1')
+            conn.create_bucket(Bucket='test-parquet-reading')
+            with open("python/tests/data/test_basic.parquet", 'rb') as data:
+                s3.upload_fileobj(data, 'test-parquet-reading', "test_basic.parquet")
+            connector = S3Connector(
+                1,
+                "test",
+                1,
+                description="Test",
+                # members specific to type of connector
+                access_key=None,
+                secret_key=None,
+                server_encryption_algorithm=None,
+                server_encryption_key=None,
+                bucket="test-parquet-reading",
+                session_token=None)
+
+            # Act
+            df_list = python_engine._read_s3(connector, "s3://test-parquet-reading/test_basic.parquet", "parquet")
+
+        # Assert
+        assert len(df_list) == 1
+        assert dataframe_fixture_basic.equals(df_list[0])
+
+    def test_read_s3_csv(self, mocker, dataframe_fixture_basic):
+        python_engine = python.Engine()
+
+        with mock_s3():
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id="",
+                aws_secret_access_key="",
+            )
+            conn = boto3.resource('s3', region_name='us-east-1')
+            conn.create_bucket(Bucket='test-csv-reading')
+            with open("python/tests/data/test_basic.csv", 'rb') as data:
+                s3.upload_fileobj(data, 'test-csv-reading', "test_basic.csv")
+            connector = S3Connector(
+                1,
+                "test",
+                1,
+                description="Test",
+                # members specific to type of connector
+                access_key=None,
+                secret_key=None,
+                server_encryption_algorithm=None,
+                server_encryption_key=None,
+                bucket="test-csv-reading",
+                session_token=None)
+
+            # Act
+            df_list = python_engine._read_s3(connector, "s3://test-csv-reading/test_basic.csv", "csv")
+
+        df_list[0]["event_date"] = pd.to_datetime(df_list[0]["event_date"], format='%Y-%m-%d').dt.date
+
+        # Assert
+        assert len(df_list) == 1
+        assert dataframe_fixture_basic.equals(df_list[0])
+
+    def test_read_pandas_parquet(self, dataframe_fixture_basic):
+        df = python.Engine()._read_pandas("parquet", "python/tests/data/test_basic.parquet")
+
+        # Assert
+        assert dataframe_fixture_basic.equals(df)
+
+    def test_read_pandas_csv(self, dataframe_fixture_basic):
+        df = python.Engine()._read_pandas("csv", "python/tests/data/test_basic.csv")
+
+        df["event_date"] = pd.to_datetime(df["event_date"], format='%Y-%m-%d').dt.date
+
+        # Assert
+        assert dataframe_fixture_basic.equals(df)
+
+    def test_read_pandas_tsv(self, dataframe_fixture_basic):
+        df = python.Engine()._read_pandas("tsv", "python/tests/data/test_basic.tsv")
+
+        df["event_date"] = pd.to_datetime(df["event_date"], format='%Y-%m-%d').dt.date
+
+        # Assert
+        assert dataframe_fixture_basic.equals(df)
+
+    def test_read_hopsfs_rest_parquet(self, mocker, dataframe_fixture_basic):
+        # Arrange
+        mock_dataset_api = mocker.patch("hsfs.core.dataset_api.DatasetApi")
+        i = inode.Inode(attributes={"path": "test_path"})
+        mock_dataset_api.return_value.list_files.return_value = (0, [i])
+        with open("python/tests/data/test_basic.parquet", mode='rb') as file: # b is important -> binary
+            mock_dataset_api.return_value.read_content.return_value.content = file.read()
+
+        # Act
+        df_list = python.Engine()._read_hopsfs_rest(location=None, data_format="parquet")
+
+        # Assert
+        assert len(df_list) == 1
+        assert dataframe_fixture_basic.equals(df_list[0])
+
+    def test_read_hopsfs_rest_csv(self, mocker, dataframe_fixture_basic):
+        # Arrange
+        mock_dataset_api = mocker.patch("hsfs.core.dataset_api.DatasetApi")
+        i = inode.Inode(attributes={"path": "test_path"})
+        mock_dataset_api.return_value.list_files.return_value = (0, [i])
+        with open("python/tests/data/test_basic.csv", mode='rb') as file: # b is important -> binary
+            mock_dataset_api.return_value.read_content.return_value.content = file.read()
+
+        # Act
+        df_list = python.Engine()._read_hopsfs_rest(location=None, data_format="csv")
+        df_list[0]["event_date"] = pd.to_datetime(df_list[0]["event_date"], format='%Y-%m-%d').dt.date
+
+        # Assert
+        assert len(df_list) == 1
+        assert dataframe_fixture_basic.equals(df_list[0])

--- a/python/tests/fixtures/dataframe_fixtures.py
+++ b/python/tests/fixtures/dataframe_fixtures.py
@@ -1,0 +1,15 @@
+import pytest
+import pandas as pd
+from datetime import datetime
+
+@pytest.fixture
+def dataframe_fixture_basic():
+    data = {
+        'primary_key': [1, 2, 3, 4],
+        'event_date': [datetime(2022, 7, 3).date(), datetime(2022, 1, 5).date(), datetime(2022, 1, 6).date(),
+                       datetime(2022, 1, 7).date()],
+        'state': ['nevada', None, 'nevada', None],
+        'measurement': [12.4, 32.5, 342.6, 43.7],
+    }
+
+    return pd.DataFrame(data)


### PR DESCRIPTION
This PR fixes a reading from parquet files from hdfs.
- apply the fix [here](https://github.com/logicalclocks/feature-store-api/pull/397) only when `obj` is a StreamingBody (boto3/s3) object
- added unit tests for all reading scenarios (hdfs, s3, rest)

JIRA Issue: https://hopsworks.atlassian.net/browse/HOPSWORKS-3325

Priority for Review: medium

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
