### PR TITLE
[HOPSWORKS-3259][append] Allow wallclocktime=None for as_of

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -153,7 +153,7 @@ class Query:
         )
         return self
 
-    def as_of(self, wallclock_time, exclude_until=None):
+    def as_of(self, wallclock_time=None, exclude_until=None):
         """Perform time travel on the given Query.
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
@@ -229,7 +229,11 @@ class Query:
         # Returns
             `Query`. The query object with the applied time travel condition.
         """
-        wallclock_timestamp = util.get_timestamp_from_date_string(wallclock_time)
+        wallclock_timestamp = (
+            util.get_timestamp_from_date_string(wallclock_time)
+            if wallclock_time
+            else None
+        )
         exclude_until_timestamp = (
             util.get_timestamp_from_date_string(exclude_until)
             if exclude_until
@@ -237,11 +241,9 @@ class Query:
         )
         for join in self._joins:
             join.query.left_feature_group_end_time = wallclock_timestamp
-            if exclude_until_timestamp:
-                join.query.left_feature_group_start_time = exclude_until_timestamp
+            join.query.left_feature_group_start_time = exclude_until_timestamp
         self.left_feature_group_end_time = wallclock_timestamp
-        if exclude_until_timestamp:
-            self.left_feature_group_start_time = exclude_until_timestamp
+        self.left_feature_group_start_time = exclude_until_timestamp
         return self
 
     def pull_changes(self, wallclock_start_time, wallclock_end_time):

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -18,6 +18,7 @@ import re
 import json
 
 from datetime import datetime
+from datetime import timezone
 from urllib.parse import urljoin, urlparse
 
 from sqlalchemy import create_engine
@@ -127,7 +128,7 @@ def check_timestamp_format_from_date_string(input_date):
     return normalized_date, date_format
 
 
-def get_timestamp_from_date_string(input_date, time_zone=None):
+def get_timestamp_from_date_string(input_date, time_zone=timezone.utc):
     norm_input_date, date_format = check_timestamp_format_from_date_string(input_date)
     date_time = datetime.strptime(norm_input_date, date_format)
     date_time = date_time.replace(tzinfo=time_zone)

--- a/python/tests/constructor/test_query.py
+++ b/python/tests/constructor/test_query.py
@@ -129,22 +129,22 @@ class TestQuery:
         q = query.Query.from_response_json(backend_fixtures["query"]["get"]["response"])
         q.as_of("2022-01-01 00:00:00")
 
-        assert q.left_feature_group_end_time == 1640991600000
-        assert q._joins[0].query.left_feature_group_end_time == 1640991600000
+        assert q.left_feature_group_end_time == 1640995200000
+        assert q._joins[0].query.left_feature_group_end_time == 1640995200000
 
         q = query.Query.from_response_json(backend_fixtures["query"]["get"]["response"])
         q.as_of(None, "2022-01-01 00:00:00")
 
-        assert q.left_feature_group_start_time == 1640991600000
-        assert q._joins[0].query.left_feature_group_start_time == 1640991600000
+        assert q.left_feature_group_start_time == 1640995200000
+        assert q._joins[0].query.left_feature_group_start_time == 1640995200000
 
         q = query.Query.from_response_json(backend_fixtures["query"]["get"]["response"])
         q.as_of("2022-01-02 00:00:00", exclude_until="2022-01-01 00:00:00")
 
-        assert q.left_feature_group_end_time == 1641078000000
-        assert q.left_feature_group_start_time == 1640991600000
-        assert q._joins[0].query.left_feature_group_end_time == 1641078000000
-        assert q._joins[0].query.left_feature_group_start_time == 1640991600000
+        assert q.left_feature_group_end_time == 1641081600000
+        assert q.left_feature_group_start_time == 1640995200000
+        assert q._joins[0].query.left_feature_group_end_time == 1641081600000
+        assert q._joins[0].query.left_feature_group_start_time == 1640995200000
 
         q.as_of()
 


### PR DESCRIPTION
This PR fixes query.as_of to allow wallclock_time=None
- includes unit tests

JIRA Issue: HOPSWORKS-3259

Priority for Review: medium

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
