### PR TITLE
[HOPSWORKS-3352] fix HSFS test flake8

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -22,10 +22,10 @@ jobs:
         run: flake8 --config python/.flake8 python
 
       - name: trailing-whitespace-fixer
-        run: trailing-whitespace-fixer $(find python/hsfs -type f) || exit 1
+        run: trailing-whitespace-fixer $(find python -type f) || exit 1
 
       - name: end-of-file-fixer
-        run: end-of-file-fixer $(find python/hsfs -type f) || exit 1
+        run: end-of-file-fixer $(find python -type f) || exit 1
 
   unit_tests:
     name: Unit Testing

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -22,10 +22,10 @@ jobs:
         run: flake8 --config python/.flake8 python
 
       - name: trailing-whitespace-fixer
-        run: trailing-whitespace-fixer $(find python -type f) || exit 1
+        run: trailing-whitespace-fixer $(find python -name "*.py" -type f) || exit 1
 
       - name: end-of-file-fixer
-        run: end-of-file-fixer $(find python -type f) || exit 1
+        run: end-of-file-fixer $(find python -name "*.py" -type f) || exit 1
 
   unit_tests:
     name: Unit Testing

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -16,7 +16,7 @@ jobs:
         run: pip install flake8==3.9.0 black==22.3.0 pre-commit-hooks==2.4.0
 
       - name: black
-        run: black --check python/hsfs
+        run: black --check python
 
       - name: flake8
         run: flake8 --config python/.flake8 python

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -19,7 +19,7 @@ jobs:
         run: black --check python/hsfs
 
       - name: flake8
-        run: flake8 --config python/.flake8 python/hsfs
+        run: flake8 --config python/.flake8 python
 
       - name: trailing-whitespace-fixer
         run: trailing-whitespace-fixer $(find python/hsfs -type f) || exit 1

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,12 +29,18 @@ setup(
         "sqlalchemy",
         "PyMySQL[rsa]",
         "great_expectations==0.14.3",
-        "jinja2==2.11.3", # GE issue 1: great_expectations pulls in jinja 3.1.2 which causes import of great_expectations to fail
-        "markupsafe==2.0.1", # GE issue 2: jinja2==2.11.3, pulls in markupsafe 2.1.0 which is not compatible with jinja2==2.11.3
-        "typing_extensions>=3.7.4", # GE issue 3: missing dependency https://github.com/great-expectations/great_expectations/pull/4082/files, set to 3.7.4 to be compatible with hopsworks base environment
+        "jinja2==2.11.3",  # GE issue 1: great_expectations pulls in jinja 3.1.2 which causes import of great_expectations to fail
+        "markupsafe==2.0.1",  # GE issue 2: jinja2==2.11.3, pulls in markupsafe 2.1.0 which is not compatible with jinja2==2.11.3
+        "typing_extensions>=3.7.4",  # GE issue 3: missing dependency https://github.com/great-expectations/great_expectations/pull/4082/files, set to 3.7.4 to be compatible with hopsworks base environment
     ],
     extras_require={
-        "dev": ["pytest==7.1.2", "pytest-mock==3.8.2", "flake8", "black", "pyspark==3.1.1"],
+        "dev": [
+            "pytest==7.1.2",
+            "pytest-mock==3.8.2",
+            "flake8",
+            "black",
+            "pyspark==3.1.1",
+        ],
         "docs": [
             "mkdocs==1.3.0",
             "mkdocs-material==8.2.8",
@@ -57,7 +63,7 @@ setup(
             "pyarrow",
             "confluent-kafka==1.8.2",
             "fastavro==1.4.11",
-            "tqdm"
+            "tqdm",
         ],
     },
     author="Hopsworks AB",
@@ -68,7 +74,7 @@ setup(
     url="https://github.com/logicalclocks/feature-store-api",
     download_url="https://github.com/logicalclocks/feature-store-api/releases/tag/"
     + __version__,
-    packages=find_packages(exclude=['tests*']),
+    packages=find_packages(exclude=["tests*"]),
     long_description=read("../README.md"),
     long_description_content_type="text/markdown",
     classifiers=[

--- a/python/tests/constructor/test_filter.py
+++ b/python/tests/constructor/test_filter.py
@@ -39,11 +39,11 @@ class TestLogic:
         json = backend_fixtures["logic"]["get"]["response"]
 
         # Act
-        l = filter.Logic.from_response_json(json)
+        logic = filter.Logic.from_response_json(json)
 
         # Assert
-        assert l._type == "test_type"
-        assert isinstance(l._left_f, filter.Filter)
-        assert isinstance(l._right_f, filter.Filter)
-        assert isinstance(l._left_l, filter.Logic)
-        assert isinstance(l._right_l, filter.Logic)
+        assert logic._type == "test_type"
+        assert isinstance(logic._left_f, filter.Filter)
+        assert isinstance(logic._right_f, filter.Filter)
+        assert isinstance(logic._left_l, filter.Logic)
+        assert isinstance(logic._right_l, filter.Logic)

--- a/python/tests/constructor/test_fs_query.py
+++ b/python/tests/constructor/test_fs_query.py
@@ -20,7 +20,6 @@ from hsfs.constructor import (
     external_feature_group_alias,
     fs_query,
 )
-from hsfs import feature_group
 
 
 class TestFsQuery:
@@ -57,5 +56,5 @@ class TestFsQuery:
         assert q.query == "test_query"
         assert len(q._on_demand_fg_aliases) == 0
         assert len(q._hudi_cached_feature_groups) == 0
-        assert q.query_online == None
-        assert q.pit_query == None
+        assert q.query_online is None
+        assert q.pit_query is None

--- a/python/tests/constructor/test_hudi_feature_group_alias.py
+++ b/python/tests/constructor/test_hudi_feature_group_alias.py
@@ -51,5 +51,5 @@ class TestFsQuery:
         # Assert
         assert isinstance(hudi_fg_alias._feature_group, feature_group.FeatureGroup)
         assert hudi_fg_alias.alias == "test_alias"
-        assert hudi_fg_alias._left_feature_group_start_timestamp == None
-        assert hudi_fg_alias._left_feature_group_end_timestamp == None
+        assert hudi_fg_alias._left_feature_group_start_timestamp is None
+        assert hudi_fg_alias._left_feature_group_end_timestamp is None

--- a/python/tests/constructor/test_join.py
+++ b/python/tests/constructor/test_join.py
@@ -56,4 +56,4 @@ class TestJoin:
         assert len(j._left_on) == 0
         assert len(j._right_on) == 0
         assert j._join_type == "INNER"
-        assert j._prefix == None
+        assert j._prefix is None

--- a/python/tests/constructor/test_prepared_statement_parameter.py
+++ b/python/tests/constructor/test_prepared_statement_parameter.py
@@ -48,5 +48,5 @@ class TestPreparedStatementParameter:
         )
 
         # Assert
-        assert psp.name == None
-        assert psp.index == None
+        assert psp.name is None
+        assert psp.index is None

--- a/python/tests/constructor/test_query.py
+++ b/python/tests/constructor/test_query.py
@@ -39,7 +39,7 @@ class TestQuery:
         assert len(q._joins) == 1
         assert isinstance(q._joins[0], join.Join)
         assert isinstance(q._filter, filter.Logic)
-        assert q._python_engine == True
+        assert q._python_engine is True
 
     def test_from_response_json_external_fg_python(self, mocker, backend_fixtures):
         # Arrange
@@ -60,7 +60,7 @@ class TestQuery:
         assert len(q._joins) == 1
         assert isinstance(q._joins[0], join.Join)
         assert isinstance(q._filter, filter.Logic)
-        assert q._python_engine == True
+        assert q._python_engine is True
 
     def test_from_response_json_spark(self, mocker, backend_fixtures):
         # Arrange
@@ -81,7 +81,7 @@ class TestQuery:
         assert len(q._joins) == 1
         assert isinstance(q._joins[0], join.Join)
         assert isinstance(q._filter, filter.Logic)
-        assert q._python_engine == False
+        assert q._python_engine is False
 
     def test_from_response_json_external_fg_spark(self, mocker, backend_fixtures):
         # Arrange
@@ -102,7 +102,7 @@ class TestQuery:
         assert len(q._joins) == 1
         assert isinstance(q._joins[0], join.Join)
         assert isinstance(q._filter, filter.Logic)
-        assert q._python_engine == False
+        assert q._python_engine is False
 
     def test_from_response_json_basic_info(self, mocker, backend_fixtures):
         # Arrange
@@ -113,13 +113,13 @@ class TestQuery:
         q = query.Query.from_response_json(json)
 
         # Assert
-        assert q._feature_store_name == None
-        assert q._feature_store_id == None
+        assert q._feature_store_name is None
+        assert q._feature_store_id is None
         assert isinstance(q._left_feature_group, feature_group.FeatureGroup)
         assert len(q._left_features) == 1
         assert isinstance(q._left_features[0], feature.Feature)
-        assert q._left_feature_group_start_time == None
-        assert q._left_feature_group_end_time == None
+        assert q._left_feature_group_start_time is None
+        assert q._left_feature_group_end_time is None
         assert len(q._joins) == 0
-        assert q._filter == None
-        assert q._python_engine == True
+        assert q._filter is None
+        assert q._python_engine is True

--- a/python/tests/core/test_external_feature_group_engine.py
+++ b/python/tests/core/test_external_feature_group_engine.py
@@ -93,7 +93,7 @@ class TestExternalFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
 
         external_fg_engine = external_feature_group_engine.ExternalFeatureGroupEngine(

--- a/python/tests/core/test_feature_group_engine.py
+++ b/python/tests/core/test_feature_group_engine.py
@@ -28,13 +28,13 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_ge_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
 
@@ -68,13 +68,13 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
         mock_ge_engine = mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
 
@@ -118,16 +118,16 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mock_ge_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
@@ -165,16 +165,16 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mock_ge_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
@@ -213,16 +213,16 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_ge_engine = mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
@@ -270,16 +270,16 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mock_ge_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
@@ -321,16 +321,16 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mock_ge_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
@@ -393,11 +393,11 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_util_get_timestamp_from_date_string = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_timestamp_from_date_string"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
 
@@ -430,11 +430,11 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_util_get_timestamp_from_date_string = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_timestamp_from_date_string"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
 
@@ -468,11 +468,11 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_util_get_timestamp_from_date_string = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_timestamp_from_date_string"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
 
@@ -501,7 +501,7 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_util_get_timestamp_from_date_string = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_timestamp_from_date_string"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
@@ -580,7 +580,7 @@ class TestFeatureGroupEngine:
         mock_sc_api = mocker.patch(
             "hsfs.core.storage_connector_api.StorageConnectorApi"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
 
         fg_engine = feature_group_engine.FeatureGroupEngine(
             feature_store_id=feature_store_id
@@ -606,7 +606,7 @@ class TestFeatureGroupEngine:
         mock_sc_api = mocker.patch(
             "hsfs.core.storage_connector_api.StorageConnectorApi"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
 
         fg_engine = feature_group_engine.FeatureGroupEngine(
             feature_store_id=feature_store_id
@@ -806,13 +806,13 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
 
@@ -858,13 +858,13 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_warnings_warn = mocker.patch("warnings.warn")
@@ -910,13 +910,13 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
 
@@ -957,13 +957,13 @@ class TestFeatureGroupEngine:
 
         mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_fg_engine_save_feature_group_metadata = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mock_fg_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_warnings_warn = mocker.patch("warnings.warn")
@@ -1148,11 +1148,11 @@ class TestFeatureGroupEngine:
         feature_group_url = "test_url"
 
         mocker.patch("hsfs.engine.get_type")
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_fg_engine_get_feature_group_url = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
             return_value=feature_group_url,
         )
@@ -1180,9 +1180,9 @@ class TestFeatureGroupEngine:
 
         # Assert
         assert mock_fg_api.return_value.save.call_count == 1
-        assert f.primary == False
-        assert f.partition == False
-        assert f.hudi_precombine_key == False
+        assert f.primary is False
+        assert f.partition is False
+        assert f.hudi_precombine_key is False
         assert mock_print.call_count == 1
         assert mock_print.call_args[0][
             0
@@ -1196,11 +1196,11 @@ class TestFeatureGroupEngine:
         feature_group_url = "test_url"
 
         mocker.patch("hsfs.engine.get_type")
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_fg_engine_get_feature_group_url = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
             return_value=feature_group_url,
         )
@@ -1229,9 +1229,9 @@ class TestFeatureGroupEngine:
 
         # Assert
         assert mock_fg_api.return_value.save.call_count == 1
-        assert f.primary == False
-        assert f.partition == False
-        assert f.hudi_precombine_key == False
+        assert f.primary is False
+        assert f.partition is False
+        assert f.hudi_precombine_key is False
         assert mock_print.call_count == 1
         assert mock_print.call_args[0][
             0
@@ -1245,11 +1245,11 @@ class TestFeatureGroupEngine:
         feature_group_url = "test_url"
 
         mocker.patch("hsfs.engine.get_type")
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_fg_engine_get_feature_group_url = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
             return_value=feature_group_url,
         )
@@ -1278,9 +1278,9 @@ class TestFeatureGroupEngine:
 
         # Assert
         assert mock_fg_api.return_value.save.call_count == 1
-        assert f.primary == True
-        assert f.partition == True
-        assert f.hudi_precombine_key == True
+        assert f.primary is True
+        assert f.partition is True
+        assert f.hudi_precombine_key is True
         assert mock_print.call_count == 1
         assert mock_print.call_args[0][
             0
@@ -1295,11 +1295,11 @@ class TestFeatureGroupEngine:
         write_options = "test"
 
         mocker.patch("hsfs.engine.get_type")
-        mock_fg_engine_verify_schema_compatibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mock_fg_engine_get_feature_group_url = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
             return_value=feature_group_url,
         )
@@ -1328,9 +1328,9 @@ class TestFeatureGroupEngine:
 
         # Assert
         assert mock_fg_api.return_value.save.call_count == 1
-        assert f.primary == False
-        assert f.partition == False
-        assert f.hudi_precombine_key == False
+        assert f.primary is False
+        assert f.partition is False
+        assert f.hudi_precombine_key is False
         assert fg._options == write_options
         assert mock_print.call_count == 1
         assert mock_print.call_args[0][

--- a/python/tests/core/test_feature_group_engine.py
+++ b/python/tests/core/test_feature_group_engine.py
@@ -31,9 +31,7 @@ class TestFeatureGroupEngine:
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._save_feature_group_metadata"
         )
-        mocker.patch(
-            "hsfs.core.great_expectation_engine.GreatExpectationEngine"
-        )
+        mocker.patch("hsfs.core.great_expectation_engine.GreatExpectationEngine")
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
@@ -124,9 +122,7 @@ class TestFeatureGroupEngine:
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mocker.patch(
-            "hsfs.core.great_expectation_engine.GreatExpectationEngine"
-        )
+        mocker.patch("hsfs.core.great_expectation_engine.GreatExpectationEngine")
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
@@ -171,9 +167,7 @@ class TestFeatureGroupEngine:
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mocker.patch(
-            "hsfs.core.great_expectation_engine.GreatExpectationEngine"
-        )
+        mocker.patch("hsfs.core.great_expectation_engine.GreatExpectationEngine")
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
@@ -276,9 +270,7 @@ class TestFeatureGroupEngine:
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mocker.patch(
-            "hsfs.core.great_expectation_engine.GreatExpectationEngine"
-        )
+        mocker.patch("hsfs.core.great_expectation_engine.GreatExpectationEngine")
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
@@ -327,9 +319,7 @@ class TestFeatureGroupEngine:
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine._verify_schema_compatibility"
         )
-        mocker.patch(
-            "hsfs.core.great_expectation_engine.GreatExpectationEngine"
-        )
+        mocker.patch("hsfs.core.great_expectation_engine.GreatExpectationEngine")
         mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.get_kafka_config"
         )
@@ -393,13 +383,9 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_timestamp_from_date_string"
-        )
+        mocker.patch("hsfs.util.get_timestamp_from_date_string")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
 
         fg_engine = feature_group_engine.FeatureGroupEngine(
             feature_store_id=feature_store_id
@@ -430,13 +416,9 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_timestamp_from_date_string"
-        )
+        mocker.patch("hsfs.util.get_timestamp_from_date_string")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
 
         fg_engine = feature_group_engine.FeatureGroupEngine(
             feature_store_id=feature_store_id
@@ -468,13 +450,9 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_timestamp_from_date_string"
-        )
+        mocker.patch("hsfs.util.get_timestamp_from_date_string")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
 
         fg_engine = feature_group_engine.FeatureGroupEngine(
             feature_store_id=feature_store_id
@@ -501,9 +479,7 @@ class TestFeatureGroupEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_timestamp_from_date_string"
-        )
+        mocker.patch("hsfs.util.get_timestamp_from_date_string")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -31,11 +31,11 @@ class TestFeatureViewEngine:
         feature_store_id = 99
         feature_view_url = "test_url"
 
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
-        mock_fv_engine_get_url = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_feature_view_url",
             return_value=feature_view_url,
         )
@@ -72,7 +72,7 @@ class TestFeatureViewEngine:
         feature_store_id = 99
 
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
-        mock_fv_engine_get_attached_transformation_fn = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.get_attached_transformation_fn"
         )
 
@@ -110,7 +110,7 @@ class TestFeatureViewEngine:
         feature_store_id = 99
 
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
-        mock_fv_engine_get_attached_transformation_fn = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.get_attached_transformation_fn"
         )
 
@@ -301,7 +301,7 @@ class TestFeatureViewEngine:
         assert "tf_name" in result
         assert mock_fv_api.return_value.get_attached_transformation_fn.call_count == 1
 
-    def test_get_attached_transformation_fn(self, mocker):
+    def test_get_attached_transformation_fn_multiple(self, mocker):
         # Arrange
         feature_store_id = 99
 
@@ -336,9 +336,7 @@ class TestFeatureViewEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
@@ -367,22 +365,18 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -421,16 +415,14 @@ class TestFeatureViewEngine:
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -466,22 +458,18 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -523,22 +511,18 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -577,22 +561,18 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -635,22 +615,18 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -694,22 +670,18 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_set_event_time = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine._set_event_time")
         mock_fv_engine_create_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._create_training_data_metadata"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fv_engine_read_from_storage_connector = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._read_from_storage_connector"
         )
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
         mock_fv_engine_compute_training_dataset_statistics = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine.compute_training_dataset_statistics"
         )
@@ -920,12 +892,10 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_code_engine = mocker.patch("hsfs.core.code_engine.CodeEngine")
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
+        mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.core.code_engine.CodeEngine")
         mock_td_engine = mocker.patch(
             "hsfs.core.training_dataset_engine.TrainingDatasetEngine"
         )
@@ -960,12 +930,10 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_code_engine = mocker.patch("hsfs.core.code_engine.CodeEngine")
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
+        mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.core.code_engine.CodeEngine")
         mock_td_engine = mocker.patch(
             "hsfs.core.training_dataset_engine.TrainingDatasetEngine"
         )
@@ -1007,12 +975,10 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_code_engine = mocker.patch("hsfs.core.code_engine.CodeEngine")
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
+        mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.core.code_engine.CodeEngine")
         mock_td_engine = mocker.patch(
             "hsfs.core.training_dataset_engine.TrainingDatasetEngine"
         )
@@ -1056,14 +1022,10 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_engine_get_type = mocker.patch(
-            "hsfs.engine.get_type", return_value="spark"
-        )
-        mock_code_engine = mocker.patch("hsfs.core.code_engine.CodeEngine")
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
+        mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
+        mocker.patch("hsfs.core.code_engine.CodeEngine")
         mock_td_engine = mocker.patch(
             "hsfs.core.training_dataset_engine.TrainingDatasetEngine"
         )
@@ -1105,14 +1067,10 @@ class TestFeatureViewEngine:
         mock_fv_engine_get_training_data_metadata = mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        mock_engine_get_type = mocker.patch(
-            "hsfs.engine.get_type", return_value="spark"
-        )
-        mock_code_engine = mocker.patch("hsfs.core.code_engine.CodeEngine")
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
+        mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
+        mocker.patch("hsfs.core.code_engine.CodeEngine")
         mock_td_engine = mocker.patch(
             "hsfs.core.training_dataset_engine.TrainingDatasetEngine"
         )
@@ -1272,36 +1230,6 @@ class TestFeatureViewEngine:
         )
         assert mock_s_engine.return_value.register_split_statistics.call_count == 0
         assert mock_s_engine.return_value.compute_statistics.call_count == 0
-
-    def test_compute_training_dataset_statistics_enabled_calc_stat(self, mocker):
-        # Arrange
-        feature_store_id = 99
-
-        mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
-        mock_s_engine = mocker.patch("hsfs.core.statistics_engine.StatisticsEngine")
-
-        fv_engine = feature_view_engine.FeatureViewEngine(
-            feature_store_id=feature_store_id
-        )
-
-        td = training_dataset.TrainingDataset(
-            name="test",
-            location="location",
-            version=1,
-            data_format="CSV",
-            featurestore_id=99,
-            splits={},
-        )
-        td.statistics_config.enabled = True
-
-        # Act
-        fv_engine.compute_training_dataset_statistics(
-            feature_view_obj=None, training_dataset_obj=td, td_df=None, calc_stat=True
-        )
-
-        # Assert
-        assert mock_s_engine.return_value.register_split_statistics.call_count == 0
-        assert mock_s_engine.return_value.compute_statistics.call_count == 1
 
     def test_compute_training_dataset_statistics_enabled_calc_stat_splits_td_df(
         self, mocker
@@ -1533,13 +1461,11 @@ class TestFeatureViewEngine:
         tf_value = "123"
 
         mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
-        mock_fv_engine_check_feature_group_accessibility = mocker.patch(
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._check_feature_group_accessibility"
         )
-        mock_fv_engine_get_batch_query = mocker.patch(
-            "hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query"
-        )
-        mock_fv_engine_get_training_data_metadata = mocker.patch(
+        mocker.patch("hsfs.core.feature_view_engine.FeatureViewEngine.get_batch_query")
+        mocker.patch(
             "hsfs.core.feature_view_engine.FeatureViewEngine._get_training_data_metadata"
         )
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")

--- a/python/tests/core/test_great_expectation_engine.py
+++ b/python/tests/core/test_great_expectation_engine.py
@@ -23,8 +23,8 @@ class TestCodeEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fg_get_expectation_suite = mocker.patch(
             "hsfs.feature_group.FeatureGroup.get_expectation_suite"
         )
@@ -56,8 +56,8 @@ class TestCodeEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fg_get_expectation_suite = mocker.patch(
             "hsfs.feature_group.FeatureGroup.get_expectation_suite"
         )
@@ -98,8 +98,8 @@ class TestCodeEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fg_get_expectation_suite = mocker.patch(
             "hsfs.feature_group.FeatureGroup.get_expectation_suite"
         )
@@ -140,8 +140,8 @@ class TestCodeEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.engine.get_instance")
         mock_fg_get_expectation_suite = mocker.patch(
             "hsfs.feature_group.FeatureGroup.get_expectation_suite"
         )

--- a/python/tests/core/test_hudi_engine.py
+++ b/python/tests/core/test_hudi_engine.py
@@ -24,9 +24,7 @@ class TestHudiEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_hudi_engine_write_hudi_dataset = mocker.patch(
-            "hsfs.core.hudi_engine.HudiEngine._write_hudi_dataset"
-        )
+        mocker.patch("hsfs.core.hudi_engine.HudiEngine._write_hudi_dataset")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
 
         h_engine = hudi_engine.HudiEngine(
@@ -82,9 +80,7 @@ class TestHudiEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_hudi_engine_setup_hudi_read_opts = mocker.patch(
-            "hsfs.core.hudi_engine.HudiEngine._setup_hudi_read_opts"
-        )
+        mocker.patch("hsfs.core.hudi_engine.HudiEngine._setup_hudi_read_opts")
 
         spark_session = mocker.Mock()
 
@@ -134,9 +130,7 @@ class TestHudiEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_hudi_engine_setup_hudi_write_opts = mocker.patch(
-            "hsfs.core.hudi_engine.HudiEngine._setup_hudi_write_opts"
-        )
+        mocker.patch("hsfs.core.hudi_engine.HudiEngine._setup_hudi_write_opts")
         mock_hudi_engine_get_last_commit_metadata = mocker.patch(
             "hsfs.core.hudi_engine.HudiEngine._get_last_commit_metadata"
         )
@@ -180,7 +174,7 @@ class TestHudiEngine:
             == fg.location
         )
 
-    def test_write_hudi_dataset(self, mocker):
+    def test__setup_hudi_write_opts(self, mocker):
         # Arrange
         feature_store_id = 99
 
@@ -400,7 +394,7 @@ class TestHudiEngine:
         )
 
         # Assert
-        assert result.commitid == None
+        assert result.commitid is None
         assert result.commit_date_string == 1
         assert result.rows_inserted == 2
         assert result.rows_updated == 3

--- a/python/tests/core/test_job.py
+++ b/python/tests/core/test_job.py
@@ -42,5 +42,5 @@ class TestJob:
         # Assert
         assert j.id == "test_id"
         assert j.name == "test_name"
-        assert j.executions == None
-        assert j.href == None
+        assert j.executions is None
+        assert j.href is None

--- a/python/tests/core/test_statistics_engine.py
+++ b/python/tests/core/test_statistics_engine.py
@@ -28,17 +28,13 @@ class TestStatisticsEngine:
 
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -74,20 +70,14 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.get_type", return_value="spark"
-        )
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -124,17 +114,13 @@ class TestStatisticsEngine:
 
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -178,20 +164,14 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.get_type", return_value="spark"
-        )
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value="test",
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -228,17 +208,13 @@ class TestStatisticsEngine:
 
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value="test",
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -282,20 +258,14 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.get_type", return_value="spark"
-        )
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.engine.get_type", return_value="spark")
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -332,17 +302,13 @@ class TestStatisticsEngine:
 
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.util.get_hudi_datestr_from_timestamp"
-        )
+        mocker.patch("hsfs.util.get_hudi_datestr_from_timestamp")
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
         mocker.patch("hsfs.statistics.Statistics")
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup.select_all"
-        )
+        mocker.patch("hsfs.feature_group.FeatureGroup.select_all")
         mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -598,9 +564,7 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics"
-        )
+        mocker.patch("hsfs.core.statistics_engine.StatisticsEngine.profile_statistics")
         mock_split_statistics = mocker.patch("hsfs.split_statistics.SplitStatistics")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -633,9 +597,7 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics"
-        )
+        mocker.patch("hsfs.core.statistics_engine.StatisticsEngine.profile_statistics")
         mock_split_statistics = mocker.patch("hsfs.split_statistics.SplitStatistics")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
@@ -715,9 +677,7 @@ class TestStatisticsEngine:
         # Arrange
         feature_store_id = 99
 
-        mocker.patch(
-            "hsfs.util.get_timestamp_from_date_string"
-        )
+        mocker.patch("hsfs.util.get_timestamp_from_date_string")
         mock_statistics_api = mocker.patch("hsfs.core.statistics_api.StatisticsApi")
 
         s_engine = statistics_engine.StatisticsEngine(feature_store_id, "featuregroup")

--- a/python/tests/core/test_statistics_engine.py
+++ b/python/tests/core/test_statistics_engine.py
@@ -27,19 +27,19 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -74,21 +74,21 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch(
+        mocker.patch(
             "hsfs.engine.get_type", return_value="spark"
         )
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -123,19 +123,19 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -178,21 +178,21 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch(
+        mocker.patch(
             "hsfs.engine.get_type", return_value="spark"
         )
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value="test",
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -227,19 +227,19 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value="test",
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -282,21 +282,21 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch(
+        mocker.patch(
             "hsfs.engine.get_type", return_value="spark"
         )
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -331,19 +331,19 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
-        mock_util_get_hudi_datestr_from_timestamp = mocker.patch(
+        mocker.patch("hsfs.engine.get_type")
+        mocker.patch(
             "hsfs.util.get_hudi_datestr_from_timestamp"
         )
         mock_statistics_engine_profile_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics",
             return_value=None,
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
-        mock_feature_group_select_all = mocker.patch(
+        mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup.select_all"
         )
-        mock_feature_group_read = mocker.patch("hsfs.feature_group.FeatureGroup.read")
+        mocker.patch("hsfs.feature_group.FeatureGroup.read")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -471,7 +471,7 @@ class TestStatisticsEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_engine_get_type = mocker.patch("hsfs.engine.get_type")
+        mocker.patch("hsfs.engine.get_type")
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
         mock_statistics_engine_profile_unique_values = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_unique_values"
@@ -598,7 +598,7 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_statistics_engine_profile_statistics = mocker.patch(
+        mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics"
         )
         mock_split_statistics = mocker.patch("hsfs.split_statistics.SplitStatistics")
@@ -633,7 +633,7 @@ class TestStatisticsEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_statistics_engine_profile_statistics = mocker.patch(
+        mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_statistics"
         )
         mock_split_statistics = mocker.patch("hsfs.split_statistics.SplitStatistics")
@@ -669,10 +669,10 @@ class TestStatisticsEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_statistics_engine_profile_transformation_fn_statistics = mocker.patch(
+        mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine.profile_transformation_fn_statistics"
         )
-        mock_statistics = mocker.patch("hsfs.statistics.Statistics")
+        mocker.patch("hsfs.statistics.Statistics")
         mock_statistics_engine_save_statistics = mocker.patch(
             "hsfs.core.statistics_engine.StatisticsEngine._save_statistics"
         )
@@ -715,7 +715,7 @@ class TestStatisticsEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_util_get_timestamp_from_date_string = mocker.patch(
+        mocker.patch(
             "hsfs.util.get_timestamp_from_date_string"
         )
         mock_statistics_api = mocker.patch("hsfs.core.statistics_api.StatisticsApi")

--- a/python/tests/core/test_training_dataset_engine.py
+++ b/python/tests/core/test_training_dataset_engine.py
@@ -27,7 +27,7 @@ class TestTrainingDatasetEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
@@ -73,10 +73,10 @@ class TestTrainingDatasetEngine:
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.engine.get_type")
 
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
 
         td = training_dataset.TrainingDataset(
@@ -109,7 +109,7 @@ class TestTrainingDatasetEngine:
         mocker.patch(
             "hsfs.transformation_function.TransformationFunction._extract_source_code"
         )
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
@@ -166,7 +166,7 @@ class TestTrainingDatasetEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
@@ -265,7 +265,7 @@ class TestTrainingDatasetEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_storage_connector_read = mocker.patch(
             "hsfs.storage_connector.StorageConnector.read"
         )
@@ -294,7 +294,7 @@ class TestTrainingDatasetEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        mocker.patch("hsfs.engine.get_instance")
         mock_storage_connector_read = mocker.patch(
             "hsfs.storage_connector.StorageConnector.read"
         )

--- a/python/tests/core/test_transformation_function_engine.py
+++ b/python/tests/core/test_transformation_function_engine.py
@@ -32,7 +32,7 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_tf_engine_is_builtin = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.is_builtin"
         )
         mock_tf_api = mocker.patch(
@@ -530,7 +530,7 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_builtin_tf_fn_min_max_scaler_stats = mocker.patch(
+        mocker.patch(
             "hsfs.core.builtin_transformation_function.BuiltInTransformationFunction.min_max_scaler_stats",
             return_value=(1, 100),
         )
@@ -559,7 +559,7 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_builtin_tf_fn_standard_scaler_stats = mocker.patch(
+        mocker.patch(
             "hsfs.core.builtin_transformation_function.BuiltInTransformationFunction.standard_scaler_stats",
             return_value=(1, 100),
         )
@@ -588,7 +588,7 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_builtin_tf_fn_robust_scaler_stats = mocker.patch(
+        mocker.patch(
             "hsfs.core.builtin_transformation_function.BuiltInTransformationFunction.robust_scaler_stats",
             return_value={24: 1, 49: 2, 74: 3},
         )
@@ -618,7 +618,7 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_builtin_tf_fn_encoder_stats = mocker.patch(
+        mocker.patch(
             "hsfs.core.builtin_transformation_function.BuiltInTransformationFunction.encoder_stats",
             return_value="test",
         )
@@ -646,11 +646,11 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_tf_engine_is_builtin = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.is_builtin",
             return_value=False,
         )
-        mock_tf_engine_populate_builtin_fn_arguments = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_fn_arguments"
         )
 
@@ -686,10 +686,10 @@ class TestTransformationFunctionEngine:
         # Arrange
         feature_store_id = 99
 
-        mock_tf_engine_is_builtin = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.is_builtin"
         )
-        mock_tf_engine_populate_builtin_fn_arguments = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_fn_arguments"
         )
 
@@ -1210,7 +1210,7 @@ class TestTransformationFunctionEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_tf_engine_is_builtin = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.is_builtin"
         )
         mock_tf_engine_compute_transformation_fn_statistics = mocker.patch(
@@ -1276,7 +1276,7 @@ class TestTransformationFunctionEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.client.get_instance")
-        mock_tf_engine_is_builtin = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.is_builtin"
         )
         mock_tf_engine_compute_transformation_fn_statistics = mocker.patch(

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -851,9 +851,7 @@ class TestPython:
 
     def test_parse_schema_feature_group(self, mocker):
         # Arrange
-        mocker.patch(
-            "hsfs.engine.python.Engine._convert_pandas_type"
-        )
+        mocker.patch("hsfs.engine.python.Engine._convert_pandas_type")
 
         python_engine = python.Engine()
 
@@ -1252,15 +1250,11 @@ class TestPython:
 
     def test_legacy_save_dataframe(self, mocker):
         # Arrange
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_app_options"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_app_options")
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mock_dataset_api = mocker.patch("hsfs.core.dataset_api.DatasetApi")
         mock_job_api = mocker.patch("hsfs.core.job_api.JobApi")
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_job_url"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_job_url")
         mock_python_engine_wait_for_job = mocker.patch(
             "hsfs.engine.python.Engine._wait_for_job"
         )
@@ -1615,9 +1609,7 @@ class TestPython:
     def test_time_series_split(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.python.Engine._convert_to_unix_timestamp"
-        )
+        mocker.patch("hsfs.engine.python.Engine._convert_to_unix_timestamp")
 
         python_engine = python.Engine()
 
@@ -1655,9 +1647,7 @@ class TestPython:
     def test_time_series_split_drop_event_time(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.python.Engine._convert_to_unix_timestamp"
-        )
+        mocker.patch("hsfs.engine.python.Engine._convert_to_unix_timestamp")
 
         python_engine = python.Engine()
 
@@ -1774,14 +1764,10 @@ class TestPython:
     def test_write_training_dataset(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf"
-        )
+        mocker.patch("hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf")
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_job_url"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_job_url")
         mock_python_engine_wait_for_job = mocker.patch(
             "hsfs.engine.python.Engine._wait_for_job"
         )
@@ -1811,14 +1797,10 @@ class TestPython:
     def test_write_training_dataset_query_td(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf"
-        )
+        mocker.patch("hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf")
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_job_url"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_job_url")
         mock_python_engine_wait_for_job = mocker.patch(
             "hsfs.engine.python.Engine._wait_for_job"
         )
@@ -1855,14 +1837,10 @@ class TestPython:
     def test_write_training_dataset_query_fv(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.get_type")
-        mocker.patch(
-            "hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf"
-        )
+        mocker.patch("hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf")
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_job_url"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_job_url")
         mock_python_engine_wait_for_job = mocker.patch(
             "hsfs.engine.python.Engine._wait_for_job"
         )
@@ -1986,9 +1964,7 @@ class TestPython:
 
         # Act
         with pytest.raises(TypeError) as e_info:
-            python_engine._return_dataframe_type(
-                dataframe=df, dataframe_type="other"
-            )
+            python_engine._return_dataframe_type(dataframe=df, dataframe_type="other")
 
         # Assert
         assert (
@@ -2248,25 +2224,15 @@ class TestPython:
 
     def test_write_dataframe_kafka(self, mocker):
         # Arrange
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_kafka_config", return_value={}
-        )
-        mocker.patch(
-            "hsfs.feature_group.FeatureGroup._get_encoded_avro_schema"
-        )
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_encoder_func"
-        )
-        mocker.patch(
-            "hsfs.engine.python.Engine._encode_complex_features"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_kafka_config", return_value={})
+        mocker.patch("hsfs.feature_group.FeatureGroup._get_encoded_avro_schema")
+        mocker.patch("hsfs.engine.python.Engine._get_encoder_func")
+        mocker.patch("hsfs.engine.python.Engine._encode_complex_features")
         mock_python_engine_kafka_produce = mocker.patch(
             "hsfs.engine.python.Engine._kafka_produce"
         )
         mocker.patch("hsfs.core.job_api.JobApi")  # get, launch
-        mocker.patch(
-            "hsfs.engine.python.Engine._get_job_url"
-        )
+        mocker.patch("hsfs.engine.python.Engine._get_job_url")
         mock_python_engine_wait_for_job = mocker.patch(
             "hsfs.engine.python.Engine._wait_for_job"
         )
@@ -2425,9 +2391,7 @@ class TestPython:
         mock_client_get_instance.return_value._get_client_key_path.return_value = (
             "_get_client_key_path"
         )
-        mocker.patch(
-            "socket.gethostname", return_value="gethostname"
-        )
+        mocker.patch("socket.gethostname", return_value="gethostname")
         mock_kafka_api = mocker.patch("hsfs.core.kafka_api.KafkaApi")
 
         python_engine = python.Engine()
@@ -2468,9 +2432,7 @@ class TestPython:
         mock_client_get_instance.return_value._get_client_key_path.return_value = (
             "_get_client_key_path"
         )
-        mocker.patch(
-            "socket.gethostname", return_value="gethostname"
-        )
+        mocker.patch("socket.gethostname", return_value="gethostname")
         mock_kafka_api = mocker.patch("hsfs.core.kafka_api.KafkaApi")
 
         python_engine = python.Engine()

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -538,7 +538,7 @@ class TestPython:
         # Assert
         assert result == {}
 
-    def test_read_options(self):
+    def test_read_options_stream_source(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -580,9 +580,9 @@ class TestPython:
         )
 
         # Assert
-        assert result == None
+        assert result is None
 
-    def test_register_hudi_temporary_table(self, mocker):
+    def test_register_hudi_temporary_table(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -595,7 +595,7 @@ class TestPython:
         )
 
         # Assert
-        assert result == None
+        assert result is None
 
     def test_profile(self, mocker):
         # Arrange
@@ -663,7 +663,7 @@ class TestPython:
         )
         assert mock_python_engine_convert_pandas_statistics.call_count == 1
 
-    def test_convert_pandas_statistics(self, mocker):
+    def test_convert_pandas_statistics(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -828,7 +828,7 @@ class TestPython:
         result = python_engine.set_job_group(group_id=None, description=None)
 
         # Assert
-        assert result == None
+        assert result is None
 
     def test_convert_to_default_dataframe(self, mocker):
         # Arrange
@@ -851,7 +851,7 @@ class TestPython:
 
     def test_parse_schema_feature_group(self, mocker):
         # Arrange
-        mock_python_engine_convert_pandas_type = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._convert_pandas_type"
         )
 
@@ -1171,7 +1171,7 @@ class TestPython:
 
         # Act
         with pytest.raises(ValueError) as e_info:
-            result = python_engine._infer_type_pyarrow(arrow_type=pa.bool_())
+            python_engine._infer_type_pyarrow(arrow_type=pa.bool_())
 
         # Assert
         assert str(e_info.value) == "dtype 'O' (arrow_type 'bool') not supported"
@@ -1252,13 +1252,13 @@ class TestPython:
 
     def test_legacy_save_dataframe(self, mocker):
         # Arrange
-        mock_python_engine_get_app_options = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_app_options"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mock_dataset_api = mocker.patch("hsfs.core.dataset_api.DatasetApi")
         mock_job_api = mocker.patch("hsfs.core.job_api.JobApi")
-        mock_python_engine_get_job_url = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_job_url"
         )
         mock_python_engine_wait_for_job = mocker.patch(
@@ -1291,7 +1291,7 @@ class TestPython:
         mock_python_engine_prepare_transform_split_df = mocker.patch(
             "hsfs.engine.python.Engine._prepare_transform_split_df"
         )
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
 
@@ -1324,7 +1324,7 @@ class TestPython:
         mock_python_engine_prepare_transform_split_df = mocker.patch(
             "hsfs.engine.python.Engine._prepare_transform_split_df"
         )
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
 
@@ -1351,7 +1351,7 @@ class TestPython:
         # Assert
         assert mock_python_engine_prepare_transform_split_df.call_count == 1
 
-    def test_split_labels(self, mocker):
+    def test_split_labels(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -1365,7 +1365,7 @@ class TestPython:
         assert str(result_df) == "   Col1  col2\n0     1     3\n1     2     4"
         assert str(result_df_split) == "None"
 
-    def test_split_labels_labels(self, mocker):
+    def test_split_labels_labels(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -1387,7 +1387,7 @@ class TestPython:
         mock_python_engine_random_split = mocker.patch(
             "hsfs.engine.python.Engine._random_split"
         )
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
 
@@ -1426,7 +1426,6 @@ class TestPython:
         assert isinstance(result["train"], pd.DataFrame)
         assert isinstance(result["test"], pd.DataFrame)
 
-
     def test_prepare_transform_split_df_time_split_td_features(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
@@ -1435,7 +1434,7 @@ class TestPython:
         mock_python_engine_time_series_split = mocker.patch(
             "hsfs.engine.python.Engine._time_series_split"
         )
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
 
@@ -1500,7 +1499,7 @@ class TestPython:
         mock_python_engine_time_series_split = mocker.patch(
             "hsfs.engine.python.Engine._time_series_split"
         )
-        mock_tf_engine = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
         )
 
@@ -1604,7 +1603,7 @@ class TestPython:
 
         # Act
         with pytest.raises(ValueError) as e_info:
-            result = python_engine._random_split(df=df, training_dataset_obj=td)
+            python_engine._random_split(df=df, training_dataset_obj=td)
 
         # Assert
         assert (
@@ -1616,7 +1615,7 @@ class TestPython:
     def test_time_series_split(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mock_python_engine_convert_to_unix_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._convert_to_unix_timestamp"
         )
 
@@ -1656,7 +1655,7 @@ class TestPython:
     def test_time_series_split_drop_event_time(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mock_python_engine_convert_to_unix_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._convert_to_unix_timestamp"
         )
 
@@ -1698,7 +1697,7 @@ class TestPython:
     def test_time_series_split_event_time(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mock_python_engine_convert_to_unix_timestamp = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._convert_to_unix_timestamp",
             side_effect=[1000, 2000, 1000, 2000],
         )
@@ -1736,7 +1735,7 @@ class TestPython:
         for column in list(result):
             assert result[column].equals(expected[column])
 
-    def test_convert_to_unix_timestamp_pandas(self, mocker):
+    def test_convert_to_unix_timestamp_pandas(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -1762,7 +1761,7 @@ class TestPython:
         # Assert
         assert result == 1483225200000
 
-    def test_convert_to_unix_timestamp_int(self, mocker):
+    def test_convert_to_unix_timestamp_int(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -1775,12 +1774,12 @@ class TestPython:
     def test_write_training_dataset(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.get_type")
-        mock_td_job_conf = mocker.patch(
+        mocker.patch(
             "hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf"
         )
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
-        mock_python_engine_get_job_url = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_job_url"
         )
         mock_python_engine_wait_for_job = mocker.patch(
@@ -1812,12 +1811,12 @@ class TestPython:
     def test_write_training_dataset_query_td(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.get_type")
-        mock_td_job_conf = mocker.patch(
+        mocker.patch(
             "hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf"
         )
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
-        mock_python_engine_get_job_url = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_job_url"
         )
         mock_python_engine_wait_for_job = mocker.patch(
@@ -1856,12 +1855,12 @@ class TestPython:
     def test_write_training_dataset_query_fv(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.get_type")
-        mock_td_job_conf = mocker.patch(
+        mocker.patch(
             "hsfs.core.training_dataset_job_conf.TrainingDatasetJobConf"
         )
         mock_fv_api = mocker.patch("hsfs.core.feature_view_api.FeatureViewApi")
         mock_td_api = mocker.patch("hsfs.core.training_dataset_api.TrainingDatasetApi")
-        mock_python_engine_get_job_url = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_job_url"
         )
         mock_python_engine_wait_for_job = mocker.patch(
@@ -1987,7 +1986,7 @@ class TestPython:
 
         # Act
         with pytest.raises(TypeError) as e_info:
-            result = python_engine._return_dataframe_type(
+            python_engine._return_dataframe_type(
                 dataframe=df, dataframe_type="other"
             )
 
@@ -1997,7 +1996,7 @@ class TestPython:
             == "Dataframe type `other` not supported on this platform."
         )
 
-    def test_return_dataframe_type_other(self):
+    def test_is_spark_dataframe(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -2176,7 +2175,7 @@ class TestPython:
         assert mock_job_api.return_value.last_execution.call_count == 1
         assert str(e_info.value) == "The Hopsworks Job was stopped"
 
-    def test_add_file(self, mocker):
+    def test_add_file(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -2230,7 +2229,7 @@ class TestPython:
         assert result["tf_name"][0] == 2
         assert result["tf_name"][1] == 3
 
-    def test_get_unique_values(self, mocker):
+    def test_get_unique_values(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -2249,23 +2248,23 @@ class TestPython:
 
     def test_write_dataframe_kafka(self, mocker):
         # Arrange
-        mock_python_engine_get_kafka_config = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_kafka_config", return_value={}
         )
-        mock_fg_get_encoded_avro_schema = mocker.patch(
+        mocker.patch(
             "hsfs.feature_group.FeatureGroup._get_encoded_avro_schema"
         )
-        mock_python_engine_get_encoder_func = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._get_encoder_func"
         )
-        mock_python_engine_encode_complex_features = mocker.patch(
+        mocker.patch(
             "hsfs.engine.python.Engine._encode_complex_features"
         )
         mock_python_engine_kafka_produce = mocker.patch(
             "hsfs.engine.python.Engine._kafka_produce"
         )
-        mock_job_api = mocker.patch("hsfs.core.job_api.JobApi")  # get, launch
-        mock_python_engine_get_job_url = mocker.patch(
+        mocker.patch("hsfs.core.job_api.JobApi")  # get, launch
+        mocker.patch(
             "hsfs.engine.python.Engine._get_job_url"
         )
         mock_python_engine_wait_for_job = mocker.patch(
@@ -2342,7 +2341,7 @@ class TestPython:
         assert mock_print.call_count == 1
         assert mock_print.call_args[0][0] == "Caught: test_error"
 
-    def test_encode_complex_features(self, mocker):
+    def test_encode_complex_features(self):
         # Arrange
         python_engine = python.Engine()
 
@@ -2426,7 +2425,7 @@ class TestPython:
         mock_client_get_instance.return_value._get_client_key_path.return_value = (
             "_get_client_key_path"
         )
-        mock_socket_gethostname = mocker.patch(
+        mocker.patch(
             "socket.gethostname", return_value="gethostname"
         )
         mock_kafka_api = mocker.patch("hsfs.core.kafka_api.KafkaApi")
@@ -2469,7 +2468,7 @@ class TestPython:
         mock_client_get_instance.return_value._get_client_key_path.return_value = (
             "_get_client_key_path"
         )
-        mock_socket_gethostname = mocker.patch(
+        mocker.patch(
             "socket.gethostname", return_value="gethostname"
         )
         mock_kafka_api = mocker.patch("hsfs.core.kafka_api.KafkaApi")

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -56,9 +56,7 @@ class TestSpark:
         mock_spark_engine_sql_offline = mocker.patch(
             "hsfs.engine.spark.Engine._sql_offline"
         )
-        mocker.patch(
-            "hsfs.engine.spark.Engine.set_job_group"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.set_job_group")
         mock_spark_engine_return_dataframe_type = mocker.patch(
             "hsfs.engine.spark.Engine._return_dataframe_type"
         )
@@ -83,9 +81,7 @@ class TestSpark:
         mock_spark_engine_sql_offline = mocker.patch(
             "hsfs.engine.spark.Engine._sql_offline"
         )
-        mocker.patch(
-            "hsfs.engine.spark.Engine.set_job_group"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.set_job_group")
         mock_spark_engine_return_dataframe_type = mocker.patch(
             "hsfs.engine.spark.Engine._return_dataframe_type"
         )
@@ -751,9 +747,7 @@ class TestSpark:
     def test_save_stream_dataframe(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.spark.Engine._encode_complex_features"
-        )
+        mocker.patch("hsfs.engine.spark.Engine._encode_complex_features")
         mock_spark_engine_online_fg_to_avro = mocker.patch(
             "hsfs.engine.spark.Engine._online_fg_to_avro"
         )
@@ -854,9 +848,7 @@ class TestSpark:
     def test_save_stream_dataframe_query_name(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.spark.Engine._encode_complex_features"
-        )
+        mocker.patch("hsfs.engine.spark.Engine._encode_complex_features")
         mock_spark_engine_online_fg_to_avro = mocker.patch(
             "hsfs.engine.spark.Engine._online_fg_to_avro"
         )
@@ -957,9 +949,7 @@ class TestSpark:
     def test_save_stream_dataframe_checkpoint_dir(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.spark.Engine._encode_complex_features"
-        )
+        mocker.patch("hsfs.engine.spark.Engine._encode_complex_features")
         mock_spark_engine_online_fg_to_avro = mocker.patch(
             "hsfs.engine.spark.Engine._online_fg_to_avro"
         )
@@ -1060,9 +1050,7 @@ class TestSpark:
     def test_save_stream_dataframe_await_termination(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.spark.Engine._encode_complex_features"
-        )
+        mocker.patch("hsfs.engine.spark.Engine._encode_complex_features")
         mock_spark_engine_online_fg_to_avro = mocker.patch(
             "hsfs.engine.spark.Engine._online_fg_to_avro"
         )
@@ -1309,9 +1297,7 @@ class TestSpark:
 
     def test_save_online_dataframe(self, mocker):
         # Arrange
-        mocker.patch(
-            "hsfs.engine.spark.Engine._encode_complex_features"
-        )
+        mocker.patch("hsfs.engine.spark.Engine._encode_complex_features")
         mock_spark_engine_online_fg_to_avro = mocker.patch(
             "hsfs.engine.spark.Engine._online_fg_to_avro"
         )
@@ -1538,9 +1524,7 @@ class TestSpark:
     def test_write_training_dataset(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mocker.patch(
-            "hsfs.engine.spark.Engine.write_options"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.write_options")
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
@@ -1591,9 +1575,7 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mocker.patch(
-            "hsfs.engine.spark.Engine.write_options"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.write_options")
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
@@ -1644,9 +1626,7 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mocker.patch(
-            "hsfs.engine.spark.Engine.write_options"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.write_options")
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
@@ -1698,9 +1678,7 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mocker.patch(
-            "hsfs.engine.spark.Engine.write_options"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.write_options")
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
@@ -1756,9 +1734,7 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mocker.patch(
-            "hsfs.engine.spark.Engine.write_options"
-        )
+        mocker.patch("hsfs.engine.spark.Engine.write_options")
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -37,7 +37,6 @@ from pyspark.sql.types import (
 from pyspark.sql.functions import lit
 
 from hsfs import (
-    storage_connector,
     feature_group,
     training_dataset,
     transformation_function,
@@ -57,7 +56,7 @@ class TestSpark:
         mock_spark_engine_sql_offline = mocker.patch(
             "hsfs.engine.spark.Engine._sql_offline"
         )
-        mock_spark_engine_set_job_group = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.set_job_group"
         )
         mock_spark_engine_return_dataframe_type = mocker.patch(
@@ -84,7 +83,7 @@ class TestSpark:
         mock_spark_engine_sql_offline = mocker.patch(
             "hsfs.engine.spark.Engine._sql_offline"
         )
-        mock_spark_engine_set_job_group = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.set_job_group"
         )
         mock_spark_engine_return_dataframe_type = mocker.patch(
@@ -347,13 +346,13 @@ class TestSpark:
             == "Dataframe type `other` not supported on this platform."
         )
 
-    def test_convert_to_default_dataframe_list_1dimension(self, mocker):
+    def test_convert_to_default_dataframe_list_1dimension(self):
         # Arrange
         spark_engine = spark.Engine()
 
         # Act
         with pytest.raises(TypeError) as e_info:
-            result = spark_engine.convert_to_default_dataframe(
+            spark_engine.convert_to_default_dataframe(
                 dataframe=list(),
             )
 
@@ -363,7 +362,7 @@ class TestSpark:
             == "Cannot convert numpy array that do not have two dimensions to a dataframe. The number of dimensions are: 1"
         )
 
-    def test_convert_to_default_dataframe_list(self, mocker):
+    def test_convert_to_default_dataframe_list(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -381,7 +380,7 @@ class TestSpark:
         for column in list(result_df):
             assert result_df[column].equals(result_df[column])
 
-    def test_convert_to_default_dataframe_numpy_array(self, mocker):
+    def test_convert_to_default_dataframe_numpy_array(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -399,7 +398,7 @@ class TestSpark:
         for column in list(result_df):
             assert result_df[column].equals(result_df[column])
 
-    def test_convert_to_default_dataframe_pandas_dataframe(self, mocker):
+    def test_convert_to_default_dataframe_pandas_dataframe(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -417,7 +416,7 @@ class TestSpark:
         for column in list(result_df):
             assert result_df[column].equals(result_df[column])
 
-    def test_convert_to_default_dataframe_pyspark_rdd(self, mocker):
+    def test_convert_to_default_dataframe_pyspark_rdd(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -440,7 +439,7 @@ class TestSpark:
         for column in list(result_df):
             assert result_df[column].equals(result_df[column])
 
-    def test_convert_to_default_dataframe_pyspark_dataframe(self, mocker):
+    def test_convert_to_default_dataframe_pyspark_dataframe(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -460,9 +459,7 @@ class TestSpark:
         for column in list(result_df):
             assert result_df[column].equals(result_df[column])
 
-    def test_convert_to_default_dataframe_pyspark_dataframe_capitalized_columns(
-        self, mocker
-    ):
+    def test_convert_to_default_dataframe_pyspark_dataframe_capitalized_columns(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -482,7 +479,7 @@ class TestSpark:
         for column in list(result_df):
             assert result_df[column.lower()].equals(result_df[column])
 
-    def test_convert_to_default_dataframe_wrong_type(self, mocker):
+    def test_convert_to_default_dataframe_wrong_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -754,7 +751,7 @@ class TestSpark:
     def test_save_stream_dataframe(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mock_spark_engine_encode_complex_features = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine._encode_complex_features"
         )
         mock_spark_engine_online_fg_to_avro = mocker.patch(
@@ -857,7 +854,7 @@ class TestSpark:
     def test_save_stream_dataframe_query_name(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mock_spark_engine_encode_complex_features = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine._encode_complex_features"
         )
         mock_spark_engine_online_fg_to_avro = mocker.patch(
@@ -960,7 +957,7 @@ class TestSpark:
     def test_save_stream_dataframe_checkpoint_dir(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mock_spark_engine_encode_complex_features = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine._encode_complex_features"
         )
         mock_spark_engine_online_fg_to_avro = mocker.patch(
@@ -1063,7 +1060,7 @@ class TestSpark:
     def test_save_stream_dataframe_await_termination(self, mocker):
         # Arrange
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mock_spark_engine_encode_complex_features = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine._encode_complex_features"
         )
         mock_spark_engine_online_fg_to_avro = mocker.patch(
@@ -1312,7 +1309,7 @@ class TestSpark:
 
     def test_save_online_dataframe(self, mocker):
         # Arrange
-        mock_spark_engine_encode_complex_features = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine._encode_complex_features"
         )
         mock_spark_engine_online_fg_to_avro = mocker.patch(
@@ -1437,8 +1434,10 @@ class TestSpark:
         fg._avro_schema = '{"fields": [{"name": "col_0"}]}'
 
         # Act
-        with pytest.raises(TypeError) as e_info:  # todo look into this (to_avro has to be mocked)
-            result = spark_engine._encode_complex_features(
+        with pytest.raises(
+            TypeError
+        ) as e_info:  # todo look into this (to_avro has to be mocked)
+            spark_engine._encode_complex_features(
                 feature_group=fg,
                 dataframe=spark_df,
             )
@@ -1446,7 +1445,7 @@ class TestSpark:
         # Assert
         assert str(e_info.value) == "'JavaPackage' object is not callable"
 
-    def test_online_fg_to_avro(self, mocker):
+    def test_online_fg_to_avro(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -1466,7 +1465,9 @@ class TestSpark:
         fg._avro_schema = '{"fields": [{"name": "col_0"}]}'
 
         # Act
-        with pytest.raises(TypeError) as e_info:  # todo look into this (to_avro has to be mocked)
+        with pytest.raises(
+            TypeError
+        ) as e_info:  # todo look into this (to_avro has to be mocked)
             spark_engine._online_fg_to_avro(
                 feature_group=fg,
                 dataframe=spark_df,
@@ -1494,7 +1495,7 @@ class TestSpark:
         # Assert
         assert mock_spark_engine_write_training_dataset.call_count == 1
 
-    def test_split_labels(self, mocker):
+    def test_split_labels(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -1510,7 +1511,7 @@ class TestSpark:
         # Assert
         assert result == (df, None)
 
-    def test_split_labels_labels(self, mocker):
+    def test_split_labels_labels(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -1537,19 +1538,19 @@ class TestSpark:
     def test_write_training_dataset(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mock_spark_engine_write_options = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.write_options"
         )
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
-        mock_tf_engine_populate_builtin_transformation_functions = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_transformation_functions"
         )
         mock_spark_engine_write_training_dataset_single = mocker.patch(
             "hsfs.engine.spark.Engine._write_training_dataset_single"
         )
-        mock_spark_engine_split_df = mocker.patch("hsfs.engine.spark.Engine._split_df")
+        mocker.patch("hsfs.engine.spark.Engine._split_df")
         mock_spark_engine_write_training_dataset_splits = mocker.patch(
             "hsfs.engine.spark.Engine._write_training_dataset_splits"
         )
@@ -1590,19 +1591,19 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mock_spark_engine_write_options = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.write_options"
         )
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
-        mock_tf_engine_populate_builtin_transformation_functions = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_transformation_functions"
         )
         mock_spark_engine_write_training_dataset_single = mocker.patch(
             "hsfs.engine.spark.Engine._write_training_dataset_single"
         )
-        mock_spark_engine_split_df = mocker.patch("hsfs.engine.spark.Engine._split_df")
+        mocker.patch("hsfs.engine.spark.Engine._split_df")
         mock_spark_engine_write_training_dataset_splits = mocker.patch(
             "hsfs.engine.spark.Engine._write_training_dataset_splits"
         )
@@ -1643,19 +1644,19 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mock_spark_engine_write_options = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.write_options"
         )
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
-        mock_tf_engine_populate_builtin_transformation_functions = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_transformation_functions"
         )
         mock_spark_engine_write_training_dataset_single = mocker.patch(
             "hsfs.engine.spark.Engine._write_training_dataset_single"
         )
-        mock_spark_engine_split_df = mocker.patch("hsfs.engine.spark.Engine._split_df")
+        mocker.patch("hsfs.engine.spark.Engine._split_df")
         mock_spark_engine_write_training_dataset_splits = mocker.patch(
             "hsfs.engine.spark.Engine._write_training_dataset_splits"
         )
@@ -1697,13 +1698,13 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mock_spark_engine_write_options = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.write_options"
         )
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
-        mock_tf_engine_populate_builtin_transformation_functions = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_transformation_functions"
         )
         mock_spark_engine_write_training_dataset_single = mocker.patch(
@@ -1755,13 +1756,13 @@ class TestSpark:
         mocker.patch("hsfs.engine.get_type")
         mocker.patch("hsfs.client.get_instance")
         mocker.patch("hsfs.constructor.query.Query.read")
-        mock_spark_engine_write_options = mocker.patch(
+        mocker.patch(
             "hsfs.engine.spark.Engine.write_options"
         )
         mock_spark_engine_convert_to_default_dataframe = mocker.patch(
             "hsfs.engine.spark.Engine.convert_to_default_dataframe"
         )
-        mock_tf_engine_populate_builtin_transformation_functions = mocker.patch(
+        mocker.patch(
             "hsfs.core.transformation_function_engine.TransformationFunctionEngine.populate_builtin_transformation_functions"
         )
         mock_spark_engine_write_training_dataset_single = mocker.patch(
@@ -2394,7 +2395,7 @@ class TestSpark:
         # Assert
         assert result is not None
         assert mock_spark_engine_setup_storage_connector.call_count == 1
-        assert mock_spark_engine_setup_storage_connector.call_args[0][1] == None
+        assert mock_spark_engine_setup_storage_connector.call_args[0][1] is None
         assert mock_pyspark_getOrCreate.return_value.read.format.call_args[0][0] == ""
         assert (
             mock_pyspark_getOrCreate.return_value.read.format.return_value.options.call_args[
@@ -2425,7 +2426,7 @@ class TestSpark:
         # Assert
         assert result is not None
         assert mock_spark_engine_setup_storage_connector.call_count == 1
-        assert mock_spark_engine_setup_storage_connector.call_args[0][1] == None
+        assert mock_spark_engine_setup_storage_connector.call_args[0][1] is None
         assert mock_pyspark_getOrCreate.return_value.read.format.call_args[0][0] == ""
         assert mock_pyspark_getOrCreate.return_value.read.format.return_value.options.call_args[
             1
@@ -2883,10 +2884,6 @@ class TestSpark:
         spark_df = spark_engine._spark_session.createDataFrame(df)
         mock_stream.load.return_value = spark_df
 
-        expected_df = pd.DataFrame(data={"name": ["value1", "value2"]})
-
-        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
-
         schema_string = """{
                                 "namespace": "example.avro",
                                 "type": "record",
@@ -2897,8 +2894,10 @@ class TestSpark:
                             }"""
 
         # Act
-        with pytest.raises(TypeError) as e_info:  # todo look into this (from_avro has to be mocked)
-            result = spark_engine._read_stream_kafka(
+        with pytest.raises(
+            TypeError
+        ) as e_info:  # todo look into this (from_avro has to be mocked)
+            spark_engine._read_stream_kafka(
                 stream=mock_stream,
                 message_format="avro",
                 schema=schema_string,
@@ -2932,20 +2931,6 @@ class TestSpark:
         spark_df = spark_engine._spark_session.createDataFrame(df)
         mock_stream.load.return_value = spark_df
 
-        expected_df = pd.DataFrame(
-            data={
-                "key": [1, 2],
-                "topic": ["test_topic", "test_topic"],
-                "partition": ["test_partition", "test_partition"],
-                "offset": ["test_offset", "test_offset"],
-                "timestamp": ["test_timestamp", "test_timestamp"],
-                "timestampType": ["test_timestampType", "test_timestampType"],
-                "name": ["value1", "value2"],
-            }
-        )
-
-        expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
-
         schema_string = """{
                                 "namespace": "example.avro",
                                 "type": "record",
@@ -2956,8 +2941,10 @@ class TestSpark:
                             }"""
 
         # Act
-        with pytest.raises(TypeError) as e_info:  # todo look into this (from_avro has to be mocked)
-            result = spark_engine._read_stream_kafka(
+        with pytest.raises(
+            TypeError
+        ) as e_info:  # todo look into this (from_avro has to be mocked)
+            spark_engine._read_stream_kafka(
                 stream=mock_stream,
                 message_format="avro",
                 schema=schema_string,
@@ -3067,7 +3054,7 @@ class TestSpark:
             "success": True,
         }
 
-    def test_write_options(self, mocker):
+    def test_write_options(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3080,7 +3067,7 @@ class TestSpark:
         # Assert
         assert result == {"test_key": "test_value"}
 
-    def test_write_options_tfrecords(self, mocker):
+    def test_write_options_tfrecords(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3093,7 +3080,7 @@ class TestSpark:
         # Assert
         assert result == {"recordType": "Example", "test_key": "test_value"}
 
-    def test_write_options_tfrecord(self, mocker):
+    def test_write_options_tfrecord(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3106,7 +3093,7 @@ class TestSpark:
         # Assert
         assert result == {"recordType": "Example", "test_key": "test_value"}
 
-    def test_write_options_csv(self, mocker):
+    def test_write_options_csv(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3119,7 +3106,7 @@ class TestSpark:
         # Assert
         assert result == {"delimiter": ",", "header": "true", "test_key": "test_value"}
 
-    def test_write_options_tsv(self, mocker):
+    def test_write_options_tsv(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3132,7 +3119,7 @@ class TestSpark:
         # Assert
         assert result == {"delimiter": "\t", "header": "true", "test_key": "test_value"}
 
-    def test_read_options(self, mocker):
+    def test_read_options(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3145,7 +3132,7 @@ class TestSpark:
         # Assert
         assert result == {}
 
-    def test_read_options_provided_options(self, mocker):
+    def test_read_options_provided_options(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3158,7 +3145,7 @@ class TestSpark:
         # Assert
         assert result == {"test_key": "test_value"}
 
-    def test_read_options_provided_options_tfrecords(self, mocker):
+    def test_read_options_provided_options_tfrecords(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3171,7 +3158,7 @@ class TestSpark:
         # Assert
         assert result == {"recordType": "Example", "test_key": "test_value"}
 
-    def test_read_options_provided_options_tfrecord(self, mocker):
+    def test_read_options_provided_options_tfrecord(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3184,7 +3171,7 @@ class TestSpark:
         # Assert
         assert result == {"recordType": "Example", "test_key": "test_value"}
 
-    def test_read_options_provided_options_csv(self, mocker):
+    def test_read_options_provided_options_csv(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3202,7 +3189,7 @@ class TestSpark:
             "test_key": "test_value",
         }
 
-    def test_read_options_provided_options_tsv(self, mocker):
+    def test_read_options_provided_options_tsv(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3243,7 +3230,7 @@ class TestSpark:
         assert result[0].name == "col_0"
         assert result[1].name == "col_1"
         assert mock_spark_engine_convert_spark_type.call_count == 2
-        assert mock_spark_engine_convert_spark_type.call_args[0][1] == False
+        assert mock_spark_engine_convert_spark_type.call_args[0][1] is False
 
     def test_parse_schema_feature_group_hudi(self, mocker):
         # Arrange
@@ -3268,7 +3255,7 @@ class TestSpark:
         assert result[0].name == "col_0"
         assert result[1].name == "col_1"
         assert mock_spark_engine_convert_spark_type.call_count == 2
-        assert mock_spark_engine_convert_spark_type.call_args[0][1] == True
+        assert mock_spark_engine_convert_spark_type.call_args[0][1] is True
 
     def test_parse_schema_feature_group_value_error(self, mocker):
         # Arrange
@@ -3297,7 +3284,7 @@ class TestSpark:
         # Assert
         assert str(e_info.value) == "Feature 'col_0': test error response"
 
-    def test_parse_schema_training_dataset(self, mocker):
+    def test_parse_schema_training_dataset(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3315,7 +3302,7 @@ class TestSpark:
         assert result[0].name == "col_0"
         assert result[1].name == "col_1"
 
-    def test_convert_spark_type(self, mocker):
+    def test_convert_spark_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3328,7 +3315,7 @@ class TestSpark:
         # Assert
         assert result == "int"
 
-    def test_convert_spark_type_using_hudi_byte_type(self, mocker):
+    def test_convert_spark_type_using_hudi_byte_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3341,7 +3328,7 @@ class TestSpark:
         # Assert
         assert result == "int"
 
-    def test_convert_spark_type_using_hudi_short_type(self, mocker):
+    def test_convert_spark_type_using_hudi_short_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3354,7 +3341,7 @@ class TestSpark:
         # Assert
         assert result == "int"
 
-    def test_convert_spark_type_using_hudi_bool_type(self, mocker):
+    def test_convert_spark_type_using_hudi_bool_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3367,7 +3354,7 @@ class TestSpark:
         # Assert
         assert result == "boolean"
 
-    def test_convert_spark_type_using_hudi_int_type(self, mocker):
+    def test_convert_spark_type_using_hudi_int_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3380,7 +3367,7 @@ class TestSpark:
         # Assert
         assert result == "int"
 
-    def test_convert_spark_type_using_hudi_long_type(self, mocker):
+    def test_convert_spark_type_using_hudi_long_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3393,7 +3380,7 @@ class TestSpark:
         # Assert
         assert result == "bigint"
 
-    def test_convert_spark_type_using_hudi_float_type(self, mocker):
+    def test_convert_spark_type_using_hudi_float_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3406,7 +3393,7 @@ class TestSpark:
         # Assert
         assert result == "float"
 
-    def test_convert_spark_type_using_hudi_double_type(self, mocker):
+    def test_convert_spark_type_using_hudi_double_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3419,7 +3406,7 @@ class TestSpark:
         # Assert
         assert result == "double"
 
-    def test_convert_spark_type_using_hudi_decimal_type(self, mocker):
+    def test_convert_spark_type_using_hudi_decimal_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3432,7 +3419,7 @@ class TestSpark:
         # Assert
         assert result == "decimal(10,0)"
 
-    def test_convert_spark_type_using_hudi_timestamp_type(self, mocker):
+    def test_convert_spark_type_using_hudi_timestamp_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3445,7 +3432,7 @@ class TestSpark:
         # Assert
         assert result == "timestamp"
 
-    def test_convert_spark_type_using_hudi_date_type(self, mocker):
+    def test_convert_spark_type_using_hudi_date_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3458,7 +3445,7 @@ class TestSpark:
         # Assert
         assert result == "date"
 
-    def test_convert_spark_type_using_hudi_string_type(self, mocker):
+    def test_convert_spark_type_using_hudi_string_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3471,7 +3458,7 @@ class TestSpark:
         # Assert
         assert result == "string"
 
-    def test_convert_spark_type_using_hudi_struct_type(self, mocker):
+    def test_convert_spark_type_using_hudi_struct_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3484,7 +3471,7 @@ class TestSpark:
         # Assert
         assert result == "struct<>"
 
-    def test_convert_spark_type_using_hudi_binary_type(self, mocker):
+    def test_convert_spark_type_using_hudi_binary_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3497,7 +3484,7 @@ class TestSpark:
         # Assert
         assert result == "binary"
 
-    def test_convert_spark_type_using_hudi_map_type(self, mocker):
+    def test_convert_spark_type_using_hudi_map_type(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3536,7 +3523,7 @@ class TestSpark:
         )
 
         # Act
-        result = spark_engine.setup_storage_connector(
+        spark_engine.setup_storage_connector(
             storage_connector=s3_connector,
             path="test_path",
         )
@@ -3568,7 +3555,7 @@ class TestSpark:
         )
 
         # Act
-        result = spark_engine.setup_storage_connector(
+        spark_engine.setup_storage_connector(
             storage_connector=adls_connector,
             path="test_path",
         )
@@ -3600,7 +3587,7 @@ class TestSpark:
         )
 
         # Act
-        result = spark_engine.setup_storage_connector(
+        spark_engine.setup_storage_connector(
             storage_connector=gcs_connector,
             path="test_path",
         )
@@ -3643,7 +3630,7 @@ class TestSpark:
         assert mock_spark_engine_setup_adls_hadoop_conf.call_count == 0
         assert mock_spark_engine_setup_gcp_hadoop_conf.call_count == 0
 
-    def test_setup_storage_connector_jdbc(self, mocker):
+    def test_setup_s3_hadoop_conf(self, mocker):
         # Arrange
         mock_pyspark_getOrCreate = mocker.patch(
             "pyspark.sql.session.SparkSession.builder.getOrCreate"
@@ -3732,7 +3719,7 @@ class TestSpark:
             "name_2", "value_2"
         )
 
-    def test_is_spark_dataframe(self, mocker):
+    def test_is_spark_dataframe(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3742,9 +3729,9 @@ class TestSpark:
         )
 
         # Assert
-        assert result == False
+        assert result is False
 
-    def test_is_spark_dataframe_spark_dataframe(self, mocker):
+    def test_is_spark_dataframe_spark_dataframe(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3759,9 +3746,9 @@ class TestSpark:
         )
 
         # Assert
-        assert result == True
+        assert result is True
 
-    def test_get_empty_appended_dataframe(self, mocker):
+    def test_get_empty_appended_dataframe(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -3859,7 +3846,11 @@ class TestSpark:
         spark_df = spark_engine._spark_session.createDataFrame(df)
 
         expected_df = pd.DataFrame(
-            data={"col_0": ["2", "3"], "col_1": ["test_1", "test_2"], "col_2": [True, False]}
+            data={
+                "col_0": ["2", "3"],
+                "col_1": ["test_1", "test_2"],
+                "col_2": [True, False],
+            }
         )  # todo why it doesnt return int?
 
         expected_spark_df = spark_engine._spark_session.createDataFrame(expected_df)
@@ -3993,7 +3984,7 @@ class TestSpark:
             "fs.gs.encryption.key.hash", gcs_connector.encryption_key_hash
         )
 
-    def test_get_unique_values(self, mocker):
+    def test_get_unique_values(self):
         # Arrange
         spark_engine = spark.Engine()
 
@@ -4011,7 +4002,7 @@ class TestSpark:
         # Assert
         assert result == [1, 2]
 
-    def test_create_empty_df(self, mocker):
+    def test_create_empty_df(self):
         # Arrange
         spark_engine = spark.Engine()
 

--- a/python/tests/test_expectation_suite.py
+++ b/python/tests/test_expectation_suite.py
@@ -69,13 +69,13 @@ class TestExpectationSuite:
         es = expectation_suite.ExpectationSuite.from_response_json(json)
 
         # Assert
-        assert es.id == None
+        assert es.id is None
         assert es.expectation_suite_name == "test_expectation_suite_name"
-        assert es._featurestore_id == None
-        assert es._featuregroup_id == None
-        assert es.ge_cloud_id == None
-        assert es.data_asset_type == None
-        assert es.run_validation == True
+        assert es._featurestore_id is None
+        assert es._featuregroup_id is None
+        assert es.ge_cloud_id is None
+        assert es.data_asset_type is None
+        assert es.run_validation is True
         assert es.validation_ingestion_policy == "ALWAYS"
         assert len(es.expectations) == 1
         assert isinstance(es.expectations[0], ge_expectation.GeExpectation)
@@ -89,4 +89,4 @@ class TestExpectationSuite:
         es_list = expectation_suite.ExpectationSuite.from_response_json(json)
 
         # Assert
-        assert es_list == None
+        assert es_list is None

--- a/python/tests/test_feature.py
+++ b/python/tests/test_feature.py
@@ -30,9 +30,9 @@ class TestFeature:
         assert f.name == "intt"
         assert f.type == "int"
         assert f.description == "test_description"
-        assert f.primary == True
-        assert f.partition == False
-        assert f.hudi_precombine_key == True
+        assert f.primary is True
+        assert f.partition is False
+        assert f.hudi_precombine_key is True
         assert f.online_type == "int"
         assert f.default_value == 1
         assert f._feature_group_id == 15
@@ -46,11 +46,11 @@ class TestFeature:
 
         # Assert
         assert f.name == "intt"
-        assert f.type == None
-        assert f.description == None
-        assert f.primary == False
-        assert f.partition == False
-        assert f.hudi_precombine_key == False
-        assert f.online_type == None
-        assert f.default_value == None
-        assert f._feature_group_id == None
+        assert f.type is None
+        assert f.description is None
+        assert f.primary is False
+        assert f.partition is False
+        assert f.hudi_precombine_key is False
+        assert f.online_type is None
+        assert f.default_value is None
+        assert f._feature_group_id is None

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -51,13 +51,13 @@ class TestFeatureGroup:
             fg.location
             == "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1"
         )
-        assert fg.online_enabled == True
+        assert fg.online_enabled is True
         assert fg.time_travel_format == "HUDI"
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
-        assert fg.event_time == None
-        assert fg.stream == False
-        assert fg.expectation_suite == None
+        assert fg.event_time is None
+        assert fg.stream is False
+        assert fg.expectation_suite is None
 
     def test_from_response_json_list(self, backend_fixtures):
         # Arrange
@@ -86,13 +86,13 @@ class TestFeatureGroup:
             fg.location
             == "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1"
         )
-        assert fg.online_enabled == True
+        assert fg.online_enabled is True
         assert fg.time_travel_format == "HUDI"
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
-        assert fg.event_time == None
-        assert fg.stream == False
-        assert fg.expectation_suite == None
+        assert fg.event_time is None
+        assert fg.stream is False
+        assert fg.expectation_suite is None
 
     def test_from_response_json_basic_info(self, backend_fixtures):
         # Arrange
@@ -108,20 +108,20 @@ class TestFeatureGroup:
         assert fg.description == ""
         assert fg.partition_key == []
         assert fg.primary_key == []
-        assert fg.hudi_precombine_key == None
-        assert fg._feature_store_name == None
-        assert fg.created == None
-        assert fg.creator == None
+        assert fg.hudi_precombine_key is None
+        assert fg._feature_store_name is None
+        assert fg.created is None
+        assert fg.creator is None
         assert fg.id == 15
         assert len(fg.features) == 0
-        assert fg.location == None
-        assert fg.online_enabled == False
-        assert fg.time_travel_format == None
+        assert fg.location is None
+        assert fg.online_enabled is False
+        assert fg.time_travel_format is None
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
-        assert fg._online_topic_name == None
-        assert fg.event_time == None
-        assert fg.stream == False
-        assert fg.expectation_suite == None
+        assert fg._online_topic_name is None
+        assert fg.event_time is None
+        assert fg.stream is False
+        assert fg.expectation_suite is None
 
     def test_from_response_json_stream(self, backend_fixtures):
         # Arrange
@@ -148,13 +148,13 @@ class TestFeatureGroup:
             fg.location
             == "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1"
         )
-        assert fg.online_enabled == True
+        assert fg.online_enabled is True
         assert fg.time_travel_format == "HUDI"
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
-        assert fg.event_time == None
-        assert fg.stream == True
-        assert fg.expectation_suite == None
+        assert fg.event_time is None
+        assert fg.stream is True
+        assert fg.expectation_suite is None
 
     def test_from_response_json_stream_list(self, backend_fixtures):
         # Arrange
@@ -183,13 +183,13 @@ class TestFeatureGroup:
             fg.location
             == "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1"
         )
-        assert fg.online_enabled == True
+        assert fg.online_enabled is True
         assert fg.time_travel_format == "HUDI"
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
-        assert fg.event_time == None
-        assert fg.stream == True
-        assert fg.expectation_suite == None
+        assert fg.event_time is None
+        assert fg.stream is True
+        assert fg.expectation_suite is None
 
     def test_from_response_json_stream_basic_info(self, backend_fixtures):
         # Arrange
@@ -205,20 +205,20 @@ class TestFeatureGroup:
         assert fg.description == ""
         assert fg.partition_key == []
         assert fg.primary_key == []
-        assert fg.hudi_precombine_key == None
-        assert fg._feature_store_name == None
-        assert fg.created == None
-        assert fg.creator == None
+        assert fg.hudi_precombine_key is None
+        assert fg._feature_store_name is None
+        assert fg.created is None
+        assert fg.creator is None
         assert fg.id == 15
         assert len(fg.features) == 0
-        assert fg.location == None
-        assert fg.online_enabled == False
-        assert fg.time_travel_format == None
+        assert fg.location is None
+        assert fg.online_enabled is False
+        assert fg.time_travel_format is None
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
-        assert fg._online_topic_name == None
-        assert fg.event_time == None
-        assert fg.stream == True
-        assert fg.expectation_suite == None
+        assert fg._online_topic_name is None
+        assert fg.event_time is None
+        assert fg.stream is True
+        assert fg.expectation_suite is None
 
 
 class TestExternalFeatureGroup:
@@ -297,21 +297,21 @@ class TestExternalFeatureGroup:
 
         # Assert
         assert isinstance(fg.storage_connector, storage_connector.StorageConnector)
-        assert fg.query == None
-        assert fg.data_format == None
-        assert fg.path == None
-        assert fg.options == None
-        assert fg.name == None
-        assert fg.version == None
-        assert fg.description == None
+        assert fg.query is None
+        assert fg.data_format is None
+        assert fg.path is None
+        assert fg.options is None
+        assert fg.name is None
+        assert fg.version is None
+        assert fg.description is None
         assert fg.primary_key == []
-        assert fg._feature_store_id == None
-        assert fg._feature_store_name == None
-        assert fg.created == None
-        assert fg.creator == None
+        assert fg._feature_store_id is None
+        assert fg._feature_store_name is None
+        assert fg.created is None
+        assert fg.creator is None
         assert fg.id == 15
-        assert fg.features == None
-        assert fg.location == None
+        assert fg.features is None
+        assert fg.location is None
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
-        assert fg.event_time == None
-        assert fg.expectation_suite == None
+        assert fg.event_time is None
+        assert fg.expectation_suite is None

--- a/python/tests/test_feature_group_commit.py
+++ b/python/tests/test_feature_group_commit.py
@@ -63,10 +63,10 @@ class TestFeatureGroupCommit:
         fg_commit = feature_group_commit.FeatureGroupCommit.from_response_json(json)
 
         # Assert
-        assert fg_commit.commitid == None
-        assert fg_commit.commit_date_string == None
-        assert fg_commit.commit_time == None
-        assert fg_commit.rows_inserted == None
-        assert fg_commit.rows_updated == None
-        assert fg_commit.rows_deleted == None
-        assert fg_commit.validation_id == None
+        assert fg_commit.commitid is None
+        assert fg_commit.commit_date_string is None
+        assert fg_commit.commit_time is None
+        assert fg_commit.rows_inserted is None
+        assert fg_commit.rows_updated is None
+        assert fg_commit.rows_deleted is None
+        assert fg_commit.validation_id is None

--- a/python/tests/test_feature_store.py
+++ b/python/tests/test_feature_store.py
@@ -41,13 +41,13 @@ class TestFeatureStore:
         assert fs._offline_feature_store_name == "test_offline_featurestore_name"
         assert fs.hive_endpoint == "test_hive_endpoint"
         assert fs.mysql_server_endpoint == "test_mysql_server_endpoint"
-        assert fs.online_enabled == True
+        assert fs.online_enabled is True
         assert fs._num_feature_groups == 2
         assert fs._num_training_datasets == 3
         assert fs._num_storage_connectors == 4
         assert fs._num_feature_views == 5
 
-    def test_from_response_json(self, mocker, backend_fixtures):
+    def test_from_response_json_basic_info(self, mocker, backend_fixtures):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
         json = backend_fixtures["feature_store"]["get_basic_info"]["response"]
@@ -64,13 +64,13 @@ class TestFeatureStore:
         assert fs.project_id == 67
         assert fs.description == "test_featurestore_description"
         assert fs._inode_id == 44
-        assert fs._online_feature_store_name == None
-        assert fs._online_feature_store_size == None
+        assert fs._online_feature_store_name is None
+        assert fs._online_feature_store_size is None
         assert fs._offline_feature_store_name == "test_offline_featurestore_name"
         assert fs.hive_endpoint == "test_hive_endpoint"
-        assert fs.mysql_server_endpoint == None
-        assert fs.online_enabled == True
-        assert fs._num_feature_groups == None
-        assert fs._num_training_datasets == None
-        assert fs._num_storage_connectors == None
-        assert fs._num_feature_views == None
+        assert fs.mysql_server_endpoint is None
+        assert fs.online_enabled is True
+        assert fs._num_feature_groups is None
+        assert fs._num_training_datasets is None
+        assert fs._num_storage_connectors is None
+        assert fs._num_feature_views is None

--- a/python/tests/test_feature_view.py
+++ b/python/tests/test_feature_view.py
@@ -52,11 +52,11 @@ class TestFeatureView:
 
         # Assert
         assert fv.name == "test_name"
-        assert fv.id == None
+        assert fv.id is None
         assert isinstance(fv.query, query.Query)
         assert fv.featurestore_id == 5
-        assert fv.version == None
-        assert fv.description == None
+        assert fv.version is None
+        assert fv.description is None
         assert fv.labels == []
         assert fv.transformation_functions == {}
         assert len(fv.schema) == 0

--- a/python/tests/test_ge_validation_result.py
+++ b/python/tests/test_ge_validation_result.py
@@ -28,7 +28,7 @@ class TestValidationResult:
 
         # Assert
         assert vr.id == 11
-        assert vr.success == True
+        assert vr.success is True
         assert vr._observed_value == "test_observed_value"
         assert vr._expectation_id == 22
         assert vr._validation_report_id == 33
@@ -47,11 +47,11 @@ class TestValidationResult:
         vr = ge_validation_result.ValidationResult.from_response_json(json)
 
         # Assert
-        assert vr.id == None
-        assert vr.success == True
-        assert vr._observed_value == None
-        assert vr._expectation_id == None
-        assert vr._validation_report_id == None
+        assert vr.id is None
+        assert vr.success is True
+        assert vr._observed_value is None
+        assert vr._expectation_id is None
+        assert vr._validation_report_id is None
         assert vr.result == {"result_key": "result_value"}
         assert vr.meta == {"meta_key": "meta_value"}
         assert vr.exception_info == {"exception_info_key": "exception_info_value"}
@@ -70,7 +70,7 @@ class TestValidationResult:
         assert len(vr_list) == 1
         vr = vr_list[0]
         assert vr.id == 11
-        assert vr.success == True
+        assert vr.success is True
         assert vr._observed_value == "test_observed_value"
         assert vr._expectation_id == 22
         assert vr._validation_report_id == 33

--- a/python/tests/test_statistics.py
+++ b/python/tests/test_statistics.py
@@ -32,7 +32,7 @@ class TestStatistics:
         assert s.content == {"key": "value"}
         assert len(s.split_statistics) == 1
         assert isinstance(s.split_statistics[0], split_statistics.SplitStatistics)
-        assert s.for_transformation == True
+        assert s.for_transformation is True
 
     def test_from_response_json_basic_info(self, backend_fixtures):
         # Arrange
@@ -43,10 +43,10 @@ class TestStatistics:
 
         # Assert
         assert s.commit_time == "test_commit_time"
-        assert s.feature_group_commit_id == None
+        assert s.feature_group_commit_id is None
         assert s.content == {}
         assert len(s.split_statistics) == 0
-        assert s.for_transformation == False
+        assert s.for_transformation is False
 
     def test_from_response_json_empty(self, backend_fixtures):
         # Arrange
@@ -56,4 +56,4 @@ class TestStatistics:
         s = statistics.Statistics.from_response_json(json)
 
         # Assert
-        assert s == None
+        assert s is None

--- a/python/tests/test_statistics_config.py
+++ b/python/tests/test_statistics_config.py
@@ -27,10 +27,10 @@ class TestStatistics:
         sc = statistics_config.StatisticsConfig.from_response_json(json)
 
         # Assert
-        assert sc.enabled == True
-        assert sc.correlations == True
-        assert sc.histograms == True
-        assert sc.exact_uniqueness == True
+        assert sc.enabled is True
+        assert sc.correlations is True
+        assert sc.histograms is True
+        assert sc.exact_uniqueness is True
         assert sc.columns == []
 
     def test_from_response_json_basic_info(self, backend_fixtures):
@@ -41,8 +41,8 @@ class TestStatistics:
         sc = statistics_config.StatisticsConfig.from_response_json(json)
 
         # Assert
-        assert sc.enabled == True
-        assert sc.correlations == False
-        assert sc.histograms == False
-        assert sc.exact_uniqueness == False
+        assert sc.enabled is True
+        assert sc.correlations is False
+        assert sc.histograms is False
+        assert sc.exact_uniqueness is False
         assert sc.columns == []

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -46,9 +46,9 @@ class TestHopsfsConnector:
         assert sc.id == 1
         assert sc.name == "test_hopsfs"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc._hopsfs_path == None
-        assert sc._dataset_name == None
+        assert sc.description is None
+        assert sc._hopsfs_path is None
+        assert sc._dataset_name is None
 
 
 class TestS3Connector:
@@ -83,14 +83,14 @@ class TestS3Connector:
         assert sc.id == 1
         assert sc.name == "test_s3"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.access_key == None
-        assert sc.secret_key == None
-        assert sc.server_encryption_algorithm == None
-        assert sc.server_encryption_key == None
-        assert sc.bucket == None
-        assert sc.session_token == None
-        assert sc.iam_role == None
+        assert sc.description is None
+        assert sc.access_key is None
+        assert sc.secret_key is None
+        assert sc.server_encryption_algorithm is None
+        assert sc.server_encryption_key is None
+        assert sc.bucket is None
+        assert sc.session_token is None
+        assert sc.iam_role is None
 
 
 class TestRedshiftConnector:
@@ -133,20 +133,20 @@ class TestRedshiftConnector:
         assert sc.id == 1
         assert sc.name == "test_redshift"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.cluster_identifier == None
-        assert sc.database_driver == None
-        assert sc.database_endpoint == None
-        assert sc.database_name == None
-        assert sc.database_port == None
-        assert sc.table_name == None
-        assert sc.database_user_name == None
-        assert sc.auto_create == None
-        assert sc.database_password == None
-        assert sc.database_group == None
-        assert sc.iam_role == None
-        assert sc.arguments == None
-        assert sc.expiration == None
+        assert sc.description is None
+        assert sc.cluster_identifier is None
+        assert sc.database_driver is None
+        assert sc.database_endpoint is None
+        assert sc.database_name is None
+        assert sc.database_port is None
+        assert sc.table_name is None
+        assert sc.database_user_name is None
+        assert sc.auto_create is None
+        assert sc.database_password is None
+        assert sc.database_group is None
+        assert sc.iam_role is None
+        assert sc.arguments is None
+        assert sc.expiration is None
 
 
 class TestAdlsConnector:
@@ -181,13 +181,13 @@ class TestAdlsConnector:
         assert sc.id == 1
         assert sc.name == "test_adls"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.generation == None
-        assert sc.directory_id == None
-        assert sc.application_id == None
-        assert sc.service_credential == None
-        assert sc.account_name == None
-        assert sc.container_name == None
+        assert sc.description is None
+        assert sc.generation is None
+        assert sc.directory_id is None
+        assert sc.application_id is None
+        assert sc.service_credential is None
+        assert sc.account_name is None
+        assert sc.container_name is None
         assert sc._spark_options == {}
 
 
@@ -256,17 +256,17 @@ class TestSnowflakeConnector:
         assert sc.id == 1
         assert sc.name == "test_snowflake"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.database == None
-        assert sc.password == None
-        assert sc.token == None
-        assert sc.role == None
-        assert sc.schema == None
-        assert sc.table == None
-        assert sc.url == None
-        assert sc.user == None
-        assert sc.warehouse == None
-        assert sc.application == None
+        assert sc.description is None
+        assert sc.database is None
+        assert sc.password is None
+        assert sc.token is None
+        assert sc.role is None
+        assert sc.schema is None
+        assert sc.table is None
+        assert sc.url is None
+        assert sc.user is None
+        assert sc.warehouse is None
+        assert sc.application is None
         assert sc._options == {}
 
 
@@ -359,9 +359,9 @@ class TestJdbcConnector:
         assert sc.id == 1
         assert sc.name == "test_jdbc"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.connection_string == None
-        assert sc.arguments == None
+        assert sc.description is None
+        assert sc.connection_string is None
+        assert sc.arguments is None
 
 
 class TestKafkaConnector:
@@ -411,15 +411,15 @@ class TestKafkaConnector:
         assert sc.id == 1
         assert sc.name == "test_kafka"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc._bootstrap_servers == None
-        assert sc.security_protocol == None
+        assert sc.description is None
+        assert sc._bootstrap_servers is None
+        assert sc.security_protocol is None
         assert sc.ssl_truststore_location == "result_from_add_file"
-        assert sc._ssl_truststore_password == None
+        assert sc._ssl_truststore_password is None
         assert sc.ssl_keystore_location == "result_from_add_file"
-        assert sc._ssl_keystore_password == None
-        assert sc._ssl_key_password == None
-        assert sc.ssl_endpoint_identification_algorithm == None
+        assert sc._ssl_keystore_password is None
+        assert sc._ssl_key_password is None
+        assert sc.ssl_endpoint_identification_algorithm is None
         assert sc.options == {}
 
 
@@ -453,12 +453,12 @@ class TestGcsConnector:
         assert sc.id == 1
         assert sc.name == "test_gcs"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.key_path == None
-        assert sc.bucket == None
-        assert sc.algorithm == None
-        assert sc.encryption_key == None
-        assert sc.encryption_key_hash == None
+        assert sc.description is None
+        assert sc.key_path is None
+        assert sc.bucket is None
+        assert sc.algorithm is None
+        assert sc.encryption_key is None
+        assert sc.encryption_key_hash is None
 
 
 class TestBigQueryConnector:
@@ -495,11 +495,11 @@ class TestBigQueryConnector:
         assert sc.id == 1
         assert sc.name == "test_big_query"
         assert sc._featurestore_id == 67
-        assert sc.description == None
-        assert sc.key_path == None
-        assert sc.parent_project == None
-        assert sc.dataset == None
-        assert sc.query_table == None
-        assert sc.query_project == None
-        assert sc.materialization_dataset == None
+        assert sc.description is None
+        assert sc.key_path is None
+        assert sc.parent_project is None
+        assert sc.dataset is None
+        assert sc.query_table is None
+        assert sc.query_project is None
+        assert sc.materialization_dataset is None
         assert sc.arguments == {}

--- a/python/tests/test_training_dataset.py
+++ b/python/tests/test_training_dataset.py
@@ -81,30 +81,30 @@ class TestTrainingDataset:
         # Assert
         assert len(td_list) == 1
         td = td_list[0]
-        assert td.id == None
+        assert td.id is None
         assert td.name == "test_name"
         assert td.version == 1
-        assert td.description == None
+        assert td.description is None
         assert td.data_format == "hudi"
-        assert td._start_time == None
-        assert td._end_time == None
-        assert td.validation_size == None
-        assert td.test_size == None
-        assert td.train_start == None
-        assert td.train_end == None
-        assert td.validation_start == None
-        assert td.validation_end == None
-        assert td.test_start == None
-        assert td.test_end == None
-        assert td.coalesce == False
-        assert td.seed == None
+        assert td._start_time is None
+        assert td._end_time is None
+        assert td.validation_size is None
+        assert td.test_size is None
+        assert td.train_start is None
+        assert td.train_end is None
+        assert td.validation_start is None
+        assert td.validation_end is None
+        assert td.test_start is None
+        assert td.test_end is None
+        assert td.coalesce is False
+        assert td.seed is None
         assert td.location == ""
-        assert td._from_query == None
-        assert td._querydto == None
+        assert td._from_query is None
+        assert td._querydto is None
         assert td.feature_store_id == 22
-        assert td.transformation_functions == None
-        assert td.train_split == None
-        assert td.training_dataset_type == None
+        assert td.transformation_functions is None
+        assert td.train_split is None
+        assert td.training_dataset_type is None
         assert isinstance(td.storage_connector, storage_connector.JdbcConnector)
         assert len(td._features) == 0
         assert len(td.splits) == 0

--- a/python/tests/test_training_dataset_feature.py
+++ b/python/tests/test_training_dataset_feature.py
@@ -56,9 +56,9 @@ class TestTrainingDatasetFeature:
 
         # Assert
         assert td_feature.name == "test_name"
-        assert td_feature.type == None
-        assert td_feature.index == None
-        assert td_feature._feature_group == None
-        assert td_feature._feature_group_feature_name == None
-        assert td_feature.label == False
-        assert td_feature.transformation_function == None
+        assert td_feature.type is None
+        assert td_feature.index is None
+        assert td_feature._feature_group is None
+        assert td_feature._feature_group_feature_name is None
+        assert td_feature.label is False
+        assert td_feature.transformation_function is None

--- a/python/tests/test_training_dataset_split.py
+++ b/python/tests/test_training_dataset_split.py
@@ -42,7 +42,7 @@ class TestTrainingDatasetSplit:
 
         # Assert
         assert td_split.name == "test_name"
-        assert td_split.percentage == None
+        assert td_split.percentage is None
         assert td_split.split_type == "test_split_type"
-        assert td_split.start_time == None
-        assert td_split.end_time == None
+        assert td_split.start_time is None
+        assert td_split.end_time is None

--- a/python/tests/test_transformation_function.py
+++ b/python/tests/test_transformation_function.py
@@ -31,14 +31,14 @@ class TestTransformationFunction:
         assert tf._featurestore_id == 11
         assert tf.version == 1
         assert tf.name == "test_name"
-        assert tf.transformation_fn == None
+        assert tf.transformation_fn is None
         assert tf.output_type == "FloatType()"
         assert (
             tf.source_code_content
             == '{"module_imports": "", "transformer_code": "test_builtin_source_code"}'
         )
-        assert tf._feature_group_feature_name == None
-        assert tf._feature_group_id == None
+        assert tf._feature_group_feature_name is None
+        assert tf._feature_group_id is None
 
     def test_from_response_json_basic_info(self, mocker, backend_fixtures):
         # Arrange
@@ -51,15 +51,15 @@ class TestTransformationFunction:
         tf = transformation_function.TransformationFunction.from_response_json(json)
 
         # Assert
-        assert tf.id == None
+        assert tf.id is None
         assert tf._featurestore_id == 11
-        assert tf.version == None
-        assert tf.name == None
-        assert tf.transformation_fn == None
-        assert tf.output_type == None
-        assert tf.source_code_content == None
-        assert tf._feature_group_feature_name == None
-        assert tf._feature_group_id == None
+        assert tf.version is None
+        assert tf.name is None
+        assert tf.transformation_fn is None
+        assert tf.output_type is None
+        assert tf.source_code_content is None
+        assert tf._feature_group_feature_name is None
+        assert tf._feature_group_id is None
 
     def test_from_response_json_list(self, backend_fixtures):
         # Arrange
@@ -77,14 +77,14 @@ class TestTransformationFunction:
         assert tf._featurestore_id == 11
         assert tf.version == 1
         assert tf.name == "test_name"
-        assert tf.transformation_fn == None
+        assert tf.transformation_fn is None
         assert tf.output_type == "FloatType()"
         assert (
             tf.source_code_content
             == '{"module_imports": "", "transformer_code": "test_builtin_source_code"}'
         )
-        assert tf._feature_group_feature_name == None
-        assert tf._feature_group_id == None
+        assert tf._feature_group_feature_name is None
+        assert tf._feature_group_id is None
 
     def test_from_response_json_list_empty(self, backend_fixtures):
         # Arrange

--- a/python/tests/test_user.py
+++ b/python/tests/test_user.py
@@ -53,4 +53,4 @@ class TestUser:
         u = user.User.from_response_json(json)
 
         # Assert
-        assert u == None
+        assert u is None

--- a/python/tests/test_validation_report.py
+++ b/python/tests/test_validation_report.py
@@ -28,7 +28,7 @@ class TestValidationReport:
 
         # Assert
         assert vr.id == 11
-        assert vr.success == True
+        assert vr.success is True
         assert vr._full_report_path == "test_full_report_path"
         assert vr._validation_time == "test_validation_time"
         assert vr._featurestore_id == "test_featurestore_id"
@@ -50,18 +50,18 @@ class TestValidationReport:
         vr = validation_report.ValidationReport.from_response_json(json)
 
         # Assert
-        assert vr.id == None
-        assert vr.success == True
-        assert vr._full_report_path == None
-        assert vr._validation_time == None
-        assert vr._featurestore_id == None
-        assert vr._featuregroup_id == None
-        assert vr.ingestion_result == None
+        assert vr.id is None
+        assert vr.success is True
+        assert vr._full_report_path is None
+        assert vr._validation_time is None
+        assert vr._featurestore_id is None
+        assert vr._featuregroup_id is None
+        assert vr.ingestion_result is None
         assert len(vr.results) == 1
         assert isinstance(vr.results[0], ge_validation_result.ValidationResult)
         assert vr.meta == {"meta_key": "meta_value"}
         assert vr.statistics == {"statistics_key": "statistics_value"}
-        assert vr.evaluation_parameters == None
+        assert vr.evaluation_parameters is None
 
     def test_from_response_json_list(self, backend_fixtures):
         # Arrange
@@ -74,7 +74,7 @@ class TestValidationReport:
         assert len(vr_list) == 1
         vr = vr_list[0]
         assert vr.id == 11
-        assert vr.success == True
+        assert vr.success is True
         assert vr._full_report_path == "test_full_report_path"
         assert vr._validation_time == "test_validation_time"
         assert vr._featurestore_id == "test_featurestore_id"


### PR DESCRIPTION
This PR adds/fixes/changes...
this pr ensures that flake8 is run also on tests and that flake8 doesn't fail on the current tests

JIRA Issue: - https://hopsworks.atlassian.net/browse/HOPSWORKS-3352

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
