### PR TITLE
[FSTORE-56] Enable cleaning of fv

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/FeatureView.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/FeatureView.java
@@ -130,6 +130,11 @@ public class FeatureView {
     featureViewEngine.delete(this.featureStore, this.name, this.version);
   }
 
+  public static void clean(FeatureStore featureStore, String featureViewName, Integer featureViewVersion)
+      throws FeatureStoreException, IOException {
+    featureViewEngine.delete(featureStore, featureViewName, featureViewVersion);
+  }
+
   public FeatureView update(FeatureView other) throws FeatureStoreException, IOException {
     return featureViewEngine.update(other);
   }

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/FeatureViewApi.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/FeatureViewApi.java
@@ -75,7 +75,19 @@ public class FeatureViewApi {
 
     LOGGER.info("Sending metadata request: " + uri);
     HopsworksClient hopsworksClient = HopsworksClient.getInstance();
-    return hopsworksClient.handleRequest(request, FeatureView.class);
+    try {
+      return hopsworksClient.handleRequest(request, FeatureView.class);
+    } catch (IOException e) {
+      if (e.getMessage().contains("\"errorCode\":270009")) {
+        throw new FeatureStoreException(
+            "Cannot get back the feature view because the query defined is no longer valid."
+            + " Some feature groups used in the query may have been deleted. You can clean up this feature view on the UI"
+            + " or `FeatureView.clean`."
+        );
+      } else {
+        throw e;
+      }
+    }
   }
 
   public List<FeatureView> get(FeatureStore featureStore, String name) throws FeatureStoreException,
@@ -92,7 +104,19 @@ public class FeatureViewApi {
 
     LOGGER.info("Sending metadata request: " + uri);
     HopsworksClient hopsworksClient = HopsworksClient.getInstance();
-    return Arrays.stream(hopsworksClient.handleRequest(request, FeatureView[].class)).collect(Collectors.toList());
+    try {
+      return Arrays.stream(hopsworksClient.handleRequest(request, FeatureView[].class)).collect(Collectors.toList());
+    } catch (IOException e) {
+      if (e.getMessage().contains("\"errorCode\":270009")) {
+        throw new FeatureStoreException(
+            "Cannot get back the feature view because the query defined is no longer valid."
+                + " Some feature groups used in the query may have been deleted. You can clean up this feature view on the UI"
+                + " or `FeatureView.clean`."
+        );
+      } else {
+        throw e;
+      }
+   }
   }
 
   private String addQueryParam(String baseUrl, Map<String, Object> params) {

--- a/java/src/main/java/com/logicalclocks/hsfs/metadata/FeatureViewApi.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/metadata/FeatureViewApi.java
@@ -81,8 +81,8 @@ public class FeatureViewApi {
       if (e.getMessage().contains("\"errorCode\":270009")) {
         throw new FeatureStoreException(
             "Cannot get back the feature view because the query defined is no longer valid."
-            + " Some feature groups used in the query may have been deleted. You can clean up this feature view on the UI"
-            + " or `FeatureView.clean`."
+            + " Some feature groups used in the query may have been deleted."
+            + " You can clean up this feature view on the UI or `FeatureView.clean`."
         );
       } else {
         throw e;
@@ -110,13 +110,13 @@ public class FeatureViewApi {
       if (e.getMessage().contains("\"errorCode\":270009")) {
         throw new FeatureStoreException(
             "Cannot get back the feature view because the query defined is no longer valid."
-                + " Some feature groups used in the query may have been deleted. You can clean up this feature view on the UI"
-                + " or `FeatureView.clean`."
+                + " Some feature groups used in the query may have been deleted."
+                + " You can clean up this feature view on the UI or `FeatureView.clean`."
         );
       } else {
         throw e;
       }
-   }
+    }
   }
 
   private String addQueryParam(String baseUrl, Map<String, Object> params) {

--- a/python/hsfs/core/feature_view_api.py
+++ b/python/hsfs/core/feature_view_api.py
@@ -22,7 +22,7 @@ from hsfs import (
 )
 from hsfs.core import job
 from hsfs.constructor import serving_prepared_statement, query
-
+from hsfs.client.exceptions import RestAPIError
 
 class FeatureViewApi:
     _POST = "POST"
@@ -61,20 +61,40 @@ class FeatureViewApi:
 
     def get_by_name(self, name):
         path = self._base_path + [name]
-        return [
-            feature_view.FeatureView.from_response_json(fv)
-            for fv in self._client._send_request(
-                self._GET, path, {"expand": ["query", "features"]}
-            )["items"]
-        ]
+        try:
+            return [
+                feature_view.FeatureView.from_response_json(fv)
+                for fv in self._client._send_request(
+                    self._GET, path, {"expand": ["query", "features"]}
+                )["items"]
+            ]
+        except RestAPIError as e:
+            if e.response.json().get("errorCode", "") == 270009:
+                raise ValueError(
+                    "Cannot get back the feature view because the query defined is no longer valid."
+                    " Some feature groups used in the query may have been deleted. You can clean up this feature view on the UI"
+                    " or `FeatureView.clean`."
+                )
+            else:
+                raise e
 
     def get_by_name_version(self, name, version):
         path = self._base_path + [name, self._VERSION, version]
-        return feature_view.FeatureView.from_response_json(
-            self._client._send_request(
-                self._GET, path, {"expand": ["query", "features"]}
+        try:
+            return feature_view.FeatureView.from_response_json(
+                self._client._send_request(
+                    self._GET, path, {"expand": ["query", "features"]}
+                )
             )
-        )
+        except RestAPIError as e:
+            if e.response.json().get("errorCode", "") == 270009:
+                raise ValueError(
+                    "Cannot get back the feature view because the query defined is no longer valid."
+                    " Some feature groups used in the query may have been deleted. You can clean up this feature view on the UI"
+                    " or `FeatureView.clean`."
+                )
+            else:
+                raise e
 
     def delete_by_name(self, name):
         path = self._base_path + [name]

--- a/python/hsfs/core/feature_view_api.py
+++ b/python/hsfs/core/feature_view_api.py
@@ -24,6 +24,7 @@ from hsfs.core import job
 from hsfs.constructor import serving_prepared_statement, query
 from hsfs.client.exceptions import RestAPIError
 
+
 class FeatureViewApi:
     _POST = "POST"
     _GET = "GET"

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -31,6 +31,7 @@ from hsfs.core import (
 )
 from hsfs.transformation_function import TransformationFunction
 from hsfs.statistics_config import StatisticsConfig
+from hsfs.core.feature_view_api import FeatureViewApi
 
 
 class FeatureView:
@@ -77,6 +78,21 @@ class FeatureView:
             `RestAPIError`.
         """
         self._feature_view_engine.delete(self.name, self.version)
+
+    @staticmethod
+    def clean(feature_store_id, feature_view_name, feature_view_version):
+        """Delete the feature view and all associated metadata.
+
+        !!! danger "Potentially dangerous operation"
+            This operation drops all metadata associated with **this version** of the
+            feature view **and** related training dataset **and** materialized data in HopsFS.
+
+        # Raises
+            `RestAPIError`.
+        """
+        FeatureViewApi(feature_store_id).delete_by_name_version(
+            feature_view_name, feature_view_version
+        )
 
     def update(self):
         # TODO feature view: wait for RestAPI


### PR DESCRIPTION
- Improve error message when getting a fv with deleted fg.
- Add `clean` method which allow users to delete fv without getting fv instance.

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
