### PR TITLE
[HOPSWORKS-3336] Fix timezone issue

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -26,6 +26,7 @@ import pyarrow as pa
 import json
 import random
 import uuid
+from datetime import datetime, timezone
 
 import great_expectations as ge
 
@@ -873,6 +874,8 @@ class Engine:
                     row[k] = row[k].tolist()
                 if isinstance(row[k], pd.Timestamp):
                     row[k] = row[k].to_pydatetime()
+                if isinstance(row[k], datetime) and row[k].tzinfo is None:
+                    row[k] = row[k].replace(tzinfo=timezone.utc)
 
             # encode complex features
             row = self._encode_complex_features(feature_writers, row)

--- a/python/tests/engine/test_python_writer.py
+++ b/python/tests/engine/test_python_writer.py
@@ -1,0 +1,103 @@
+#
+#   Copyright 2022 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from io import BytesIO
+import datetime
+import json
+import fastavro
+
+from hsfs import feature_group
+from hsfs.engine import python
+
+
+class TestPythonWriter:
+    def test_write_dataframe_kafka(self, mocker, dataframe_fixture_times):
+        # Arrange
+        mocker.patch("hsfs.engine.python.Engine._get_kafka_config", return_value={})
+        avro_schema_mock = mocker.patch(
+            "hsfs.feature_group.FeatureGroup._get_encoded_avro_schema"
+        )
+        avro_schema = (
+            '{"type":"record","name":"test_fg","namespace":"test_featurestore.db","fields":'
+            '[{"name":"primary_key","type":["null","long"]},{"name":"event_date","type":'
+            '["null",{"type":"int","logicalType":"date"}]},{"name":"event_datetime_notz","type":'
+            '["null",{"type":"long","logicalType":"timestamp-micros"}]},{"name":"event_datetime_utc",'
+            '"type":["null",{"type":"long","logicalType":"timestamp-micros"}]},'
+            '{"name":"event_datetime_utc_3","type":["null",{"type":"long","logicalType":'
+            '"timestamp-micros"}]},{"name":"event_timestamp","type":["null",{"type":"long",'
+            '"logicalType":"timestamp-micros"}]},{"name":"event_timestamp_pacific","type":'
+            '["null",{"type":"long","logicalType":"timestamp-micros"}]},{"name":"state","type":'
+            '["null","string"]},{"name":"measurement","type":["null","double"]}]}'
+        )
+        avro_schema_mock.side_effect = [avro_schema]
+        mock_python_engine_kafka_produce = mocker.patch(
+            "hsfs.engine.python.Engine._kafka_produce"
+        )
+        mocker.patch("hsfs.core.job_api.JobApi")  # get, launch
+        mocker.patch("hsfs.engine.python.Engine._get_job_url")
+        mocker.patch("hsfs.engine.python.Engine._wait_for_job")
+
+        python_engine = python.Engine()
+
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            stream=False,
+        )
+
+        # Act
+        python_engine._write_dataframe_kafka(
+            feature_group=fg,
+            dataframe=dataframe_fixture_times,
+            offline_write_options={"start_offline_backfill": True},
+        )
+
+        # Assert
+        encoded_row = mock_python_engine_kafka_produce.call_args[0][3]
+        print("Value" + str(encoded_row))
+        parsed_schema = fastavro.parse_schema(json.loads(avro_schema))
+        with BytesIO() as outf:
+            outf.write(encoded_row)
+            outf.seek(0)
+            record = fastavro.schemaless_reader(outf, parsed_schema)
+
+        reference_record = {
+            "primary_key": 1,
+            "event_date": datetime.date(2022, 7, 3),
+            "event_datetime_notz": datetime.datetime(
+                2022, 7, 3, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+            "event_datetime_utc": datetime.datetime(
+                2022, 7, 3, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+            "event_datetime_utc_3": datetime.datetime(
+                2022, 7, 2, 21, 0, tzinfo=datetime.timezone.utc
+            ),
+            "event_timestamp": datetime.datetime(
+                2022, 7, 3, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+            "event_timestamp_pacific": datetime.datetime(
+                2022, 7, 3, 7, 0, tzinfo=datetime.timezone.utc
+            ),
+            "state": "nevada",
+            "measurement": 12.4,
+        }
+
+        assert reference_record == record

--- a/python/tests/fixtures/dataframe_fixtures.py
+++ b/python/tests/fixtures/dataframe_fixtures.py
@@ -1,6 +1,6 @@
 import pytest
 import pandas as pd
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 
 @pytest.fixture
@@ -15,6 +15,27 @@ def dataframe_fixture_basic():
         ],
         "state": ["nevada", None, "nevada", None],
         "measurement": [12.4, 32.5, 342.6, 43.7],
+    }
+
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def dataframe_fixture_times():
+    data = {
+        "primary_key": [1],
+        "event_date": [datetime(2022, 7, 3).date()],
+        "event_datetime_notz": [datetime(2022, 7, 3, 0, 0, 0)],
+        "event_datetime_utc": [
+            datetime(2022, 7, 3, 0, 0, 0).replace(tzinfo=timezone.utc)
+        ],
+        "event_datetime_utc_3": [
+            datetime(2022, 7, 3, 0, 0, 0).replace(tzinfo=timezone(timedelta(hours=3)))
+        ],
+        "event_timestamp": [pd.Timestamp("2022-07-03T00")],
+        "event_timestamp_pacific": [pd.Timestamp("2022-07-03T00", tz="US/Pacific")],
+        "state": ["nevada"],
+        "measurement": [12.4],
     }
 
     return pd.DataFrame(data)


### PR DESCRIPTION
This PR fixed the timezone issue decribed in HOPSWORKS-3336
- This is to circumvent a bug/inconsistency in fastavro https://github.com/fastavro/fastavro/issues/642
- timestamps without tzinfo are handled as being in local timezone on linux and as being in UTC timezone on windows.
- to fix the issue, we explicitly set the timezone to utc if no tzinfo is specified.

JIRA Issue: https://hopsworks.atlassian.net/browse/HOPSWORKS-3336

Priority for Review: high

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
