### PR TITLE
[FSTORE-11] Add mkdocs macros dependency for docs

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -50,6 +50,7 @@ setup(
             "mkdocs-jupyter==0.21.0",
             "markdown==3.3.7",
             "pymdown-extensions",
+            "mkdocs-macros-plugin==7.0",
         ],
         "hive": [
             "pyhopshive[thrift]",

--- a/python/setup.py
+++ b/python/setup.py
@@ -50,7 +50,7 @@ setup(
             "mkdocs-jupyter==0.21.0",
             "markdown==3.3.7",
             "pymdown-extensions",
-            "mkdocs-macros-plugin==7.0",
+            "mkdocs-macros-plugin==0.7.0",
         ],
         "hive": [
             "pyhopshive[thrift]",


### PR DESCRIPTION
This PR adds/fixes/changes...

adds a dependency for a plugin used in mkdocs in the documentation. It allows us to set variables and template links correctly with the right version without changing the links manually everywhere when releasing.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-11

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
