### PR TITLE
[FSTORE-331] BigQuery connector doesn't work if the application is ex…

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,6 +26,10 @@
         <scala.version>2.12.10</scala.version>
         <scala-short.version>2.12</scala-short.version>
         <dbutils.version>0.0.5</dbutils.version>
+        <json.version>20190722</json.version>
+        <hoverfly.version>0.12.2</hoverfly.version>
+        <junit.version>5.9.1</junit.version>
+        <surefire-plugin.version>2.22.0</surefire-plugin.version>
     </properties>
 
     <dependencies>
@@ -200,20 +204,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.specto</groupId>
-            <artifactId>hoverfly-java</artifactId>
-            <version>0.12.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/org.apache.hudi/hudi-spark-bundle -->
         <dependency>
             <groupId>io.hops.hudi</groupId>
@@ -252,7 +242,35 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20190722</version>
+            <version>${json.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.specto</groupId>
+            <artifactId>hoverfly-java</artifactId>
+            <version>${hoverfly.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala-short.version}</artifactId>
+            <version>${spark.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -328,7 +346,20 @@
                     </sourceDirectories>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertiesFile>src/test/resources/system.properties</systemPropertiesFile>
+                </configuration>
+            </plugin>
         </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
     </build>
 
     <repositories>

--- a/java/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -600,7 +600,7 @@ public abstract class StorageConnector {
 
       Map<String, String> readOptions = sparkOptions();
       // merge user spark options on top of default spark options
-      if (!options.isEmpty()) {
+      if (options != null && !options.isEmpty()) {
         readOptions.putAll(options);
       }
 

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/SparkEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/SparkEngine.java
@@ -746,13 +746,17 @@ public class SparkEngine {
   }
 
   public String addFile(String filePath) {
-    sparkSession.sparkContext().addFile("hdfs://" + filePath);
+    // this is used for unit testing
+    if (!filePath.startsWith("file://")) {
+      filePath = "hdfs://" + filePath;
+    }
+    sparkSession.sparkContext().addFile(filePath);
     return SparkFiles.get((new Path(filePath)).getName());
   }
 
   public Dataset<Row> readStream(StorageConnector storageConnector, String dataFormat, String messageFormat,
                                  String schema, Map<String, String> options, boolean includeMetadata)
-      throws FeatureStoreException {
+      throws FeatureStoreException, IOException {
     DataStreamReader stream = sparkSession.readStream().format(dataFormat);
 
     // set user options last so that they overwrite any default options

--- a/java/src/main/java/com/logicalclocks/hsfs/util/Constants.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/util/Constants.java
@@ -87,7 +87,7 @@ public class Constants {
   public static final String PROPERTY_GCS_ACCOUNT_ENABLE = "google.cloud.auth.service.account.enable";
   // end gcs
   // bigquery constants
-  public static final String BIGQ_CREDENTIALS_FILE = "credentialsFile";
+  public static final String BIGQ_CREDENTIALS = "credentials";
   public static final String BIGQ_PARENT_PROJECT = "parentProject";
   public static final String BIGQ_MATERIAL_DATASET = "materializationDataset";
   public static final String BIGQ_VIEWS_ENABLED = "viewsEnabled";

--- a/java/src/test/java/com/logicalclocks/hsfs/TestHopsworksExternalClient.java
+++ b/java/src/test/java/com/logicalclocks/hsfs/TestHopsworksExternalClient.java
@@ -24,9 +24,9 @@ import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -63,6 +63,6 @@ public class TestHopsworksExternalClient {
     HopsworksExternalClient hopsworksExternalClient = new HopsworksExternalClient(
         httpClient, httpHost);
     String apiKey = hopsworksExternalClient.readApiKey(null, null, apiFilePath.toString());
-    Assert.assertEquals("hello", apiKey);
+    Assertions.assertEquals("hello", apiKey);
   }
 }

--- a/java/src/test/java/com/logicalclocks/hsfs/TestStorageConnector.java
+++ b/java/src/test/java/com/logicalclocks/hsfs/TestStorageConnector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2022 Hopsworks AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.logicalclocks.hsfs;
+
+import com.logicalclocks.hsfs.util.Constants;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.Map;
+
+public class TestStorageConnector {
+
+  @Test
+  public void testBigQueryCredentialsBase64Encoded(@TempDir Path tempDir) throws IOException {
+    // Arrange
+    String credentials = "{\"type\": \"service_account\", \"project_id\": \"test\"}";
+    Path credentialsFile = tempDir.resolve("bigquery.json");
+    Files.write(credentialsFile, credentials.getBytes());
+
+    StorageConnector.BigqueryConnector bigqueryConnector = new StorageConnector.BigqueryConnector();
+    bigqueryConnector.setKeyPath("file://" + credentialsFile);
+
+    // Act
+    Map<String, String> sparkOptions = bigqueryConnector.sparkOptions();
+
+    // Assert
+    Assertions.assertEquals(credentials,
+        new String(Base64.getDecoder().decode(sparkOptions.get(Constants.BIGQ_CREDENTIALS)),  StandardCharsets.UTF_8));
+  }
+}

--- a/java/src/test/java/com/logicalclocks/hsfs/metadata/TestTagsApi.java
+++ b/java/src/test/java/com/logicalclocks/hsfs/metadata/TestTagsApi.java
@@ -17,8 +17,8 @@ package com.logicalclocks.hsfs.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.logicalclocks.hsfs.EntityEndpointType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
@@ -29,7 +29,7 @@ public class TestTagsApi {
     TagsApi tagsApi = new TagsApi(EntityEndpointType.FEATURE_GROUP);
     ObjectMapper objectMapper = new ObjectMapper();
     Object obj = tagsApi.parseTagValue(objectMapper, 4.2d);
-    Assert.assertTrue(obj instanceof Double);
+    Assertions.assertTrue(obj instanceof Double);
   }
 
   @Test
@@ -44,7 +44,7 @@ public class TestTagsApi {
     TagsApi tagsApi = new TagsApi(EntityEndpointType.FEATURE_GROUP);
     ObjectMapper objectMapper = new ObjectMapper();
     Object obj = tagsApi.parseTagValue(objectMapper, 4);
-    Assert.assertTrue(obj instanceof Integer);
+    Assertions.assertTrue(obj instanceof Integer);
   }
 
   @Test
@@ -52,7 +52,7 @@ public class TestTagsApi {
     TagsApi tagsApi = new TagsApi(EntityEndpointType.FEATURE_GROUP);
     ObjectMapper objectMapper = new ObjectMapper();
     Object obj = tagsApi.parseTagValue(objectMapper, "test");
-    Assert.assertTrue(obj instanceof String);
+    Assertions.assertTrue(obj instanceof String);
   }
 
   @Test
@@ -60,7 +60,7 @@ public class TestTagsApi {
     TagsApi tagsApi = new TagsApi(EntityEndpointType.FEATURE_GROUP);
     ObjectMapper objectMapper = new ObjectMapper();
     Object obj = tagsApi.parseTagValue(objectMapper, "{\"key\":\"value\"}");
-    Assert.assertTrue(obj instanceof Map);
+    Assertions.assertTrue(obj instanceof Map);
   }
 
   @Test
@@ -68,7 +68,7 @@ public class TestTagsApi {
     TagsApi tagsApi = new TagsApi(EntityEndpointType.FEATURE_GROUP);
     ObjectMapper objectMapper = new ObjectMapper();
     Object obj = tagsApi.parseTagValue(objectMapper, "[{\"key\":\"value1\"}, {\"key\":\"value2\"}]");
-    Assert.assertTrue(obj.getClass().isArray());
+    Assertions.assertTrue(obj.getClass().isArray());
   }
 
   @Test
@@ -76,9 +76,9 @@ public class TestTagsApi {
     TagsApi tagsApi = new TagsApi(EntityEndpointType.FEATURE_GROUP);
     ObjectMapper objectMapper = new ObjectMapper();
     Object obj = tagsApi.parseTagValue(objectMapper, "{\"key1\":\"value\", \"key2\":4.2, \"key3\":4}");
-    Assert.assertTrue(obj instanceof Map);
-    Assert.assertTrue(((Map) obj).get("key1") instanceof String);
-    Assert.assertTrue(((Map) obj).get("key2") instanceof Double);
-    Assert.assertTrue(((Map) obj).get("key3") instanceof Integer);
+    Assertions.assertTrue(obj instanceof Map);
+    Assertions.assertTrue(((Map) obj).get("key1") instanceof String);
+    Assertions.assertTrue(((Map) obj).get("key2") instanceof Double);
+    Assertions.assertTrue(((Map) obj).get("key3") instanceof Integer);
   }
 }

--- a/java/src/test/resources/system.properties
+++ b/java/src/test/resources/system.properties
@@ -1,0 +1,1 @@
+spark.master=local[1]

--- a/python/.pre-commit-config.yaml
+++ b/python/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 exclude: setup.py
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.8.0
     hooks:
     -   id: black
         language_version: python3
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
       - id: flake8
         language_version: python3
         args: [--config=python/.flake8]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/python/hsfs/engine/__init__.py
+++ b/python/hsfs/engine/__init__.py
@@ -55,6 +55,14 @@ def get_instance():
     raise Exception("Couldn't find execution engine. Try reconnecting to Hopsworks.")
 
 
+# Used for testing
+def set_instance(engine_type, engine):
+    global _engine_type
+    global _engine
+    _engine_type = engine_type
+    _engine = engine
+
+
 def get_type():
     global _engine_type
     if _engine_type:

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -627,7 +627,11 @@ class Engine:
         return stream.load().select("key", "value")
 
     def add_file(self, file):
-        self._spark_context.addFile("hdfs://" + file)
+        # This is used for unit testing
+        if not file.startswith("file://"):
+            file = "hdfs://" + file
+
+        self._spark_context.addFile(file)
         return SparkFiles.get(os.path.basename(file))
 
     def profile(

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1118,8 +1118,8 @@ class BigQueryConnector(StorageConnector):
 
         local_key_path = engine.get_instance().add_file(self._key_path)
         with open(local_key_path, "rb") as credentials_file:
-            properties[self.BIGQ_CREDENTIALS] = base64.b64encode(
-                credentials_file.read()
+            properties[self.BIGQ_CREDENTIALS] = str(
+                base64.b64encode(credentials_file.read()), "utf-8"
             )
 
         if self._materialization_dataset:


### PR DESCRIPTION
…ecuted on multiple nodes

* Change the BigQuery configuration so that it uses the credential field (base64 encoding of the content of the credential file) instead of providing the path in the credentialFile property.

* For Java, updated the tests to use JUnit5 to allow for the @TmpDir annotation

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -
https://hopsworks.atlassian.net/browse/FSTORE-331

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
