### PR TITLE
[FSTORE-311][Append] Timezone-aware Timestamp conversion for PySpark client

### DIFF
--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -89,7 +89,7 @@ class Engine:
         self._spark_session.conf.set("hive.exec.dynamic.partition", "true")
         self._spark_session.conf.set("hive.exec.dynamic.partition.mode", "nonstrict")
         self._spark_session.conf.set("spark.sql.hive.convertMetastoreParquet", "false")
-        self._spark_session.conf.set("spark.sql.session.timeZone", "GMT")
+        self._spark_session.conf.set("spark.sql.session.timeZone", "UTC")
 
         if importlib.util.find_spec("pydoop"):
             # If we are on Databricks don't setup Pydoop as it's not available and cannot be easily installed.

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -24,6 +24,7 @@ from typing import Optional, TypeVar
 import numpy as np
 import pandas as pd
 import avro
+from datetime import datetime
 
 # in case importing in %%local
 try:
@@ -88,7 +89,7 @@ class Engine:
         self._spark_session.conf.set("hive.exec.dynamic.partition", "true")
         self._spark_session.conf.set("hive.exec.dynamic.partition.mode", "nonstrict")
         self._spark_session.conf.set("spark.sql.hive.convertMetastoreParquet", "false")
-        self._spark_session.conf.set("spark.sql.session.timeZone", "UTC")
+        self._spark_session.conf.set("spark.sql.session.timeZone", "GMT")
 
         if importlib.util.find_spec("pydoop"):
             # If we are on Databricks don't setup Pydoop as it's not available and cannot be easily installed.
@@ -171,9 +172,18 @@ class Engine:
             for n_col in list(range(num_cols)):
                 col_name = "col_" + str(n_col)
                 dataframe_dict[col_name] = dataframe[:, n_col]
-            pandas_df = pd.DataFrame(dataframe_dict)
-            dataframe = self._spark_session.createDataFrame(pandas_df)
-        elif isinstance(dataframe, pd.DataFrame):
+            dataframe = pd.DataFrame(dataframe_dict)
+
+        if isinstance(dataframe, pd.DataFrame):
+            # convert timestamps to current timezone
+            current_timezone = datetime.now().astimezone().tzinfo
+            for c in dataframe.columns:
+                if isinstance(
+                    dataframe[c].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
+                ):
+                    dataframe[c] = dataframe[c].dt.tz_convert(current_timezone)
+                elif dataframe[c].dtype == np.dtype("datetime64[ns]"):
+                    dataframe[c] = dataframe[c].dt.tz_localize(current_timezone)
             dataframe = self._spark_session.createDataFrame(dataframe)
         elif isinstance(dataframe, RDD):
             dataframe = dataframe.toDF()

--- a/python/tests/engine/test_python_spark_convert_dataframe.py
+++ b/python/tests/engine/test_python_spark_convert_dataframe.py
@@ -19,7 +19,31 @@ from hsfs.engine import python
 
 
 class TestPythonSparkConvertDataframe:
-    def test_convert_to_default_dataframe_w_timezone(
+    def test_convert_to_default_dataframe_w_timezone_notz(
+        self, mocker, dataframe_fixture_times
+    ):
+        mocker.patch("hsfs.client.get_instance")
+        python_engine = python.Engine()
+
+        default_df_python = python_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
+        spark_engine = spark.Engine()
+
+        default_df_spark_from_pd = spark_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
+        tz = spark_engine._spark_session.conf.get("spark.sql.session.timeZone")
+        print(tz)
+
+        assert (
+            default_df_spark_from_pd.head()[2]
+            == default_df_python["event_datetime_notz"][0].to_pydatetime()
+        )
+
+    def test_convert_to_default_dataframe_w_timezone_utc(
         self, mocker, dataframe_fixture_times
     ):
         mocker.patch("hsfs.client.get_instance")
@@ -36,21 +60,68 @@ class TestPythonSparkConvertDataframe:
         )
 
         assert (
-            default_df_spark_from_pd.head()[2]
-            == default_df_python["event_datetime_notz"][0].to_pydatetime()
-        )
-        assert (
             default_df_spark_from_pd.head()[3]
             == default_df_python["event_datetime_utc"][0].to_pydatetime()
         )
+
+    def test_convert_to_default_dataframe_w_timezone_utc_3(
+        self, mocker, dataframe_fixture_times
+    ):
+        mocker.patch("hsfs.client.get_instance")
+        python_engine = python.Engine()
+
+        default_df_python = python_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
+        spark_engine = spark.Engine()
+
+        default_df_spark_from_pd = spark_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
         assert (
             default_df_spark_from_pd.head()[4]
             == default_df_python["event_datetime_utc_3"][0].to_pydatetime()
         )
+
+    def test_convert_to_default_dataframe_w_timezone_timestamp(
+        self, mocker, dataframe_fixture_times
+    ):
+        mocker.patch("hsfs.client.get_instance")
+        python_engine = python.Engine()
+
+        default_df_python = python_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
+        spark_engine = spark.Engine()
+
+        default_df_spark_from_pd = spark_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
         assert (
             default_df_spark_from_pd.head()[5]
             == default_df_python["event_timestamp"][0].to_pydatetime()
         )
+
+    def test_convert_to_default_dataframe_w_timezone_timestamp_pacific(
+        self, mocker, dataframe_fixture_times
+    ):
+        mocker.patch("hsfs.client.get_instance")
+        python_engine = python.Engine()
+
+        default_df_python = python_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
+        spark_engine = spark.Engine()
+
+        default_df_spark_from_pd = spark_engine.convert_to_default_dataframe(
+            dataframe_fixture_times
+        )
+
         assert (
             default_df_spark_from_pd.head()[6]
             == default_df_python["event_timestamp_pacific"][0].to_pydatetime()


### PR DESCRIPTION
This PR adds
- correct timezone-aware timestamp conversion in pySpark client non-UTC systems

JIRA Issue: FSTORE-311

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
