### PR TITLE
[FSTORE-392] Change GCS authentication from key file path to account properties

### DIFF
--- a/java/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/StorageConnector.java
@@ -500,15 +500,15 @@ public abstract class StorageConnector {
   }
 
   public static class GcsConnector extends StorageConnector {
-    @Getter
+    @Getter  @Setter
     private String keyPath;
-    @Getter
+    @Getter @Setter
     private String algorithm;
-    @Getter
+    @Getter @Setter
     private String encryptionKey;
-    @Getter
+    @Getter @Setter
     private String encryptionKeyHash;
-    @Getter
+    @Getter @Setter
     private String bucket;
 
     public GcsConnector() {

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/SparkEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/SparkEngine.java
@@ -836,24 +836,19 @@ public class SparkEngine {
     // The JSON key file of the service account used for GCS
     // access when google.cloud.auth.service.account.enable is true.
     String localPath = addFile(storageConnector.getKeyPath());
-    StringBuilder stringBuilder = new StringBuilder();
-    Stream<String> stream = Files.lines(Paths.get(localPath), StandardCharsets.UTF_8);
-    //Read the content with stream
-    stream.forEach(s -> stringBuilder.append(s).append("\n"));
-    String fileContent = stringBuilder.toString();
+    String fileContent = Files.lines(Paths.get(localPath), StandardCharsets.UTF_8)
+      .collect(Collectors.joining("\n"));
     JSONObject jsonObject = new JSONObject(fileContent);
-    String keyId = jsonObject.getString("private_key_id");
-    String key = jsonObject.getString("private_key");
-    String email = jsonObject.getString("client_email");
+
     // set the account properties instead of key file path
     sparkSession.sparkContext().hadoopConfiguration().set(
-        Constants.PROPERTY_GCS_ACCOUNT_EMAIL, email
+        Constants.PROPERTY_GCS_ACCOUNT_EMAIL, jsonObject.getString("client_email")
     );
     sparkSession.sparkContext().hadoopConfiguration().set(
-        Constants.PROPERTY_GCS_ACCOUNT_KEY_ID, keyId
+        Constants.PROPERTY_GCS_ACCOUNT_KEY_ID, jsonObject.getString("private_key_id")
     );
     sparkSession.sparkContext().hadoopConfiguration().set(
-        Constants.PROPERTY_GCS_ACCOUNT_KEY, key
+        Constants.PROPERTY_GCS_ACCOUNT_KEY, jsonObject.getString("private_key")
     );
 
     // if encryption fields present

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/SparkEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/SparkEngine.java
@@ -86,7 +86,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.logicalclocks.hsfs.FeatureType.BIGINT;
 import static com.logicalclocks.hsfs.FeatureType.DATE;
@@ -837,7 +836,7 @@ public class SparkEngine {
     // access when google.cloud.auth.service.account.enable is true.
     String localPath = addFile(storageConnector.getKeyPath());
     String fileContent = Files.lines(Paths.get(localPath), StandardCharsets.UTF_8)
-      .collect(Collectors.joining("\n"));
+        .collect(Collectors.joining("\n"));
     JSONObject jsonObject = new JSONObject(fileContent);
 
     // set the account properties instead of key file path

--- a/java/src/main/java/com/logicalclocks/hsfs/util/Constants.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/util/Constants.java
@@ -85,6 +85,9 @@ public class Constants {
   public static final String PROPERTY_GCS_FS_KEY = "fs.AbstractFileSystem.gs.impl";
   public static final String PROPERTY_GCS_FS_VALUE = "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS";
   public static final String PROPERTY_GCS_ACCOUNT_ENABLE = "google.cloud.auth.service.account.enable";
+  public static final String PROPERTY_GCS_ACCOUNT_EMAIL = "fs.gs.auth.service.account.email";
+  public static final String PROPERTY_GCS_ACCOUNT_KEY_ID = "fs.gs.auth.service.account.private.key.id";
+  public static final String PROPERTY_GCS_ACCOUNT_KEY = "fs.gs.auth.service.account.private.key";
   // end gcs
   // bigquery constants
   public static final String BIGQ_CREDENTIALS = "credentials";

--- a/java/src/test/java/com/logicalclocks/hsfs/TestStorageConnector.java
+++ b/java/src/test/java/com/logicalclocks/hsfs/TestStorageConnector.java
@@ -18,6 +18,8 @@ package com.logicalclocks.hsfs;
 
 import com.logicalclocks.hsfs.engine.SparkEngine;
 import com.logicalclocks.hsfs.util.Constants;
+import org.apache.parquet.Strings;
+import org.apache.spark.SparkContext;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -30,7 +32,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Map;
-
 
 public class TestStorageConnector {
 
@@ -60,7 +61,6 @@ public class TestStorageConnector {
 
     SparkEngine sparkEngine = Mockito.mock(SparkEngine.class);
     SparkEngine.setInstance(sparkEngine);
-
     ArgumentCaptor<Map> mapArg = ArgumentCaptor.forClass(Map.class);
     String query = "select * from dbtable";
 
@@ -71,5 +71,68 @@ public class TestStorageConnector {
     // Assert
     Assertions.assertFalse(mapArg.getValue().containsKey(Constants.SNOWFLAKE_TABLE));
     Assertions.assertEquals(query, mapArg.getValue().get("query"));
+    // clear static instance
+    SparkEngine.setInstance(null);
   }
+
+  @Test
+  public void testGcsConnectorCredentials(@TempDir Path tempDir) throws IOException, FeatureStoreException {
+    // Arrange
+    String credentials = "{\"type\": \"service_account\", \"project_id\": \"test\", \"private_key_id\": \"123456\", "+
+      "\"private_key\": \"-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----\", " +
+      "\"client_email\": \"test@project.iam.gserviceaccount.com\"}";
+    Path credentialsFile = tempDir.resolve("gcs.json");
+    Files.write(credentialsFile, credentials.getBytes());
+
+    StorageConnector.GcsConnector gcsConnector = new StorageConnector.GcsConnector();
+    gcsConnector.setKeyPath("file://" + credentialsFile);
+    gcsConnector.setStorageConnectorType(StorageConnectorType.GCS);
+    // Act
+    gcsConnector.prepareSpark();
+    SparkContext sc = SparkEngine.getInstance().getSparkSession().sparkContext();
+    // Assert
+    Assertions.assertEquals(
+      "test@project.iam.gserviceaccount.com",
+      sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_EMAIL));
+    Assertions.assertEquals(
+      "123456",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_KEY_ID));
+    Assertions.assertEquals("-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_KEY));
+    Assertions.assertEquals(Constants.PROPERTY_GCS_FS_VALUE,sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_FS_KEY));
+    Assertions.assertEquals("true",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_ENABLE));
+    Assertions.assertTrue(Strings.isNullOrEmpty(sc.hadoopConfiguration().get(Constants.PROPERTY_ENCRYPTION_KEY)));
+    Assertions.assertTrue(Strings.isNullOrEmpty(sc.hadoopConfiguration().get(Constants.PROPERTY_ENCRYPTION_HASH)));
+    Assertions.assertTrue(Strings.isNullOrEmpty(sc.hadoopConfiguration().get(Constants.PROPERTY_ALGORITHM)));
+  }
+
+  @Test
+  public void testGcsConnectorCredentials_encrypted(@TempDir Path tempDir) throws IOException,
+    FeatureStoreException {
+    // Arrange
+    String credentials = "{\"type\": \"service_account\", \"project_id\": \"test\", \"private_key_id\": \"123456\", "+
+      "\"private_key\": \"-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----\", " +
+      "\"client_email\": \"test@project.iam.gserviceaccount.com\"}";
+    Path credentialsFile = tempDir.resolve("gcs.json");
+    Files.write(credentialsFile, credentials.getBytes());
+
+    StorageConnector.GcsConnector gcsConnector = new StorageConnector.GcsConnector();
+    gcsConnector.setKeyPath("file://" + credentialsFile);
+    gcsConnector.setStorageConnectorType(StorageConnectorType.GCS);
+    gcsConnector.setAlgorithm("AES256");
+    gcsConnector.setEncryptionKey("encryptionkey");
+    gcsConnector.setEncryptionKeyHash("encryptionkeyhash");
+    // Act
+    gcsConnector.prepareSpark();
+    SparkContext sc = SparkEngine.getInstance().getSparkSession().sparkContext();
+
+    // Assert
+    Assertions.assertEquals("test@project.iam.gserviceaccount.com",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_EMAIL));
+    Assertions.assertEquals("123456",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_KEY_ID));
+    Assertions.assertEquals("-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_KEY));
+    Assertions.assertEquals(Constants.PROPERTY_GCS_FS_VALUE,sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_FS_KEY));
+    Assertions.assertEquals("true",sc.hadoopConfiguration().get(Constants.PROPERTY_GCS_ACCOUNT_ENABLE));
+    Assertions.assertEquals("encryptionkey",sc.hadoopConfiguration().get(Constants.PROPERTY_ENCRYPTION_KEY));
+    Assertions.assertEquals("encryptionkeyhash",sc.hadoopConfiguration().get(Constants.PROPERTY_ENCRYPTION_HASH));
+    Assertions.assertEquals("AES256",sc.hadoopConfiguration().get(Constants.PROPERTY_ALGORITHM));
+  }
+
 }

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -949,6 +949,9 @@ class Engine:
         PROPERTY_GCS_FS_KEY = "fs.AbstractFileSystem.gs.impl"
         PROPERTY_GCS_FS_VALUE = "com.google.cloud.hadoop.fs.gcs.GoogleHadoopFS"
         PROPERTY_GCS_ACCOUNT_ENABLE = "google.cloud.auth.service.account.enable"
+        PROPERTY_ACCT_EMAIL = "fs.gs.auth.service.account.email"
+        PROPERTY_ACCT_KEY_ID = "fs.gs.auth.service.account.private.key.id"
+        PROPERTY_ACCT_KEY = "fs.gs.auth.service.account.private.key"
         # The AbstractFileSystem for 'gs:' URIs
         self._spark_context._jsc.hadoopConfiguration().setIfUnset(
             PROPERTY_GCS_FS_KEY, PROPERTY_GCS_FS_VALUE
@@ -965,6 +968,18 @@ class Engine:
         self._spark_context._jsc.hadoopConfiguration().set(
             PROPERTY_KEY_FILE, local_path
         )
+
+        with open(local_path, "r") as fin:
+            jsondata = json.load(fin)
+            self._spark_context._jsc.hadoopConfiguration().set(
+                PROPERTY_ACCT_EMAIL, jsondata["client_email"]
+            )
+            self._spark_context._jsc.hadoopConfiguration().set(
+                PROPERTY_ACCT_KEY_ID, jsondata["private_key_id"]
+            )
+            self._spark_context._jsc.hadoopConfiguration().set(
+                PROPERTY_ACCT_KEY, jsondata["private_key"]
+            )
 
         if storage_connector.algorithm:
             # if encryption fields present

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -942,7 +942,6 @@ class Engine:
 
     def _setup_gcp_hadoop_conf(self, storage_connector, path):
 
-        PROPERTY_KEY_FILE = "fs.gs.auth.service.account.json.keyfile"
         PROPERTY_ENCRYPTION_KEY = "fs.gs.encryption.key"
         PROPERTY_ENCRYPTION_HASH = "fs.gs.encryption.key.hash"
         PROPERTY_ALGORITHM = "fs.gs.encryption.algorithm"
@@ -965,21 +964,17 @@ class Engine:
         # The JSON key file of the service account used for GCS
         # access when google.cloud.auth.service.account.enable is true.
         local_path = self.add_file(storage_connector.key_path)
+        with open(local_path, "r") as f_in:
+            jsondata = json.load(f_in)
         self._spark_context._jsc.hadoopConfiguration().set(
-            PROPERTY_KEY_FILE, local_path
+            PROPERTY_ACCT_EMAIL, jsondata["client_email"]
         )
-
-        with open(local_path, "r") as fin:
-            jsondata = json.load(fin)
-            self._spark_context._jsc.hadoopConfiguration().set(
-                PROPERTY_ACCT_EMAIL, jsondata["client_email"]
-            )
-            self._spark_context._jsc.hadoopConfiguration().set(
-                PROPERTY_ACCT_KEY_ID, jsondata["private_key_id"]
-            )
-            self._spark_context._jsc.hadoopConfiguration().set(
-                PROPERTY_ACCT_KEY, jsondata["private_key"]
-            )
+        self._spark_context._jsc.hadoopConfiguration().set(
+            PROPERTY_ACCT_KEY_ID, jsondata["private_key_id"]
+        )
+        self._spark_context._jsc.hadoopConfiguration().set(
+            PROPERTY_ACCT_KEY, jsondata["private_key"]
+        )
 
         if storage_connector.algorithm:
             # if encryption fields present

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -4055,9 +4055,6 @@ class TestSpark:
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.setIfUnset.assert_any_call(
             "google.cloud.auth.service.account.enable", "true"
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.json.keyfile", "test_local_path"
-        )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
             "fs.gs.encryption.algorithm"
         )
@@ -4066,6 +4063,15 @@ class TestSpark:
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
             "fs.gs.encryption.key.hash"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+            "fs.gs.auth.service.account.email"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+            "fs.gs.auth.service.account.private.key.id"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+            "fs.gs.auth.service.account.private.key"
         )
 
     def test_setup_gcp_hadoop_conf_algorithm(self, mocker):
@@ -4117,9 +4123,6 @@ class TestSpark:
             "google.cloud.auth.service.account.enable", "true"
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.json.keyfile", "test_local_path"
-        )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.encryption.algorithm", gcs_connector.algorithm
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
@@ -4127,6 +4130,15 @@ class TestSpark:
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.encryption.key.hash", gcs_connector.encryption_key_hash
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+            "fs.gs.auth.service.account.email"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+            "fs.gs.auth.service.account.private.key.id"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+            "fs.gs.auth.service.account.private.key"
         )
 
     def test_get_unique_values(self):

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -4042,7 +4042,7 @@ class TestSpark:
         assert mock_spark_engine_add_file.call_count == 1
         assert (
             mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.call_count
-            == 1
+            == 3
         )
         assert (
             mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.call_count
@@ -4064,13 +4064,13 @@ class TestSpark:
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
             "fs.gs.encryption.key.hash"
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.auth.service.account.email"
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.auth.service.account.private.key.id"
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.auth.service.account.private.key"
         )
 
@@ -4109,7 +4109,7 @@ class TestSpark:
         assert mock_spark_engine_add_file.call_count == 1
         assert (
             mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.call_count
-            == 4
+            == 6
         )
         assert (
             mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.call_count
@@ -4131,13 +4131,13 @@ class TestSpark:
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.encryption.key.hash", gcs_connector.encryption_key_hash
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.auth.service.account.email"
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.auth.service.account.private.key.id"
         )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
             "fs.gs.auth.service.account.private.key"
         )
 

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -4019,13 +4019,20 @@ class TestSpark:
 
         spark_engine = spark.Engine()
 
+        content = (
+            '{"type": "service_account", "project_id": "test", "private_key_id": "123456", '
+            '"private_key": "-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----", '
+            '"client_email": "test@project.iam.gserviceaccount.com"}'
+        )
+        credentialsFile = "keyFile.json"
+        with open(credentialsFile, "w") as f:
+            f.write(content)
+
         gcs_connector = storage_connector.GcsConnector(
-            id=1,
-            name="test_connector",
-            featurestore_id=99,
+            id=1, name="test_connector", featurestore_id=99, key_path=credentialsFile
         )
 
-        mock_spark_engine_add_file.return_value = "test_local_path"
+        mock_spark_engine_add_file.return_value = "keyFile.json"
 
         # Act
         result = spark_engine._setup_gcp_hadoop_conf(
@@ -4055,6 +4062,16 @@ class TestSpark:
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.setIfUnset.assert_any_call(
             "google.cloud.auth.service.account.enable", "true"
         )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
+            "fs.gs.auth.service.account.email", "test@project.iam.gserviceaccount.com"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
+            "fs.gs.auth.service.account.private.key.id", "123456"
+        )
+        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
+            "fs.gs.auth.service.account.private.key",
+            "-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----",
+        )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
             "fs.gs.encryption.algorithm"
         )
@@ -4063,15 +4080,6 @@ class TestSpark:
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.unset.assert_any_call(
             "fs.gs.encryption.key.hash"
-        )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.email"
-        )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.private.key.id"
-        )
-        mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.private.key"
         )
 
     def test_setup_gcp_hadoop_conf_algorithm(self, mocker):
@@ -4083,16 +4091,26 @@ class TestSpark:
 
         spark_engine = spark.Engine()
 
+        content = (
+            '{"type": "service_account", "project_id": "test", "private_key_id": "123456", '
+            '"private_key": "-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----", '
+            '"client_email": "test@project.iam.gserviceaccount.com"}'
+        )
+        credentialsFile = "keyFile.json"
+        with open(credentialsFile, "w") as f:
+            f.write(content)
+
         gcs_connector = storage_connector.GcsConnector(
             id=1,
             name="test_connector",
             featurestore_id=99,
+            key_path=credentialsFile,
             algorithm="temp_algorithm",
             encryption_key="1",
             encryption_key_hash="2",
         )
 
-        mock_spark_engine_add_file.return_value = "test_local_path"
+        mock_spark_engine_add_file.return_value = "keyFile.json"
 
         # Act
         result = spark_engine._setup_gcp_hadoop_conf(
@@ -4132,13 +4150,14 @@ class TestSpark:
             "fs.gs.encryption.key.hash", gcs_connector.encryption_key_hash
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.email"
+            "fs.gs.auth.service.account.email", "test@project.iam.gserviceaccount.com"
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.private.key.id"
+            "fs.gs.auth.service.account.private.key.id", "123456"
         )
         mock_pyspark_getOrCreate.return_value.sparkContext._jsc.hadoopConfiguration.return_value.set.assert_any_call(
-            "fs.gs.auth.service.account.private.key"
+            "fs.gs.auth.service.account.private.key",
+            "-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----",
         )
 
     def test_get_unique_values(self):


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs
- Fixes issue of key file not found authentication issue in case of multiple executors

JIRA Issue: -
https://hopsworks.atlassian.net/browse/FSTORE-392

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
