### PR TITLE
[FSTORE-311][Append] Make Datetime Conversion DST-safe

### DIFF
--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -183,10 +183,10 @@ class Engine:
                 if isinstance(
                     dataframe[c].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
                 ):
-                    dataframe[c] = dataframe[c].dt.tz_convert(local_tz)
+                    dataframe[c] = dataframe[c].dt.tz_convert(str(local_tz))
                 elif dataframe[c].dtype == np.dtype("datetime64[ns]"):
                     dataframe[c] = dataframe[c].dt.tz_localize(
-                        local_tz, ambiguous="infer", nonexistent="shift_forward"
+                        str(local_tz), ambiguous="infer", nonexistent="shift_forward"
                     )
             dataframe = self._spark_session.createDataFrame(dataframe)
         elif isinstance(dataframe, RDD):

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,7 @@ setup(
         "PyMySQL[rsa]",
         "great_expectations==0.14.12",
         "markupsafe<2.1.0",  # GE issue 1: jinja2==2.11.3, pulls in markupsafe 2.1.0 which is not compatible with jinja2==2.11.3.
+        "tzlocal"
     ],
     extras_require={
         "dev": [

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,7 +30,7 @@ setup(
         "PyMySQL[rsa]",
         "great_expectations==0.14.12",
         "markupsafe<2.1.0",  # GE issue 1: jinja2==2.11.3, pulls in markupsafe 2.1.0 which is not compatible with jinja2==2.11.3.
-        "tzlocal"
+        "tzlocal",
     ],
     extras_require={
         "dev": [

--- a/python/tests/engine/test_python_spark_transformation_functions.py
+++ b/python/tests/engine/test_python_spark_transformation_functions.py
@@ -585,7 +585,7 @@ class TestPythonSparkTransformationFunctions:
         local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            local_tz
+            str(local_tz)
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema
@@ -643,7 +643,7 @@ class TestPythonSparkTransformationFunctions:
         local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            local_tz
+            str(local_tz)
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema
@@ -704,7 +704,7 @@ class TestPythonSparkTransformationFunctions:
         local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            local_tz
+            str(local_tz)
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema
@@ -764,7 +764,7 @@ class TestPythonSparkTransformationFunctions:
         local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            local_tz
+            str(local_tz)
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema

--- a/python/tests/engine/test_python_spark_transformation_functions.py
+++ b/python/tests/engine/test_python_spark_transformation_functions.py
@@ -20,6 +20,7 @@ import pandas as pd
 import numpy as np
 import datetime
 import pytz
+import tzlocal
 
 import pytest
 from pyspark.sql.types import (
@@ -581,10 +582,10 @@ class TestPythonSparkTransformationFunctions:
             }
         )
         # convert timestamps to current timezone
-        current_timezone = datetime.datetime.now().astimezone().tzinfo
+        local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            current_timezone
+            local_tz
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema
@@ -639,10 +640,10 @@ class TestPythonSparkTransformationFunctions:
             }
         )
         # convert timestamps to current timezone
-        current_timezone = datetime.datetime.now().astimezone().tzinfo
+        local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            current_timezone
+            local_tz
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema
@@ -700,10 +701,10 @@ class TestPythonSparkTransformationFunctions:
             }
         )
         # convert timestamps to current timezone
-        current_timezone = datetime.datetime.now().astimezone().tzinfo
+        local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            current_timezone
+            local_tz
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema
@@ -760,10 +761,10 @@ class TestPythonSparkTransformationFunctions:
             }
         )
         # convert timestamps to current timezone
-        current_timezone = datetime.datetime.now().astimezone().tzinfo
+        local_tz = tzlocal.get_localzone()
         expected_df_localized = expected_df.copy(True)
         expected_df_localized["col_0"] = expected_df_localized["col_0"].dt.tz_localize(
-            current_timezone
+            local_tz
         )
         expected_spark_df = spark_engine._spark_session.createDataFrame(
             expected_df_localized, schema=expected_schema


### PR DESCRIPTION
This PR fixes datetime conversions for mixed timezones (e.g. timezones with DST)

JIRA Issue: FSTORE-311

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
