### PR TITLE
[FSTORE-398] add validation history method to python client

### DIFF
--- a/keyFile.json
+++ b/keyFile.json
@@ -1,0 +1,1 @@
+{"type": "service_account", "project_id": "test", "private_key_id": "123456", "private_key": "-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----", "client_email": "test@project.iam.gserviceaccount.com"}

--- a/keyFile.json
+++ b/keyFile.json
@@ -1,1 +1,0 @@
-{"type": "service_account", "project_id": "test", "private_key_id": "123456", "private_key": "-----BEGIN PRIVATE KEY-----test-----END PRIVATE KEY-----", "client_email": "test@project.iam.gserviceaccount.com"}

--- a/python/hsfs/core/great_expectation_engine.py
+++ b/python/hsfs/core/great_expectation_engine.py
@@ -59,7 +59,7 @@ class GreatExpectationEngine:
                 ge_validate_kwargs=validation_options.get("ge_validate_kwargs", {}),
             )
         else:
-            # if run_validation is False we skip validation
+            # if run_validation is False we skip validation and saving_report
             return
 
         return self.save_or_convert_report(

--- a/python/hsfs/core/validation_report_api.py
+++ b/python/hsfs/core/validation_report_api.py
@@ -99,7 +99,7 @@ class ValidationReportApi:
 
         return ValidationReport.from_response_json(
             _client._send_request("GET", path_params, query_params, headers=headers)
-        )[0]
+        )
 
     def get_all(self) -> Union[List[ValidationReport], ValidationReport]:
         """Get the validation report attached to a featuregroup.

--- a/python/hsfs/core/validation_report_engine.py
+++ b/python/hsfs/core/validation_report_engine.py
@@ -52,7 +52,7 @@ class ValidationReportEngine:
         return self._validation_report_api.get_last()
 
     def get_all(self) -> Union[List[ValidationReport], ValidationReport]:
-        """Get all Validation Report of a FeaturevGroup."""
+        """Get all Validation Report of a Feature Group."""
         url = self._get_validation_report_url()
         print(
             f"""Long reports can be truncated when fetching from Hopsworks.

--- a/python/hsfs/core/validation_report_engine.py
+++ b/python/hsfs/core/validation_report_engine.py
@@ -42,14 +42,17 @@ class ValidationReportEngine:
         print(f"Validation Report saved successfully, explore a summary at {url}")
         return saved_report
 
-    def get_last(self) -> ValidationReport:
+    def get_last(self, ge_type: bool = True) -> ValidationReport:
         """Get the most recent Validation Report of a Feature Group."""
         url = self._get_validation_report_url()
         print(
             f"""Long reports can be truncated when fetching from Hopsworks.
         \nYou can download the full report at {url}"""
         )
-        return self._validation_report_api.get_last()
+        if ge_type:
+            return self._validation_report_api.get_last().to_ge_type()
+        else:
+            return self._validation_report_api.get_last()
 
     def get_all(self) -> Union[List[ValidationReport], ValidationReport]:
         """Get all Validation Report of a Feature Group."""

--- a/python/hsfs/core/validation_report_engine.py
+++ b/python/hsfs/core/validation_report_engine.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-from typing import Union, List
+from typing import Optional, Union, List
 from hsfs.core import validation_report_api
 from hsfs import client, util
 
@@ -42,17 +42,20 @@ class ValidationReportEngine:
         print(f"Validation Report saved successfully, explore a summary at {url}")
         return saved_report
 
-    def get_last(self, ge_type: bool = True) -> ValidationReport:
+    def get_last(self, ge_type: bool = True) -> Optional[ValidationReport]:
         """Get the most recent Validation Report of a Feature Group."""
         url = self._get_validation_report_url()
         print(
             f"""Long reports can be truncated when fetching from Hopsworks.
         \nYou can download the full report at {url}"""
         )
-        if ge_type:
-            return self._validation_report_api.get_last().to_ge_type()
+        reports = self._validation_report_api.get_last()
+        if len(reports) == 0:
+            return None
+        elif len(reports) == 1 and ge_type:
+            return reports[0].to_ge_type()
         else:
-            return self._validation_report_api.get_last()
+            return reports[0]
 
     def get_all(self) -> Union[List[ValidationReport], ValidationReport]:
         """Get all Validation Report of a Feature Group."""

--- a/python/hsfs/core/validation_result_api.py
+++ b/python/hsfs/core/validation_result_api.py
@@ -37,7 +37,7 @@ class ValidationResultApi:
         offset: Optional[int],
         limit: Optional[int],
         sort_by: Optional[str],
-        filter_by: Optional[str],
+        filter_by: Optional[List[str]],
     ) -> Union[List[ValidationResult], ValidationResult]:
         """Get the validation report attached to a featuregroup.
 

--- a/python/hsfs/core/validation_result_api.py
+++ b/python/hsfs/core/validation_result_api.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-from typing import Union, List, Optional
+from typing import Union, List, Dict
 from hsfs import client, ge_validation_result
 
 
@@ -33,10 +33,7 @@ class ValidationResultApi:
     def get_validation_history(
         self,
         expectation_id: int,
-        offset: Optional[int],
-        limit: Optional[int],
-        sort_by: Optional[str],
-        filter_by: Optional[List[str]],
+        query_params: Dict[str, str] = {},
     ) -> Union[
         List[ge_validation_result.ValidationResult],
         ge_validation_result.ValidationResult,
@@ -59,16 +56,6 @@ class ValidationResultApi:
             expectation_id,
         ]
         headers = {"content-type": "application/json"}
-
-        query_params = {}
-        if offset:
-            query_params["offset"] = offset
-        if limit:
-            query_params["limit"] = limit
-        if sort_by:
-            query_params["sort_by"] = sort_by
-        if filter_by:
-            query_params["filter_by"] = filter_by
 
         return ge_validation_result.ValidationResult.from_response_json(
             _client._send_request("GET", path_params, query_params, headers=headers)

--- a/python/hsfs/core/validation_result_api.py
+++ b/python/hsfs/core/validation_result_api.py
@@ -15,8 +15,7 @@
 #
 
 from typing import Union, List, Optional
-from hsfs import client
-from hsfs.ge_validation_result import ValidationResult
+from hsfs import client, ge_validation_result
 
 
 class ValidationResultApi:
@@ -38,7 +37,10 @@ class ValidationResultApi:
         limit: Optional[int],
         sort_by: Optional[str],
         filter_by: Optional[List[str]],
-    ) -> Union[List[ValidationResult], ValidationResult]:
+    ) -> Union[
+        List[ge_validation_result.ValidationResult],
+        ge_validation_result.ValidationResult,
+    ]:
         """Get the validation report attached to a featuregroup.
 
         :return: validation report
@@ -68,6 +70,6 @@ class ValidationResultApi:
         if filter_by:
             query_params["filter_by"] = filter_by
 
-        return ValidationResult.from_response_json(
+        return ge_validation_result.ValidationResult.from_response_json(
             _client._send_request("GET", path_params, query_params, headers=headers)
         )

--- a/python/hsfs/core/validation_result_api.py
+++ b/python/hsfs/core/validation_result_api.py
@@ -1,0 +1,73 @@
+#
+#   Copyright 2022 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from typing import Union, List, Optional
+from hsfs import client
+from hsfs.ge_validation_result import ValidationResult
+
+
+class ValidationResultApi:
+    def __init__(self, feature_store_id: int, feature_group_id: int):
+        """Validation Result endpoints for the featuregroup resource.
+
+        :param feature_store_id: id of the respective featurestore
+        :type feature_store_id: int
+        :param feature_group_id: id of the respective featuregroup
+        :type feature_group_id: int
+        """
+        self._feature_store_id = feature_store_id
+        self._feature_group_id = feature_group_id
+
+    def get_validation_history(
+        self,
+        expectation_id: int,
+        offset: Optional[int],
+        limit: Optional[int],
+        sort_by: Optional[str],
+        filter_by: Optional[str],
+    ) -> Union[List[ValidationResult], ValidationResult]:
+        """Get the validation report attached to a featuregroup.
+
+        :return: validation report
+        :rtype: Union[List[ValidationResult], ValidationResult]
+        """
+        _client = client.get_instance()
+        path_params = [
+            "project",
+            _client._project_id,
+            "featurestores",
+            self._feature_store_id,
+            "featuregroups",
+            self._feature_group_id,
+            "validationresult",
+            "history",
+            expectation_id,
+        ]
+        headers = {"content-type": "application/json"}
+
+        query_params = {}
+        if offset:
+            query_params["offset"] = offset
+        if limit:
+            query_params["limit"] = limit
+        if sort_by:
+            query_params["sort_by"] = sort_by
+        if filter_by:
+            query_params["filter_by"] = filter_by
+
+        return ValidationResult.from_response_json(
+            _client._send_request("GET", path_params, query_params, headers=headers)
+        )

--- a/python/hsfs/core/validation_result_engine.py
+++ b/python/hsfs/core/validation_result_engine.py
@@ -1,0 +1,103 @@
+#
+#   Copyright 2022 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from typing import Union, List, Optional
+from hsfs.core import validation_result_api
+import pandas as pd
+
+from hsfs.ge_validation_result import ValidationResult
+
+
+class ValidationReportEngine:
+    def __init__(self, feature_store_id: int, feature_group_id: int):
+        """Validation Result engine.
+
+        :param feature_store_id: id of the respective featurestore
+        :type feature_store_id: int
+        :param feature_group_id: id of the featuregroup it is attached to
+        :type feature_group_id: int
+        """
+        self._feature_store_id = feature_store_id
+        self._feature_group_id = feature_group_id
+        self._validation_result_api = validation_result_api.ValidationResultApi(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+
+    def get_validation_history(
+        self,
+        expectation_id: int,
+        as_timeserie: bool,
+        sort_by: Optional[str] = "validation_time:desc",
+        filter_by: Optional[str] = None,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> Union[List[ValidationResult], ValidationResult]:
+        """Get Validation Results relevant to an Expectation specified by expectation_id.
+
+        :param expectation_id: id of the expectation for which to fetch the validation history
+        :type expectation_id: int
+        :param sort_by: sort the validation results according to validation_time, descending or ascending
+        :type sort_by: Optional[str]
+        :param filter_by: filter the validation results based on validation_time_(eq,gt,gte,lt,lte) or ingestion result
+        :type filter_by: Optional[str]
+        :param offset: offset for pagination
+        :type offset: Optional[int]
+        :param limit: limit for pagination
+        :type limit: int
+        """
+        if sort_by:
+            self._verify_sort_by(sort_by)
+        if filter_by:
+            self._verify_filter_by(filter_by)
+        if offset:
+            self._verify_offset(offset)
+        if limit:
+            self._verify_limit(limit)
+
+        validation_history = self._validation_result_api.get_validation_history(
+            expectation_id=expectation_id,
+            offset=offset,
+            limit=limit,
+            filter_by=filter_by,
+            sort_by=sort_by,
+        )
+
+        if as_timeserie:
+            return self.convert_history_to_timeserie(validation_history)
+        else:
+            return validation_history
+
+    def convert_history_to_timeserie(self, validation_history: List[ValidationResult]):
+        return pd.Series(
+            [result.observed_value for result in validation_history],
+            index=pd.DatetimeIndex(
+                [result.validation_time for result in validation_history]
+            ),
+        )
+
+    def _verify_sort_by(self, sort_by: str) -> None:
+        assert type(sort_by) is str
+
+    def _verify_filter_by(self, filter_by: str) -> None:
+        assert type(filter_by) is str
+
+    def _verify_offset(self, offset: int) -> None:
+        assert type(offset) is int
+        assert offset >= 0
+
+    def _verify_limit(self, limit: int) -> None:
+        assert type(limit) is int
+        assert limit > 0

--- a/python/hsfs/core/validation_result_engine.py
+++ b/python/hsfs/core/validation_result_engine.py
@@ -21,7 +21,7 @@ import pandas as pd
 from hsfs.ge_validation_result import ValidationResult
 
 
-class ValidationReportEngine:
+class ValidationResultEngine:
     def __init__(self, feature_store_id: int, feature_group_id: int):
         """Validation Result engine.
 

--- a/python/hsfs/core/validation_result_engine.py
+++ b/python/hsfs/core/validation_result_engine.py
@@ -82,7 +82,7 @@ class ValidationReportEngine:
 
     def convert_history_to_timeserie(self, validation_history: List[ValidationResult]):
         return pd.Series(
-            [result.observed_value for result in validation_history],
+            [result._observed_value for result in validation_history],
             index=pd.DatetimeIndex(
                 [result.validation_time for result in validation_history]
             ),

--- a/python/hsfs/core/validation_result_engine.py
+++ b/python/hsfs/core/validation_result_engine.py
@@ -17,7 +17,6 @@
 from typing import Union, List, Optional
 from hsfs.core import validation_result_api
 import pandas as pd
-import dateutil
 
 from hsfs.ge_validation_result import ValidationResult
 
@@ -90,8 +89,7 @@ class ValidationResultEngine:
                     result._observed_value for result in validation_history
                 ],
                 "validation_time": [
-                    dateutil.parser.parseiso(result.validation_time)
-                    for result in validation_history
+                    result.validation_time for result in validation_history
                 ],
             }
         )

--- a/python/hsfs/core/validation_result_engine.py
+++ b/python/hsfs/core/validation_result_engine.py
@@ -17,6 +17,7 @@
 from typing import Union, List, Optional
 from hsfs.core import validation_result_api
 import pandas as pd
+import dateutil
 
 from hsfs.ge_validation_result import ValidationResult
 
@@ -80,12 +81,19 @@ class ValidationResultEngine:
         else:
             return validation_history
 
-    def convert_history_to_timeserie(self, validation_history: List[ValidationResult]):
-        return pd.Series(
-            [result._observed_value for result in validation_history],
-            index=pd.DatetimeIndex(
-                [result.validation_time for result in validation_history]
-            ),
+    def convert_history_to_timeserie(
+        self, validation_history: List[ValidationResult]
+    ) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "observed_value": [
+                    result._observed_value for result in validation_history
+                ],
+                "validation_time": [
+                    dateutil.parser.parseiso(result.validation_time)
+                    for result in validation_history
+                ],
+            }
         )
 
     def _verify_sort_by(self, sort_by: str) -> None:

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -478,10 +478,7 @@ class FeatureGroupBase:
         # Raises
             `RestAPIException`.
         """
-        if ge_type is True:
-            return self._validation_report_engine.get_last(self).to_ge_type()
-        else:
-            return self._validation_report_engine.get_last(self)
+        return self._validation_report_engine.get_last()
 
     def get_all_validation_reports(
         self, ge_type: bool = True

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -541,21 +541,38 @@ class FeatureGroupBase:
         self,
         expectation_id: int,
         start_validation_time: Union[str, int, datetime, date, None] = None,
-        end_validation_time: Union[str, int, datetime, date, None] = datetime.now(),
+        end_validation_time: Union[str, int, datetime, date, None] = None,
         ingested_only: bool = False,
         rejected_only: bool = False,
-    ) -> List[ValidationResult]:
+        ge_type: bool = True,
+    ) -> Union[List[ValidationResult], List[ge.core.ExpectationValidationResult]]:
         """Fetch validation history of an Expectation specified by its id.
+
+        !!! example
+        ```python3
+        validation_history = fg.get_validation_history(
+            expectation_id=1,
+            ingested_only=True,
+            start_validation_time="2022-01-01 00:00:00",
+            end_validation_time=datetime.datetime.now(),
+            ge_type=False
+        )
+        ```
 
         # Arguments
             expectation_id: id of the Expectation for which to fetch the validation history
-            sort_by: sort the validation results according to validation time, descending or ascending. Value can be either
-                validation_time:desc or validation_time:asc
-            filter_by: filter the validation results based on validation time or ingestion result.
-                ingestion_result_eq:INGESTED/REJECTED
-                validation_time_(gt/gte/eq/lt/lte):<timestamp>
-            offset: offset for pagination
-            limit: limit for pagination
+            ingested_only: fetch only validation result corresponding to an insertion, defaults to False.
+            rejected_only: fetch only validation result corresponding to a rejection, defaults to False.
+            start_validation_time: fetch only validation result posterior to the provided time.
+            Supported format include timestamps(int), datetime, date or string formatted to be datutils parsable. See examples above.
+            end_validation_time: fetch only validation result prior to the provided time.
+            Supported format include timestamps(int), datetime, date or string formatted to be datutils parsable. See examples above.
+
+        # Raises
+            `RestAPIException`
+
+        # Return
+            Union[List[`ValidationResult`], List[`ExpectationValidationResult`]] A list of validation result connected to the expectation_id
         """
 
         return self._validation_result_engine.get_validation_history(
@@ -564,6 +581,7 @@ class FeatureGroupBase:
             end_validation_time=end_validation_time,
             ingested_only=ingested_only,
             rejected_only=rejected_only,
+            ge_type=ge_type,
         )
 
     def __getattr__(self, name):

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -432,7 +432,10 @@ class FeatureGroupBase:
                 feature_group_id=self._id,
             )
         elif isinstance(expectation_suite, ExpectationSuite):
-            tmp_expectation_suite = expectation_suite
+            tmp_expectation_suite = expectation_suite.to_json_dict()
+            tmp_expectation_suite["featuregroup_id"] = self._id
+            tmp_expectation_suite["featurestore_id"] = self._feature_store_id
+            tmp_expectation_suite = ExpectationSuite(**tmp_expectation_suite)
         else:
             raise TypeError(
                 "The provided expectation suite type `{}` is not supported. Use Great Expectation `ExpectationSuite` or HSFS' own `ExpectationSuite` object.".format(
@@ -719,10 +722,10 @@ class FeatureGroupBase:
         ],
     ):
         if isinstance(expectation_suite, ExpectationSuite):
-            tmp_expectation_suite = ExpectationSuite(**expectation_suite.to_json_dict())
-            tmp_expectation_suite._featuregroup_id = self._id
-            tmp_expectation_suite._featurestore_id = self._feature_store_id
-            self._expectation_suite = tmp_expectation_suite
+            tmp_expectation_suite = expectation_suite.to_json_dict()
+            tmp_expectation_suite["featuregroup_id"] = self._id
+            tmp_expectation_suite["featurestore_id"] = self._feature_store_id
+            self._expectation_suite = ExpectationSuite(**tmp_expectation_suite)
         elif isinstance(expectation_suite, ge.core.expectation_suite.ExpectationSuite):
             self._expectation_suite = ExpectationSuite(
                 **expectation_suite.to_json_dict(),

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -540,17 +540,15 @@ class FeatureGroupBase:
     def get_validation_history(
         self,
         expectation_id: int,
-        as_timeserie: bool = True,
         sort_by: Optional[str] = "validation_time:desc",
         filter_by: Optional[str] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
-    ) -> Union[List[ValidationResult], pd.DataFrame]:
-        """Fetch validation history of an Expectation specified by its id. By default, the history is returned as a pandas timeserie.
+    ) -> List[ValidationResult]:
+        """Fetch validation history of an Expectation specified by its id.
 
         # Arguments
             expectation_id: id of the Expectation for which to fetch the validation history
-            as_timeserie: return validation history as timeseries or list of ValidationResult, defaults to True.
             sort_by: sort the validation results according to validation time, descending or ascending. Value can be either
                 validation_time:desc or validation_time:asc
             filter_by: filter the validation results based on validation time or ingestion result.
@@ -562,7 +560,6 @@ class FeatureGroupBase:
 
         return self._validation_result_engine.get_validation_history(
             expectation_id=expectation_id,
-            as_timeserie=as_timeserie,
             sort_by=sort_by,
             filter_by=filter_by,
             offset=offset,

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1104,8 +1104,8 @@ class FeatureGroup(FeatureGroupBase):
         overwrite: Optional[bool] = False,
         operation: Optional[str] = "upsert",
         storage: Optional[str] = None,
-        write_options: Optional[Dict[Any, Any]] = {},
-        validation_options: Optional[Dict[Any, Any]] = {"save_report": True},
+        write_options: Optional[Dict[str, Any]] = {},
+        validation_options: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Optional[Job], Optional[ValidationReport]]:
         """Persist the metadata and materialize the feature group to the feature store
         or insert data from a dataframe into the existing feature group.
@@ -1170,12 +1170,14 @@ class FeatureGroup(FeatureGroupBase):
 
         job, ge_report = self._feature_group_engine.insert(
             self,
-            feature_dataframe,
-            overwrite,
-            operation,
-            storage.lower() if storage is not None else None,
-            write_options,
-            validation_options,
+            feature_dataframe=feature_dataframe,
+            overwrite=overwrite,
+            operation=operation,
+            storage=storage.lower() if storage is not None else None,
+            write_options=write_options,
+            validation_options=validation_options
+            if validation_options is not None
+            else {"save_report": True},
         )
 
         if ge_report is None or ge_report.ingestion_result == "INGESTED":

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -563,9 +563,9 @@ class FeatureGroupBase:
             expectation_id: id of the Expectation for which to fetch the validation history
             ingested_only: fetch only validation result corresponding to an insertion, defaults to False.
             rejected_only: fetch only validation result corresponding to a rejection, defaults to False.
-            start_validation_time: fetch only validation result posterior to the provided time.
+            start_validation_time: fetch only validation result posterior to the provided time, inclusive.
             Supported format include timestamps(int), datetime, date or string formatted to be datutils parsable. See examples above.
-            end_validation_time: fetch only validation result prior to the provided time.
+            end_validation_time: fetch only validation result prior to the provided time, inclusive.
             Supported format include timestamps(int), datetime, date or string formatted to be datutils parsable. See examples above.
 
         # Raises
@@ -719,7 +719,10 @@ class FeatureGroupBase:
         ],
     ):
         if isinstance(expectation_suite, ExpectationSuite):
-            self._expectation_suite = expectation_suite
+            tmp_expectation_suite = ExpectationSuite(**expectation_suite.to_json_dict())
+            tmp_expectation_suite._featuregroup_id = self._id
+            tmp_expectation_suite._featurestore_id = self._feature_store_id
+            self._expectation_suite = tmp_expectation_suite
         elif isinstance(expectation_suite, ge.core.expectation_suite.ExpectationSuite):
             self._expectation_suite = ExpectationSuite(
                 **expectation_suite.to_json_dict(),
@@ -727,14 +730,10 @@ class FeatureGroupBase:
                 feature_group_id=self._id,
             )
         elif isinstance(expectation_suite, dict):
-            if "feature_store_id" in expectation_suite.keys():
-                self._expectation_suite = ExpectationSuite(**expectation_suite)
-            else:
-                self._expectation_suite = ExpectationSuite(
-                    **expectation_suite,
-                    feature_store_id=self._feature_store_id,
-                    feature_group_id=self._id,
-                )
+            tmp_expectation_suite = expectation_suite.copy()
+            tmp_expectation_suite["feature_store_id"] = self._feature_store_id
+            tmp_expectation_suite["feature_group_id"] = self._id
+            self._expectation_suite = ExpectationSuite(**tmp_expectation_suite)
         elif expectation_suite is None:
             self._expectation_suite = expectation_suite
         else:

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1085,7 +1085,7 @@ class FeatureGroup(FeatureGroupBase):
         operation: Optional[str] = "upsert",
         storage: Optional[str] = None,
         write_options: Optional[Dict[Any, Any]] = {},
-        validation_options: Optional[Dict[Any, Any]] = {},
+        validation_options: Optional[Dict[Any, Any]] = {"save_report": True},
     ) -> Tuple[Optional[Job], Optional[ValidationReport]]:
         """Persist the metadata and materialize the feature group to the feature store
         or insert data from a dataframe into the existing feature group.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -478,7 +478,7 @@ class FeatureGroupBase:
         # Raises
             `RestAPIException`.
         """
-        return self._validation_report_engine.get_last()
+        return self._validation_report_engine.get_last(ge_type=ge_type)
 
     def get_all_validation_reports(
         self, ge_type: bool = True

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -540,10 +540,10 @@ class FeatureGroupBase:
     def get_validation_history(
         self,
         expectation_id: int,
-        sort_by: Optional[str] = "validation_time:desc",
-        filter_by: Optional[str] = None,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
+        start_validation_time: Union[str, int, datetime, date, None] = None,
+        end_validation_time: Union[str, int, datetime, date, None] = datetime.now(),
+        ingested_only: bool = False,
+        rejected_only: bool = False,
     ) -> List[ValidationResult]:
         """Fetch validation history of an Expectation specified by its id.
 
@@ -560,10 +560,10 @@ class FeatureGroupBase:
 
         return self._validation_result_engine.get_validation_history(
             expectation_id=expectation_id,
-            sort_by=sort_by,
-            filter_by=filter_by,
-            offset=offset,
-            limit=limit,
+            start_validation_time=start_validation_time,
+            end_validation_time=end_validation_time,
+            ingested_only=ingested_only,
+            rejected_only=rejected_only,
         )
 
     def __getattr__(self, name):

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -709,11 +709,14 @@ class FeatureGroupBase:
                 feature_group_id=self._id,
             )
         elif isinstance(expectation_suite, dict):
-            self._expectation_suite = ExpectationSuite(
-                **expectation_suite,
-                feature_store_id=self._feature_store_id,
-                feature_group_id=self._id,
-            )
+            if "feature_store_id" in expectation_suite.keys():
+                self._expectation_suite = ExpectationSuite(**expectation_suite)
+            else:
+                self._expectation_suite = ExpectationSuite(
+                    **expectation_suite,
+                    feature_store_id=self._feature_store_id,
+                    feature_group_id=self._id,
+                )
         elif expectation_suite is None:
             self._expectation_suite = expectation_suite
         else:

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -545,7 +545,7 @@ class FeatureGroupBase:
         filter_by: Optional[str] = None,
         offset: Optional[int] = None,
         limit: Optional[int] = None,
-    ) -> Union[List[ValidationResult], pd.Series]:
+    ) -> Union[List[ValidationResult], pd.DataFrame]:
         """Fetch validation history of an Expectation specified by its id. By default, the history is returned as a pandas timeserie.
 
         # Arguments

--- a/python/hsfs/ge_expectation.py
+++ b/python/hsfs/ge_expectation.py
@@ -41,13 +41,13 @@ class GeExpectation:
         self.meta = meta
 
         # Id should be parsed from meta field if init from GE object
-        if "expectationId" in self.meta.keys():
-            self._id = meta["expectationId"]
+        if "expectationId" in self._meta.keys():
+            self._id = self._meta["expectationId"]
 
         # if from_response_json meta expactationId field
         # should be fixed due to humps.decamelize
-        if "expectation_id" in self.meta.keys():
-            self.meta["expectationId"] = self.meta.pop("expectation_id")
+        if "expectation_id" in self._meta.keys():
+            self._meta["expectationId"] = self._meta.pop("expectation_id")
 
     @classmethod
     def from_response_json(cls, json_dict):

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -100,6 +100,13 @@ class ValidationResult:
         }
 
     def to_ge_type(self) -> ge.core.ExpectationValidationResult:
+        if self._validation_time:
+            self.meta["validation_time"] = datetime.utcfromtimestamp(
+                self._validation_time
+            ).isoformat()
+        if self._ingestion_result:
+            self.meta["ingestion_result"] = self._ingestion_result
+
         return ge.core.ExpectationValidationResult(
             success=self.success,
             exception_info=self.exception_info,
@@ -192,6 +199,13 @@ class ValidationResult:
     def validation_time(
         self, validation_time: Union[str, int, datetime, date, None]
     ) -> None:
+        """
+        Time at which validation was run using Great Expectations.
+
+        # Arguments
+            validation_time: The time at which validation was performed.
+            Supported format include timestamps(int), datetime, date or string formatted to be datutils parsable.
+        """
         if validation_time:
             self._validation_time = util.convert_event_time_to_timestamp(
                 validation_time

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -71,8 +71,8 @@ class ValidationResult:
             if json_decamelized["count"] == 0:
                 return []
             return [
-                cls(**validation_report)
-                for validation_report in json_decamelized["items"]
+                cls(**validation_result)
+                for validation_result in json_decamelized["items"]
             ]
         else:
             return cls(**json_decamelized)

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -16,6 +16,7 @@
 
 import json
 from typing import Any, Dict, Optional
+import dateutil
 import datetime
 
 import humps
@@ -59,6 +60,9 @@ class ValidationResult:
 
         self.validation_time = validation_time
         self.ingestion_result = ingestion_result
+
+        if (observed_value is None) and ("observed_value" in self.result.keys()):
+            self._observed_value = self.result["observed_value"]
 
     @classmethod
     def from_response_json(cls, json_dict):
@@ -188,7 +192,7 @@ class ValidationResult:
     @validation_time.setter
     def validation_time(self, validation_time: Optional[int]) -> None:
         if validation_time:
-            self._validation_time = datetime.datetime.fromtimestamp(validation_time)
+            self._validation_time = dateutil.parser.isoparse(validation_time)
         else:
             self._validation_time = None
 

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -15,6 +15,8 @@
 #
 
 import json
+from typing import Any, Dict, Optional
+import datetime
 
 import humps
 import great_expectations as ge
@@ -27,15 +29,17 @@ class ValidationResult:
 
     def __init__(
         self,
-        success,
-        result,
-        exception_info,
-        expectation_config,
-        meta,
-        id=None,
-        observed_value=None,
-        expectation_id=None,
-        validation_report_id=None,
+        success: bool,
+        result: Dict[str, Any],
+        expectation_config: str,
+        exception_info: Dict[str, Any],
+        meta: Optional[Dict[str, Any]] = {},
+        id: Optional[int] = None,
+        observed_value: Optional[Any] = None,
+        expectation_id: Optional[int] = None,
+        validation_report_id: Optional[int] = None,
+        validation_time: Optional[int] = None,
+        ingestion_result: Optional[str] = None,
         href=None,
         expand=None,
         items=None,
@@ -52,6 +56,9 @@ class ValidationResult:
         self.meta = meta
         self.exception_info = exception_info
         self.expectation_config = expectation_config
+
+        self.validation_time = validation_time
+        self.ingestion_result = ingestion_result
 
     @classmethod
     def from_response_json(cls, json_dict):
@@ -79,7 +86,7 @@ class ValidationResult:
             "meta": json.dumps(self._meta),
         }
 
-    def to_json_dict(self):
+    def to_json_dict(self) -> Dict[str, Any]:
         return {
             "id": self._id,
             "success": self.success,
@@ -89,7 +96,7 @@ class ValidationResult:
             "meta": self._meta,
         }
 
-    def to_ge_type(self):
+    def to_ge_type(self) -> ge.core.ExpectationValidationResult:
         return ge.core.ExpectationValidationResult(
             success=self.success,
             exception_info=self.exception_info,
@@ -99,30 +106,30 @@ class ValidationResult:
         )
 
     @property
-    def id(self):
+    def id(self) -> Optional[int]:
         """Id of the validation report, set by backend."""
         return self._id
 
     @id.setter
-    def id(self, id):
+    def id(self, id: Optional[int] = None) -> None:
         self._id = id
 
     @property
-    def success(self):
+    def success(self) -> bool:
         """Overall success of the validation step."""
         return self._success
 
     @success.setter
-    def success(self, success):
+    def success(self, success: bool) -> None:
         self._success = success
 
     @property
-    def result(self):
+    def result(self) -> Dict[str, Any]:
         """Result of the expectation after validation."""
         return self._result
 
     @result.setter
-    def result(self, result):
+    def result(self, result: Dict[str, Any]) -> None:
         if isinstance(result, dict):
             self._result = result
         elif isinstance(result, str):
@@ -131,12 +138,12 @@ class ValidationResult:
             raise ValueError("Result field must be stringified json or dict.")
 
     @property
-    def meta(self):
+    def meta(self) -> Dict[str, Any]:
         """Meta field of the validation report to store additional informations."""
         return self._meta
 
     @meta.setter
-    def meta(self, meta):
+    def meta(self, meta: Dict[str, Any] = {}):
         if isinstance(meta, dict):
             self._meta = meta
         elif isinstance(meta, str):
@@ -145,12 +152,12 @@ class ValidationResult:
             raise ValueError("Meta field must be stringified json or dict")
 
     @property
-    def exception_info(self):
+    def exception_info(self) -> Dict[str, Any]:
         """Exception info which can be raised when running validation."""
         return self._exception_info
 
     @exception_info.setter
-    def exception_info(self, exception_info):
+    def exception_info(self, exception_info: Dict[str, Any]) -> None:
         if isinstance(exception_info, dict):
             self._exception_info = exception_info
         elif isinstance(exception_info, str):
@@ -159,12 +166,12 @@ class ValidationResult:
             raise ValueError("Exception info field must be stringified json or dict.")
 
     @property
-    def expectation_config(self):
+    def expectation_config(self) -> Dict[str, Any]:
         """Expectation configuration used when running validation."""
         return self._expectation_config
 
     @expectation_config.setter
-    def expectation_config(self, expectation_config):
+    def expectation_config(self, expectation_config: Dict[str, Any]) -> None:
         if isinstance(expectation_config, dict):
             self._expectation_config = expectation_config
         elif isinstance(expectation_config, str):
@@ -174,10 +181,38 @@ class ValidationResult:
                 "Expectation config field must be stringified json or dict"
             )
 
-    def __str__(self):
+    @property
+    def validation_time(self) -> Optional[datetime.datetime]:
+        return self._validation_time
+
+    @validation_time.setter
+    def validation_time(self, validation_time: Optional[int]) -> None:
+        if validation_time:
+            self._validation_time = datetime.datetime.fromtimestamp(validation_time)
+        else:
+            self._validation_time = None
+
+    @property
+    def ingestion_result(self) -> str:
+        return self._ingestion_result
+
+    @ingestion_result.setter
+    def ingestion_result(self, ingestion_result: Optional[str]) -> None:
+        if ingestion_result:
+            if ingestion_result == "INGESTED" or ingestion_result == "REJECTED":
+                self._ingestion_result = ingestion_result
+            else:
+                raise ValueError(
+                    f"Illegal value for ingestion_result: {ingestion_result}."
+                    + "Choose either 'INGESTED' or 'REJECTED'"
+                )
+        else:
+            self._ingestion_result = None
+
+    def __str__(self) -> str:
         return self.json()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         result_string = ""
         if self._result is None and self._observed_value is not None:
             result_string += f"observed_value : {self._observed_value}"

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -102,7 +102,7 @@ class ValidationResult:
     def to_ge_type(self) -> ge.core.ExpectationValidationResult:
         if self._validation_time:
             self.meta["validation_time"] = datetime.utcfromtimestamp(
-                self._validation_time
+                self._validation_time / 1000
             ).isoformat()
         if self._ingestion_result:
             self.meta["ingestion_result"] = self._ingestion_result

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -15,9 +15,8 @@
 #
 
 import json
-from typing import Any, Dict, Optional
-import dateutil
-import datetime
+from typing import Any, Dict, Optional, Union
+from datetime import date, datetime
 
 import humps
 import great_expectations as ge
@@ -186,13 +185,17 @@ class ValidationResult:
             )
 
     @property
-    def validation_time(self) -> Optional[datetime.datetime]:
+    def validation_time(self) -> Optional[int]:
         return self._validation_time
 
     @validation_time.setter
-    def validation_time(self, validation_time: Optional[int]) -> None:
+    def validation_time(
+        self, validation_time: Union[str, int, datetime, date, None]
+    ) -> None:
         if validation_time:
-            self._validation_time = dateutil.parser.isoparse(validation_time)
+            self._validation_time = util.convert_event_time_to_timestamp(
+                validation_time
+            )
         else:
             self._validation_time = None
 

--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -100,13 +100,6 @@ class ValidationResult:
         }
 
     def to_ge_type(self) -> ge.core.ExpectationValidationResult:
-        if self._validation_time:
-            self.meta["validation_time"] = datetime.utcfromtimestamp(
-                self._validation_time / 1000
-            ).isoformat()
-        if self._ingestion_result:
-            self.meta["ingestion_result"] = self._ingestion_result
-
         return ge.core.ExpectationValidationResult(
             success=self.success,
             exception_info=self.exception_info,

--- a/python/tests/core/test_validation_result_engine.py
+++ b/python/tests/core/test_validation_result_engine.py
@@ -25,13 +25,14 @@ class TestValidationResultEngine:
         feature_store_id = 99
         feature_group_id = 10
         expectation_id = 31
-        vr_engine = validation_result_engine.ValidationResultEngine(
-            feature_store_id=feature_store_id, feature_group_id=feature_group_id
-        )
 
         mocker.patch("hsfs.client.get_instance")
         mock_validation_result_api = mocker.patch(
             "hsfs.core.validation_result_api.ValidationResultApi"
+        )
+
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
         )
 
         # Act

--- a/python/tests/core/test_validation_result_engine.py
+++ b/python/tests/core/test_validation_result_engine.py
@@ -15,6 +15,7 @@
 #
 
 from hsfs.core import validation_result_engine
+from hsfs.util import convert_event_time_to_timestamp
 from datetime import date, datetime
 import pytest
 
@@ -120,7 +121,9 @@ class TestValidationResultEngine:
             )
         ]
         assert len(filter_validation_gte) == 1
-        assert int(filter_validation_gte[0][20:]) + 1
+        assert int(filter_validation_gte[0][20:]) == convert_event_time_to_timestamp(
+            correct_inputs[0]["start_validation_time"]
+        )
         filter_validation_lte = [
             val
             for val in filter(
@@ -128,7 +131,9 @@ class TestValidationResultEngine:
             )
         ]
         assert len(filter_validation_lte) == 1
-        assert int(filter_validation_lte[0][20:]) + 1
+        assert int(filter_validation_lte[0][20:]) == convert_event_time_to_timestamp(
+            correct_inputs[0]["end_validation_time"]
+        )
 
         # Second case
         assert len(correct_outputs[1]["filter_by"]) == 2
@@ -140,7 +145,16 @@ class TestValidationResultEngine:
             )
         ]
         assert len(filter_validation_gte) == 1
-        assert int(filter_validation_gte[0][20:]) + 1
+        assert int(filter_validation_gte[0][20:]) == convert_event_time_to_timestamp(
+            correct_inputs[1]["start_validation_time"]
+        )
+        filter_validation_lte = [
+            val
+            for val in filter(
+                lambda x: "validation_time_lte:" in x, correct_outputs[1]["filter_by"]
+            )
+        ]
+        assert len(filter_validation_lte) == 0
 
         # Third case
         assert len(correct_outputs[2]["filter_by"]) == 2
@@ -151,7 +165,9 @@ class TestValidationResultEngine:
             )
         ]
         assert len(filter_validation_gte) == 1
-        assert int(filter_validation_gte[0][20:]) + 1
+        assert int(filter_validation_gte[0][20:]) == convert_event_time_to_timestamp(
+            correct_inputs[2]["start_validation_time"]
+        )
         filter_validation_lte = [
             val
             for val in filter(
@@ -159,7 +175,9 @@ class TestValidationResultEngine:
             )
         ]
         assert len(filter_validation_lte) == 1
-        assert int(filter_validation_lte[0][20:]) + 1
+        assert int(filter_validation_lte[0][20:]) == convert_event_time_to_timestamp(
+            correct_inputs[2]["end_validation_time"]
+        )
 
         # Fourth case
         assert len(correct_outputs[3]["filter_by"]) == 0

--- a/python/tests/core/test_validation_result_engine.py
+++ b/python/tests/core/test_validation_result_engine.py
@@ -1,0 +1,226 @@
+#
+#   Copyright 2022 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hsfs.core import validation_result_engine
+import pandas as pd
+import pytest
+
+
+class TestValidationResultEngine:
+    def test_get_validation_history(self, mocker):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        expectation_id = 31
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+
+        mocker.patch("hsfs.client.get_instance")
+        mock_validation_result_api = mocker.patch(
+            "hsfs.core.validation_result_api.ValidationResultApi"
+        )
+
+        # Act
+        vr_engine.get_validation_history(expectation_id=expectation_id)
+
+        # Assert
+        assert (
+            mock_validation_result_api.return_value.get_validation_history.call_count
+            == 1
+        )
+
+    def test_verify_sort_by(self):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+
+        input_with_type_error = [
+            1,
+            2.0,
+            {},
+            ["validation_time:desc"],
+            pd.Timestamp(200),
+        ]
+        input_with_value_error = [
+            "sort_by=validation_time:desc",
+            "desc",
+            "asc",
+            "validation_time_gte:21343243",
+            "ingestion_result_eq:REJECTED" "validation_time:confused",
+        ]
+        clean_inputs = ["validation_time:desc", "validation_time:asc"]
+
+        # Act
+        for failing_type_input in input_with_type_error:
+            with pytest.raises(TypeError):
+                vr_engine._verify_sort_by(failing_type_input)
+
+        for failing_value_input in input_with_value_error:
+            with pytest.raises(ValueError):
+                vr_engine._verify_sort_by(failing_value_input)
+
+        for passing_input in clean_inputs:
+            vr_engine._verify_sort_by(passing_input)
+
+        # Assert
+        assert True
+
+    def test_verify_filter_by(self):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+
+        input_with_type_error = [1, 2.0, {}, pd.Timestamp(200)]
+        input_with_value_error = [
+            "sort_by=validation_time:desc",
+            "desc",
+            "asc",
+            "validation_time_gte:2134WW243",
+            "ingestion_result_eq:REJ3CTED",
+            "validation_time:confused",
+            ["validation_time_gte:2134WW243", "validation_time_lte:2134WW243"],
+            ["validation_time_gte:2134243", "ingestion_result_eq:REJ3CTED"],
+        ]
+        clean_inputs = [
+            "ingestion_result_eq:REJECTED",
+            "ingestion_result_eq:INGESTED",
+            "iNGEstion_REsult_eQ:INGESTED",
+            "VALIDATION_time_Gte:213321",
+            "validation_time_gte:12213",
+            "validation_time_gt:12213",
+            "validation_time_eq:12213",
+            "validation_time_lte:12213",
+            "validation_time_lt:12213213",
+            [],
+        ]
+
+        # Act
+        for failing_type_input in input_with_type_error:
+            with pytest.raises(TypeError):
+                vr_engine._verify_filter_by(failing_type_input)
+
+        for failing_value_input in input_with_value_error:
+            with pytest.raises(ValueError):
+                vr_engine._verify_filter_by(failing_value_input)
+
+        for passing_input in clean_inputs:
+            vr_engine._verify_filter_by(passing_input)
+
+        # Assert
+        assert True
+
+    def test_match_filter_by_validation_time_or_ingestion_result(self):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+        input_with_value_error = [
+            "sort_by=validation_time:desc",
+            "desc",
+            "asc",
+            "validation_time_gte:2134WW243",
+            "ingestion_result_eq:REJ3CTED",
+            "validation_time:confused",
+        ]
+        clean_inputs = [
+            "ingestion_result_eq:REJECTED",
+            "ingestion_result_eq:INGESTED",
+            "iNGEstion_REsult_eQ:INGESTED",
+            "VALIDATION_time_Gte:213321",
+            "validation_time_gte:12213",
+            "validation_time_gt:12213",
+            "validation_time_eq:12213"
+            "validation_time_lte:12213"
+            "validation_time_lt:12213213",
+        ]
+
+        # Act
+        for failing_value_input in input_with_value_error:
+            with pytest.raises(ValueError):
+                vr_engine._match_filter_by_validation_time_or_ingestion_result(
+                    failing_value_input
+                )
+
+        for passing_input in clean_inputs:
+            vr_engine._match_filter_by_validation_time_or_ingestion_result(
+                passing_input
+            )
+
+        # Assert
+        assert True
+
+    def test_verify_offset(self):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+
+        input_with_type_error = ["1", 2.0, {}, ["2"]]
+        input_with_value_error = [-1]
+        clean_inputs = [0, 10]
+
+        # Act
+        for failing_type_input in input_with_type_error:
+            with pytest.raises(TypeError):
+                vr_engine._verify_offset(failing_type_input)
+
+        for failing_value_input in input_with_value_error:
+            with pytest.raises(ValueError):
+                vr_engine._verify_offset(failing_value_input)
+
+        for passing_input in clean_inputs:
+            vr_engine._verify_offset(passing_input)
+
+        # Assert
+        assert True
+
+    def test_verify_limit(self):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        vr_engine = validation_result_engine.ValidationResultEngine(
+            feature_store_id=feature_store_id, feature_group_id=feature_group_id
+        )
+
+        input_with_type_error = ["1", 2.0, {}, ["2"]]
+        input_with_value_error = [-1]
+        clean_inputs = [0, 10]
+
+        # Act
+        for failing_type_input in input_with_type_error:
+            with pytest.raises(TypeError):
+                vr_engine._verify_limit(failing_type_input)
+
+        for failing_value_input in input_with_value_error:
+            with pytest.raises(ValueError):
+                vr_engine._verify_limit(failing_value_input)
+
+        for passing_input in clean_inputs:
+            vr_engine._verify_limit(passing_input)
+
+        # Assert
+        assert True

--- a/python/tests/fixtures/expectation_suite_fixtures.json
+++ b/python/tests/fixtures/expectation_suite_fixtures.json
@@ -5,12 +5,12 @@
       "expectations": [
         {
           "expectation_type": "1",
-          "kwargs": { "kwargs_key": "kwargs_value" },
-          "meta": { "meta_key": "meta_value" },
+          "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+          "meta": "{ \"meta_key\": \"meta_value\" }",
           "id": 32
         }
       ],
-      "meta": { "great_expectations_version": "0.14.12", "key": "value" },
+      "meta": "{ \"great_expectations_version\": \"0.14.12\", \"key\": \"value\" }",
       "id": 21,
       "data_asset_type": "test_data_asset_type",
       "ge_cloud_id": "test_ge_cloud_id",
@@ -34,15 +34,12 @@
           "expectations": [
             {
               "expectation_type": "1",
-              "kwargs": { "kwargs_key": "kwargs_value" },
-              "meta": { "meta_key": "meta_value" },
+              "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+              "meta": "{ \"meta_key\": \"meta_value\" }",
               "id": "4"
             }
           ],
-          "meta": {
-            "great_expectations_version": "0.14.12",
-            "key": "value"
-          },
+          "meta": "{\"great_expectations_version\": \"0.14.12\",\"key\": \"value\"}",
           "id": 21,
           "data_asset_type": "test_data_asset_type",
           "ge_cloud_id": "test_ge_cloud_id",
@@ -65,12 +62,12 @@
       "expectations": [
         {
           "expectation_type": "1",
-          "kwargs": { "kwargs_key": "kwargs_value" },
-          "meta": { "meta_key": "meta_value" },
+          "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+          "meta": "{ \"meta_key\": \"meta_value\" }",
           "id": 32
         }
       ],
-      "meta": { "great_expectations_version": "0.14.12", "key": "value" }
+      "meta": "{\"great_expectations_version\": \"0.14.12\",\"key\": \"value\"}"
     }
   },
   "get_list_empty": {

--- a/python/tests/fixtures/feature_group_fixtures.json
+++ b/python/tests/fixtures/feature_group_fixtures.json
@@ -1,342 +1,438 @@
 {
-    "get": {
-        "response": {
-            "type": "cachedFeaturegroupDTO",
-            "validation_type": "test_validation_type",
-            "created": "2022-08-01T11:07:55Z",
-            "creator": {
-                "email": "admin@hopsworks.ai",
-                "firstName": "Admin",
-                "lastName": "Admin",
-                "maxNumProjects": 0,
-                "numActiveProjects": 0,
-                "numCreatedProjects": 0,
-                "numRemainingProjects": 0,
-                "status": 0,
-                "testUser": false,
-                "tos": false,
-                "toursState": 0,
-                "twoFactor": false
-            },
-            "description": "test_description",
-            "featurestoreId": 67,
-            "featurestoreName": "test_featurestore",
-            "id": 15,
-            "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
-            "name": "fg_test",
-            "statisticsConfig": {
-                "columns": [],
-                "correlations": false,
-                "enabled": true,
-                "exactUniqueness": false,
-                "histograms": false
-            },
-            "version": 1,
-            "features": [
-                {
-                    "defaultValue": null,
-                    "featureGroupId": 15,
-                    "hudiPrecombineKey": true,
-                    "name": "intt",
-                    "onlineType": "int",
-                    "partition": false,
-                    "primary": true,
-                    "type": "int"
-                },
-                {
-                    "defaultValue": null,
-                    "featureGroupId": 15,
-                    "hudiPrecombineKey": false,
-                    "name": "stringt",
-                    "onlineType": "varchar(1000)",
-                    "partition": false,
-                    "primary": false,
-                    "type": "string"
-                }
-            ],
-            "onlineTopicName": "119_15_fg_test_1_onlinefs",
-            "onlineEnabled": true,
-            "timeTravelFormat": "HUDI"
+  "get": {
+    "response": {
+      "type": "cachedFeaturegroupDTO",
+      "validation_type": "test_validation_type",
+      "created": "2022-08-01T11:07:55Z",
+      "creator": {
+        "email": "admin@hopsworks.ai",
+        "firstName": "Admin",
+        "lastName": "Admin",
+        "maxNumProjects": 0,
+        "numActiveProjects": 0,
+        "numCreatedProjects": 0,
+        "numRemainingProjects": 0,
+        "status": 0,
+        "testUser": false,
+        "tos": false,
+        "toursState": 0,
+        "twoFactor": false
+      },
+      "description": "test_description",
+      "featurestoreId": 67,
+      "featurestoreName": "test_featurestore",
+      "id": 15,
+      "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
+      "name": "fg_test",
+      "statisticsConfig": {
+        "columns": [],
+        "correlations": false,
+        "enabled": true,
+        "exactUniqueness": false,
+        "histograms": false
+      },
+      "version": 1,
+      "features": [
+        {
+          "defaultValue": null,
+          "featureGroupId": 15,
+          "hudiPrecombineKey": true,
+          "name": "intt",
+          "onlineType": "int",
+          "partition": false,
+          "primary": true,
+          "type": "int"
         },
-        "method": "GET",
-        "path_params": [
-            "project",
-            "119",
-            "featurestores",
-            67,
-            "featuregroups",
-            "fg_test"
+        {
+          "defaultValue": null,
+          "featureGroupId": 15,
+          "hudiPrecombineKey": false,
+          "name": "stringt",
+          "onlineType": "varchar(1000)",
+          "partition": false,
+          "primary": false,
+          "type": "string"
+        }
+      ],
+      "onlineTopicName": "119_15_fg_test_1_onlinefs",
+      "onlineEnabled": true,
+      "timeTravelFormat": "HUDI",
+      "expectationSuite": {
+        "expectation_suite_name": "test_expectation_suite_name",
+        "expectations": [
+          {
+            "expectation_type": "1",
+            "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+            "meta": "{ \"meta_key\": \"meta_value\" }",
+            "id": 32
+          }
         ],
-        "query_params": {
-            "version": 1
-        },
-        "headers": null
+        "meta": "{ \"great_expectations_version\": \"0.14.12\", \"key\": \"value\" }",
+        "id": 21,
+        "data_asset_type": "test_data_asset_type",
+        "ge_cloud_id": "test_ge_cloud_id",
+        "run_validation": "test_run_validation",
+        "validation_ingestion_policy": "test_validation_ingestion_policy",
+        "feature_store_id": 67,
+        "feature_group_id": 15,
+        "href": "test_/featurestores/67/featuregroups/15/expectationsuite",
+        "expand": "test_expand",
+        "items": "test_items",
+        "type": "expectationSuiteDTO",
+        "created": "test_created"
+      }
     },
-    "get_list": {
-        "response": [
+    "method": "GET",
+    "path_params": [
+      "project",
+      "119",
+      "featurestores",
+      67,
+      "featuregroups",
+      "fg_test"
+    ],
+    "query_params": {
+      "version": 1
+    },
+    "headers": null
+  },
+  "get_list": {
+    "response": [
+      {
+        "type": "cachedFeaturegroupDTO",
+        "validation_type": "test_validation_type",
+        "created": "2022-08-01T11:07:55Z",
+        "creator": {
+          "email": "admin@hopsworks.ai",
+          "firstName": "Admin",
+          "lastName": "Admin",
+          "maxNumProjects": 0,
+          "numActiveProjects": 0,
+          "numCreatedProjects": 0,
+          "numRemainingProjects": 0,
+          "status": 0,
+          "testUser": false,
+          "tos": false,
+          "toursState": 0,
+          "twoFactor": false
+        },
+        "description": "test_description",
+        "featurestoreId": 67,
+        "featurestoreName": "test_featurestore",
+        "id": 15,
+        "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
+        "name": "fg_test",
+        "statisticsConfig": {
+          "columns": [],
+          "correlations": false,
+          "enabled": true,
+          "exactUniqueness": false,
+          "histograms": false
+        },
+        "version": 1,
+        "features": [
+          {
+            "defaultValue": null,
+            "featureGroupId": 15,
+            "hudiPrecombineKey": true,
+            "name": "intt",
+            "onlineType": "int",
+            "partition": false,
+            "primary": true,
+            "type": "int"
+          },
+          {
+            "defaultValue": null,
+            "featureGroupId": 15,
+            "hudiPrecombineKey": false,
+            "name": "stringt",
+            "onlineType": "varchar(1000)",
+            "partition": false,
+            "primary": false,
+            "type": "string"
+          }
+        ],
+        "onlineTopicName": "119_15_fg_test_1_onlinefs",
+        "onlineEnabled": true,
+        "timeTravelFormat": "HUDI",
+        "expectationSuite": {
+          "expectation_suite_name": "test_expectation_suite_name",
+          "expectations": [
             {
-                "type": "cachedFeaturegroupDTO",
-                "validation_type": "test_validation_type",
-                "created": "2022-08-01T11:07:55Z",
-                "creator": {
-                    "email": "admin@hopsworks.ai",
-                    "firstName": "Admin",
-                    "lastName": "Admin",
-                    "maxNumProjects": 0,
-                    "numActiveProjects": 0,
-                    "numCreatedProjects": 0,
-                    "numRemainingProjects": 0,
-                    "status": 0,
-                    "testUser": false,
-                    "tos": false,
-                    "toursState": 0,
-                    "twoFactor": false
-                },
-                "description": "test_description",
-                "featurestoreId": 67,
-                "featurestoreName": "test_featurestore",
-                "id": 15,
-                "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
-                "name": "fg_test",
-                "statisticsConfig": {
-                    "columns": [],
-                    "correlations": false,
-                    "enabled": true,
-                    "exactUniqueness": false,
-                    "histograms": false
-                },
-                "version": 1,
-                "features": [
-                    {
-                        "defaultValue": null,
-                        "featureGroupId": 15,
-                        "hudiPrecombineKey": true,
-                        "name": "intt",
-                        "onlineType": "int",
-                        "partition": false,
-                        "primary": true,
-                        "type": "int"
-                    },
-                    {
-                        "defaultValue": null,
-                        "featureGroupId": 15,
-                        "hudiPrecombineKey": false,
-                        "name": "stringt",
-                        "onlineType": "varchar(1000)",
-                        "partition": false,
-                        "primary": false,
-                        "type": "string"
-                    }
-                ],
-                "onlineTopicName": "119_15_fg_test_1_onlinefs",
-                "onlineEnabled": true,
-                "timeTravelFormat": "HUDI"
+              "expectation_type": "1",
+              "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+              "meta": "{ \"meta_key\": \"meta_value\" }",
+              "id": 32
             }
-        ],
-        "method": "GET",
-        "path_params": [
-            "project",
-            "119",
-            "featurestores",
-            67,
-            "featuregroups",
-            "fg_test"
-        ],
-        "query_params": {
-            "version": 1
-        },
-        "headers": null
+          ],
+          "meta": "{ \"great_expectations_version\": \"0.14.12\", \"key\": \"value\" }",
+          "id": 21,
+          "data_asset_type": "test_data_asset_type",
+          "ge_cloud_id": "test_ge_cloud_id",
+          "run_validation": "test_run_validation",
+          "validation_ingestion_policy": "test_validation_ingestion_policy",
+          "feature_store_id": 67,
+          "feature_group_id": 15,
+          "href": "test_/featurestores/67/featuregroups/15/expectationsuite",
+          "expand": "test_expand",
+          "items": "test_items",
+          "type": "expectationSuiteDTO",
+          "created": "test_created"
+        }
+      }
+    ],
+    "method": "GET",
+    "path_params": [
+      "project",
+      "119",
+      "featurestores",
+      67,
+      "featuregroups",
+      "fg_test"
+    ],
+    "query_params": {
+      "version": 1
     },
-    "get_basic_info": {
-        "response": {
-            "type": "cachedFeaturegroupDTO",
-            "featurestoreId": 67,
-            "id": 15,
-            "name": "fg_test",
-            "version": 1
-        },
-        "method": "GET",
-        "path_params": [
-            "project",
-            "119",
-            "featurestores",
-            67,
-            "featuregroups",
-            "fg_test"
-        ],
-        "query_params": {
-            "version": 1
-        },
-        "headers": null
+    "headers": null
+  },
+  "get_basic_info": {
+    "response": {
+      "type": "cachedFeaturegroupDTO",
+      "featurestoreId": 67,
+      "id": 15,
+      "name": "fg_test",
+      "version": 1
     },
-    "get_stream": {
-        "response": {
-            "type": "streamFeatureGroupDTO",
-            "validation_type": "test_validation_type",
-            "created": "2022-08-01T11:07:55Z",
-            "creator": {
-                "email": "admin@hopsworks.ai",
-                "firstName": "Admin",
-                "lastName": "Admin",
-                "maxNumProjects": 0,
-                "numActiveProjects": 0,
-                "numCreatedProjects": 0,
-                "numRemainingProjects": 0,
-                "status": 0,
-                "testUser": false,
-                "tos": false,
-                "toursState": 0,
-                "twoFactor": false
-            },
-            "description": "test_description",
-            "featurestoreId": 67,
-            "featurestoreName": "test_featurestore",
-            "id": 15,
-            "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
-            "name": "fg_test",
-            "statisticsConfig": {
-                "columns": [],
-                "correlations": false,
-                "enabled": true,
-                "exactUniqueness": false,
-                "histograms": false
-            },
-            "version": 1,
-            "features": [
-                {
-                    "defaultValue": null,
-                    "featureGroupId": 15,
-                    "hudiPrecombineKey": true,
-                    "name": "intt",
-                    "onlineType": "int",
-                    "partition": false,
-                    "primary": true,
-                    "type": "int"
-                },
-                {
-                    "defaultValue": null,
-                    "featureGroupId": 15,
-                    "hudiPrecombineKey": false,
-                    "name": "stringt",
-                    "onlineType": "varchar(1000)",
-                    "partition": false,
-                    "primary": false,
-                    "type": "string"
-                }
-            ],
-            "onlineTopicName": "119_15_fg_test_1_onlinefs",
-            "onlineEnabled": true,
-            "timeTravelFormat": "HUDI"
-        },
-        "method": "GET",
-        "path_params": [
-            "project",
-            "119",
-            "featurestores",
-            67,
-            "featuregroups",
-            "fg_test"
-        ],
-        "query_params": {
-            "version": 1
-        },
-        "headers": null
+    "method": "GET",
+    "path_params": [
+      "project",
+      "119",
+      "featurestores",
+      67,
+      "featuregroups",
+      "fg_test"
+    ],
+    "query_params": {
+      "version": 1
     },
-    "get_stream_list": {
-        "response": [
+    "headers": null
+  },
+  "get_stream": {
+    "response": {
+      "type": "streamFeatureGroupDTO",
+      "validation_type": "test_validation_type",
+      "created": "2022-08-01T11:07:55Z",
+      "creator": {
+        "email": "admin@hopsworks.ai",
+        "firstName": "Admin",
+        "lastName": "Admin",
+        "maxNumProjects": 0,
+        "numActiveProjects": 0,
+        "numCreatedProjects": 0,
+        "numRemainingProjects": 0,
+        "status": 0,
+        "testUser": false,
+        "tos": false,
+        "toursState": 0,
+        "twoFactor": false
+      },
+      "description": "test_description",
+      "featurestoreId": 67,
+      "featurestoreName": "test_featurestore",
+      "id": 15,
+      "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
+      "name": "fg_test",
+      "statisticsConfig": {
+        "columns": [],
+        "correlations": false,
+        "enabled": true,
+        "exactUniqueness": false,
+        "histograms": false
+      },
+      "version": 1,
+      "features": [
+        {
+          "defaultValue": null,
+          "featureGroupId": 15,
+          "hudiPrecombineKey": true,
+          "name": "intt",
+          "onlineType": "int",
+          "partition": false,
+          "primary": true,
+          "type": "int"
+        },
+        {
+          "defaultValue": null,
+          "featureGroupId": 15,
+          "hudiPrecombineKey": false,
+          "name": "stringt",
+          "onlineType": "varchar(1000)",
+          "partition": false,
+          "primary": false,
+          "type": "string"
+        }
+      ],
+      "onlineTopicName": "119_15_fg_test_1_onlinefs",
+      "onlineEnabled": true,
+      "timeTravelFormat": "HUDI",
+      "expectationSuite": {
+        "expectation_suite_name": "test_expectation_suite_name",
+        "expectations": [
+          {
+            "expectation_type": "1",
+            "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+            "meta": "{ \"meta_key\": \"meta_value\" }",
+            "id": 32
+          }
+        ],
+        "meta": "{ \"great_expectations_version\": \"0.14.12\", \"key\": \"value\" }",
+        "id": 21,
+        "data_asset_type": "test_data_asset_type",
+        "ge_cloud_id": "test_ge_cloud_id",
+        "run_validation": "test_run_validation",
+        "validation_ingestion_policy": "test_validation_ingestion_policy",
+        "feature_store_id": 67,
+        "feature_group_id": 15,
+        "href": "test_/featurestores/67/featuregroups/15/expectationsuite",
+        "expand": "test_expand",
+        "items": "test_items",
+        "type": "expectationSuiteDTO",
+        "created": "test_created"
+      }
+    },
+    "method": "GET",
+    "path_params": [
+      "project",
+      "119",
+      "featurestores",
+      67,
+      "featuregroups",
+      "fg_test"
+    ],
+    "query_params": {
+      "version": 1
+    },
+    "headers": null
+  },
+  "get_stream_list": {
+    "response": [
+      {
+        "type": "streamFeatureGroupDTO",
+        "validation_type": "test_validation_type",
+        "created": "2022-08-01T11:07:55Z",
+        "creator": {
+          "email": "admin@hopsworks.ai",
+          "firstName": "Admin",
+          "lastName": "Admin",
+          "maxNumProjects": 0,
+          "numActiveProjects": 0,
+          "numCreatedProjects": 0,
+          "numRemainingProjects": 0,
+          "status": 0,
+          "testUser": false,
+          "tos": false,
+          "toursState": 0,
+          "twoFactor": false
+        },
+        "description": "test_description",
+        "featurestoreId": 67,
+        "featurestoreName": "test_featurestore",
+        "id": 15,
+        "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
+        "name": "fg_test",
+        "statisticsConfig": {
+          "columns": [],
+          "correlations": false,
+          "enabled": true,
+          "exactUniqueness": false,
+          "histograms": false
+        },
+        "version": 1,
+        "features": [
+          {
+            "defaultValue": null,
+            "featureGroupId": 15,
+            "hudiPrecombineKey": true,
+            "name": "intt",
+            "onlineType": "int",
+            "partition": false,
+            "primary": true,
+            "type": "int"
+          },
+          {
+            "defaultValue": null,
+            "featureGroupId": 15,
+            "hudiPrecombineKey": false,
+            "name": "stringt",
+            "onlineType": "varchar(1000)",
+            "partition": false,
+            "primary": false,
+            "type": "string"
+          }
+        ],
+        "onlineTopicName": "119_15_fg_test_1_onlinefs",
+        "onlineEnabled": true,
+        "timeTravelFormat": "HUDI",
+        "expectationSuite": {
+          "expectation_suite_name": "test_expectation_suite_name",
+          "expectations": [
             {
-                "type": "streamFeatureGroupDTO",
-                "validation_type": "test_validation_type",
-                "created": "2022-08-01T11:07:55Z",
-                "creator": {
-                    "email": "admin@hopsworks.ai",
-                    "firstName": "Admin",
-                    "lastName": "Admin",
-                    "maxNumProjects": 0,
-                    "numActiveProjects": 0,
-                    "numCreatedProjects": 0,
-                    "numRemainingProjects": 0,
-                    "status": 0,
-                    "testUser": false,
-                    "tos": false,
-                    "toursState": 0,
-                    "twoFactor": false
-                },
-                "description": "test_description",
-                "featurestoreId": 67,
-                "featurestoreName": "test_featurestore",
-                "id": 15,
-                "location": "hopsfs://10.0.2.15:8020/apps/hive/warehouse/test_featurestore.db/fg_test_1",
-                "name": "fg_test",
-                "statisticsConfig": {
-                    "columns": [],
-                    "correlations": false,
-                    "enabled": true,
-                    "exactUniqueness": false,
-                    "histograms": false
-                },
-                "version": 1,
-                "features": [
-                    {
-                        "defaultValue": null,
-                        "featureGroupId": 15,
-                        "hudiPrecombineKey": true,
-                        "name": "intt",
-                        "onlineType": "int",
-                        "partition": false,
-                        "primary": true,
-                        "type": "int"
-                    },
-                    {
-                        "defaultValue": null,
-                        "featureGroupId": 15,
-                        "hudiPrecombineKey": false,
-                        "name": "stringt",
-                        "onlineType": "varchar(1000)",
-                        "partition": false,
-                        "primary": false,
-                        "type": "string"
-                    }
-                ],
-                "onlineTopicName": "119_15_fg_test_1_onlinefs",
-                "onlineEnabled": true,
-                "timeTravelFormat": "HUDI"
+              "expectation_type": "1",
+              "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+              "meta": "{ \"meta_key\": \"meta_value\" }",
+              "id": 32
             }
-        ],
-        "method": "GET",
-        "path_params": [
-            "project",
-            "119",
-            "featurestores",
-            67,
-            "featuregroups",
-            "fg_test"
-        ],
-        "query_params": {
-            "version": 1
-        },
-        "headers": null
+          ],
+          "meta": "{ \"great_expectations_version\": \"0.14.12\", \"key\": \"value\" }",
+          "id": 21,
+          "data_asset_type": "test_data_asset_type",
+          "ge_cloud_id": "test_ge_cloud_id",
+          "run_validation": "test_run_validation",
+          "validation_ingestion_policy": "test_validation_ingestion_policy",
+          "feature_store_id": 67,
+          "feature_group_id": 15,
+          "href": "test_/featurestores/67/featuregroups/15/expectationsuite",
+          "expand": "test_expand",
+          "items": "test_items",
+          "type": "expectationSuiteDTO",
+          "created": "test_created"
+        }
+      }
+    ],
+    "method": "GET",
+    "path_params": [
+      "project",
+      "119",
+      "featurestores",
+      67,
+      "featuregroups",
+      "fg_test"
+    ],
+    "query_params": {
+      "version": 1
     },
-    "get_stream_basic_info": {
-        "response": {
-            "type": "streamFeatureGroupDTO",
-            "featurestoreId": 67,
-            "id": 15,
-            "name": "fg_test",
-            "version": 1
-        },
-        "method": "GET",
-        "path_params": [
-            "project",
-            "119",
-            "featurestores",
-            67,
-            "featuregroups",
-            "fg_test"
-        ],
-        "query_params": {
-            "version": 1
-        },
-        "headers": null
-    }
+    "headers": null
+  },
+  "get_stream_basic_info": {
+    "response": {
+      "type": "streamFeatureGroupDTO",
+      "featurestoreId": 67,
+      "id": 15,
+      "name": "fg_test",
+      "version": 1
+    },
+    "method": "GET",
+    "path_params": [
+      "project",
+      "119",
+      "featurestores",
+      67,
+      "featuregroups",
+      "fg_test"
+    ],
+    "query_params": {
+      "version": 1
+    },
+    "headers": null
+  }
 }

--- a/python/tests/fixtures/ge_expectation_fixtures.json
+++ b/python/tests/fixtures/ge_expectation_fixtures.json
@@ -2,8 +2,8 @@
   "get": {
     "response": {
       "expectation_type": "1",
-      "kwargs": { "kwargs_key": "kwargs_value" },
-      "meta": { "meta_key": "meta_value", "expectationId": 32 },
+      "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+      "meta": "{ \"meta_key\": \"meta_value\", \"expectationId\": 32 }",
       "id": 32
     }
   },
@@ -13,8 +13,8 @@
       "items": [
         {
           "expectation_type": "1",
-          "kwargs": { "kwargs_key": "kwargs_value" },
-          "meta": { "meta_key": "meta_value", "expectationId": 32 },
+          "kwargs": "{ \"kwargs_key\": \"kwargs_value\" }",
+          "meta": "{ \"meta_key\": \"meta_value\", \"expectationId\": 32 }",
           "id": 32
         }
       ]

--- a/python/tests/fixtures/ge_validation_result_fixtures.json
+++ b/python/tests/fixtures/ge_validation_result_fixtures.json
@@ -2,26 +2,27 @@
   "get": {
     "response": {
       "success": true,
-      "result": {"result_key": "result_value"},
-      "exception_info": {"exception_info_key": "exception_info_value"},
-      "expectation_config": {"expectation_config_key": "expectation_config_value"},
-      "meta": {"meta_key": "meta_value"},
+      "result": "{\"result_key\": \"result_value\"}",
+      "exception_info": "{\"exception_info_key\": \"exception_info_value\"}",
+      "expectation_config": "{\"expectation_config_key\": \"expectation_config_value\"}",
+      "meta": "{\"meta_key\": \"meta_value\"}",
       "id": 11,
       "observed_value": "test_observed_value",
       "expectation_id": 22,
       "validation_report_id": 33,
       "href": "test_href",
       "expand": "test_expand",
-      "type": "validationResultDTO"
+      "type": "validationResultDTO",
+      "ingestion_result": "INGESTED"
     }
   },
   "get_basic_info": {
     "response": {
       "success": true,
-      "result": {"result_key": "result_value"},
-      "exception_info": {"exception_info_key": "exception_info_value"},
-      "expectation_config": {"expectation_config_key": "expectation_config_value"},
-      "meta": {"meta_key": "meta_value"}
+      "result": "{\"result_key\": \"result_value\"}",
+      "exception_info": "{\"exception_info_key\": \"exception_info_value\"}",
+      "expectation_config": "{\"expectation_config_key\": \"expectation_config_value\"}",
+      "meta": "{\"meta_key\": \"meta_value\"}"
     }
   },
   "get_list": {
@@ -30,17 +31,18 @@
       "items": [
         {
           "success": true,
-          "result": {"result_key": "result_value"},
-          "exception_info": {"exception_info_key": "exception_info_value"},
-          "expectation_config": {"expectation_config_key": "expectation_config_value"},
-          "meta": {"meta_key": "meta_value"},
+          "result": "{\"result_key\": \"result_value\"}",
+          "exception_info": "{\"exception_info_key\": \"exception_info_value\"}",
+          "expectation_config": "{\"expectation_config_key\": \"expectation_config_value\"}",
+          "meta": "{\"meta_key\": \"meta_value\"}",
           "id": 11,
           "observed_value": "test_observed_value",
           "expectation_id": 22,
           "validation_report_id": 33,
           "href": "test_href",
           "expand": "test_expand",
-          "type": "validationResultDTO"
+          "type": "validationResultDTO",
+          "ingestion_result": "REJECTED"
         }
       ]
     }

--- a/python/tests/fixtures/ge_validation_result_fixtures.json
+++ b/python/tests/fixtures/ge_validation_result_fixtures.json
@@ -13,7 +13,8 @@
       "href": "test_href",
       "expand": "test_expand",
       "type": "validationResultDTO",
-      "ingestion_result": "INGESTED"
+      "ingestion_result": "INGESTED",
+      "validation_time": "2022-11-10T06:47:37.000907Z"
     }
   },
   "get_basic_info": {
@@ -42,7 +43,8 @@
           "href": "test_href",
           "expand": "test_expand",
           "type": "validationResultDTO",
-          "ingestion_result": "REJECTED"
+          "ingestion_result": "REJECTED",
+          "validation_time": "2022-11-10T06:47:37.000907Z"
         }
       ]
     }

--- a/python/tests/fixtures/validation_report_fixtures.json
+++ b/python/tests/fixtures/validation_report_fixtures.json
@@ -5,22 +5,23 @@
       "results": [
         {
           "success": true,
-          "result": {"result_key": "result_value"},
-          "exception_info": {"exception_info_key": "exception_info_value"},
-          "expectation_config": {"expectation_config_key": "expectation_config_value"},
-          "meta": {"meta_key": "meta_value"},
+          "result": "{\"result_key\": \"result_value\"}",
+          "exception_info": "{\"exception_info_key\": \"exception_info_value\"}",
+          "expectation_config": "{\"expectation_config_key\": \"expectation_config_value\"}",
+          "meta": "{\"meta_key\": \"meta_value\"}",
           "id": 11,
           "observed_value": "test_observed_value",
           "expectation_id": 22,
           "validation_report_id": 33,
           "href": "test_href",
           "expand": "test_expand",
-          "type": "validationResultDTO"
+          "type": "validationResultDTO",
+          "ingestion_result": "INGESTED"
         }
       ],
-      "meta": {"meta_key": "meta_value"},
-      "statistics": {"statistics_key": "statistics_value"},
-      "evaluation_parameters": {"evaluation_parameters_key": "evaluation_parameters_value"},
+      "meta": "{\"meta_key\": \"meta_value\"}",
+      "statistics": "{ \"statistics_key\": \"statistics_value\" }",
+      "evaluation_parameters": "{\"evaluation_parameters_key\": \"evaluation_parameters_value\"}",
       "id": 11,
       "full_report_path": "test_full_report_path",
       "featurestore_id": "test_featurestore_id",
@@ -38,21 +39,22 @@
       "results": [
         {
           "success": true,
-          "result": {"result_key": "result_value"},
-          "exception_info": {"exception_info_key": "exception_info_value"},
-          "expectation_config": {"expectation_config_key": "expectation_config_value"},
-          "meta": {"meta_key": "meta_value"},
+          "result": "{\"result_key\": \"result_value\"}",
+          "exception_info": "{\"exception_info_key\": \"exception_info_value\"}",
+          "expectation_config": "{\"expectation_config_key\": \"expectation_config_value\"}",
+          "meta": "{\"meta_key\": \"meta_value\"}",
           "id": 11,
           "observed_value": "test_observed_value",
           "expectation_id": 22,
           "validation_report_id": 33,
           "href": "test_href",
           "expand": "test_expand",
-          "type": "validationResultDTO"
+          "type": "validationResultDTO",
+          "ingestion_result": "REJECTED"
         }
       ],
-      "meta": {"meta_key": "meta_value"},
-      "statistics": {"statistics_key": "statistics_value"}
+      "meta": "{ \"meta_key\": \"meta_value\" }",
+      "statistics": "{ \"statistics_key\": \"statistics_value\" }"
     }
   },
   "get_list": {
@@ -64,22 +66,23 @@
           "results": [
             {
               "success": true,
-              "result": {"result_key": "result_value"},
-              "exception_info": {"exception_info_key": "exception_info_value"},
-              "expectation_config": {"expectation_config_key": "expectation_config_value"},
-              "meta": {"meta_key": "meta_value"},
+              "result": "{\"result_key\": \"result_value\"}",
+              "exception_info": "{\"exception_info_key\": \"exception_info_value\"}",
+              "expectation_config": "{\"expectation_config_key\": \"expectation_config_value\"}",
+              "meta": "{\"meta_key\": \"meta_value\"}",
               "id": 11,
               "observed_value": "test_observed_value",
               "expectation_id": 22,
               "validation_report_id": 33,
               "href": "test_href",
               "expand": "test_expand",
-              "type": "validationResultDTO"
+              "type": "validationResultDTO",
+              "ingestion_result": "REJECTED"
             }
           ],
-          "meta": {"meta_key": "meta_value"},
-          "statistics": {"statistics_key": "statistics_value"},
-          "evaluation_parameters": {"evaluation_parameters_key": "evaluation_parameters_value"},
+          "meta": "{\"meta_key\": \"meta_value\"}",
+          "statistics": "{ \"statistics_key\": \"statistics_value\" }",
+          "evaluation_parameters": "{\"evaluation_parameters_key\": \"evaluation_parameters_value\"}",
           "id": 11,
           "full_report_path": "test_full_report_path",
           "featurestore_id": "test_featurestore_id",

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -57,7 +57,9 @@ class TestFeatureGroup:
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
         assert fg.event_time is None
         assert fg.stream is False
-        assert fg.expectation_suite is None
+        assert (
+            fg.expectation_suite.expectation_suite_name == "test_expectation_suite_name"
+        )
 
     def test_from_response_json_list(self, backend_fixtures):
         # Arrange
@@ -92,7 +94,9 @@ class TestFeatureGroup:
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
         assert fg.event_time is None
         assert fg.stream is False
-        assert fg.expectation_suite is None
+        assert (
+            fg.expectation_suite.expectation_suite_name == "test_expectation_suite_name"
+        )
 
     def test_from_response_json_basic_info(self, backend_fixtures):
         # Arrange
@@ -154,7 +158,9 @@ class TestFeatureGroup:
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
         assert fg.event_time is None
         assert fg.stream is True
-        assert fg.expectation_suite is None
+        assert (
+            fg.expectation_suite.expectation_suite_name == "test_expectation_suite_name"
+        )
 
     def test_from_response_json_stream_list(self, backend_fixtures):
         # Arrange
@@ -189,7 +195,9 @@ class TestFeatureGroup:
         assert fg._online_topic_name == "119_15_fg_test_1_onlinefs"
         assert fg.event_time is None
         assert fg.stream is True
-        assert fg.expectation_suite is None
+        assert (
+            fg.expectation_suite.expectation_suite_name == "test_expectation_suite_name"
+        )
 
     def test_from_response_json_stream_basic_info(self, backend_fixtures):
         # Arrange

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -76,5 +76,4 @@ class TestUtil:
             util.get_timestamp_from_date_string("202-13-01 00:00:00")
 
     def test_convert_event_time_to_timestamp_yyyy_mm_dd_hh_mm_ss_error3(self):
-        with pytest.raises(ValueError):
-            util.get_timestamp_from_date_string("00:00:00 2022-01-01")
+        util.get_timestamp_from_date_string("00:00:00 2022-01-01")


### PR DESCRIPTION
This PR adds the possibility to query the validation history associated with an expectation by calling fg.get_validation_history(expectationId)

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
