### PR TITLE
[FSTORE-427] Fix fsspec version

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -55,12 +55,16 @@ setup(
         ],
         "hive": [
             "pyhopshive[thrift]",
+            # Pin gcsfs version since there is a bug in fsspec which gcsfs depends on in newer version: https://github.com/fsspec/filesystem_spec/pull/1103
+            "gcsfs==2022.7.1",
             "pyarrow",
             "confluent-kafka==1.8.2",
             "fastavro==1.4.11",
         ],
         "python": [
             "pyhopshive[thrift]",
+            # Pin gcsfs version since there is a bug in fsspec which gcsfs depends on in newer version: https://github.com/fsspec/filesystem_spec/pull/1103
+            "gcsfs==2022.7.1",
             "pyarrow",
             "confluent-kafka==1.8.2",
             "fastavro==1.4.11",


### PR DESCRIPTION
Pin gcsfs version to 2022.7.1

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
