### PR TITLE
[FSTORE-333] Hudi should use HMS hive sync instead of jdbc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ target/
 
 # mkdocs intemediate files
 docs/generated
+
+# Test artifacts
+keyFile.json

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/HudiEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/HudiEngine.java
@@ -75,8 +75,9 @@ public class HudiEngine {
   protected static final String HUDI_HIVE_SYNC_ENABLE = "hoodie.datasource.hive_sync.enable";
   protected static final String HUDI_HIVE_SYNC_TABLE = "hoodie.datasource.hive_sync.table";
   protected static final String HUDI_HIVE_SYNC_DB = "hoodie.datasource.hive_sync.database";
-  protected static final String HUDI_HIVE_SYNC_JDBC_URL =
-      "hoodie.datasource.hive_sync.jdbcurl";
+  protected static final String HUDI_HIVE_SYNC_MODE =
+      "hoodie.datasource.hive_sync.mode";
+  protected static final String HUDI_HIVE_SYNC_MODE_VAL = "hms";
   protected static final String HUDI_HIVE_SYNC_PARTITION_FIELDS =
       "hoodie.datasource.hive_sync.partition_fields";
   protected static final String HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY =
@@ -245,8 +246,8 @@ public class HudiEngine {
 
     // Hive args
     hudiArgs.put(HUDI_HIVE_SYNC_ENABLE, "true");
+    hudiArgs.put(HUDI_HIVE_SYNC_MODE, HUDI_HIVE_SYNC_MODE_VAL);
     hudiArgs.put(HUDI_HIVE_SYNC_TABLE, tableName);
-    hudiArgs.put(HUDI_HIVE_SYNC_JDBC_URL, utils.getHiveServerConnection(featureGroup));
     hudiArgs.put(HUDI_HIVE_SYNC_DB, featureGroup.getFeatureStore().getName());
     hudiArgs.put(HIVE_AUTO_CREATE_DATABASE_OPT_KEY, HIVE_AUTO_CREATE_DATABASE_OPT_VAL);
     hudiArgs.put(HUDI_HIVE_SYNC_SUPPORT_TIMESTAMP, "true");

--- a/python/tests/core/test_hudi_engine.py
+++ b/python/tests/core/test_hudi_engine.py
@@ -179,9 +179,6 @@ class TestHudiEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_hudi_engine_get_conn_str = mocker.patch(
-            "hsfs.core.hudi_engine.HudiEngine._get_conn_str"
-        )
 
         fg = feature_group.FeatureGroup(
             name="test",
@@ -200,8 +197,6 @@ class TestHudiEngine:
             spark_session=None,
         )
 
-        mock_hudi_engine_get_conn_str.return_value = "test_conn_str"
-
         # Act
         result = h_engine._setup_hudi_write_opts(
             operation="test", write_options={"test_name": "test_value"}
@@ -212,7 +207,7 @@ class TestHudiEngine:
             "hoodie.bulkinsert.shuffle.parallelism": "5",
             "hoodie.datasource.hive_sync.database": None,
             "hoodie.datasource.hive_sync.enable": "true",
-            "hoodie.datasource.hive_sync.jdbcurl": "test_conn_str",
+            "hoodie.datasource.hive_sync.mode": "hms",
             "hoodie.datasource.hive_sync.partition_extractor_class": "org.apache.hudi.hive.MultiPartKeysValueExtractor",
             "hoodie.datasource.hive_sync.partition_fields": "key3,key4",
             "hoodie.datasource.hive_sync.support_timestamp": "true",
@@ -233,9 +228,6 @@ class TestHudiEngine:
         feature_store_id = 99
 
         mocker.patch("hsfs.engine.get_type")
-        mock_hudi_engine_get_conn_str = mocker.patch(
-            "hsfs.core.hudi_engine.HudiEngine._get_conn_str"
-        )
 
         fg = feature_group.FeatureGroup(
             name="test",
@@ -255,8 +247,6 @@ class TestHudiEngine:
             spark_session=None,
         )
 
-        mock_hudi_engine_get_conn_str.return_value = "test_conn_str"
-
         # Act
         result = h_engine._setup_hudi_write_opts(
             operation="test", write_options={"test_name": "test_value"}
@@ -267,7 +257,7 @@ class TestHudiEngine:
             "hoodie.bulkinsert.shuffle.parallelism": "5",
             "hoodie.datasource.hive_sync.database": None,
             "hoodie.datasource.hive_sync.enable": "true",
-            "hoodie.datasource.hive_sync.jdbcurl": "test_conn_str",
+            "hoodie.datasource.hive_sync.mode": "hms",
             "hoodie.datasource.hive_sync.partition_extractor_class": "org.apache.hudi.hive.MultiPartKeysValueExtractor",
             "hoodie.datasource.hive_sync.partition_fields": "key3,key4",
             "hoodie.datasource.hive_sync.support_timestamp": "true",
@@ -400,34 +390,3 @@ class TestHudiEngine:
         assert result.rows_updated == 3
         assert result.rows_deleted == 4
         assert result.commit_time == 5
-
-    def test_get_conn_str_connstr(self, mocker):
-        # Arrange
-        feature_store_id = 99
-
-        mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-
-        h_engine = hudi_engine.HudiEngine(
-            feature_store_id=feature_store_id,
-            feature_store_name=None,
-            feature_group=None,
-            spark_context=None,
-            spark_session=None,
-        )
-        h_engine._connstr = "test_url;"
-
-        mock_client_get_instance.return_value._get_jks_trust_store_path.return_value = (
-            "1"
-        )
-        mock_client_get_instance.return_value._cert_key = "2"
-        mock_client_get_instance.return_value._get_jks_key_store_path.return_value = "3"
-        mock_client_get_instance.return_value._cert_key = "4"
-
-        # Act
-        result = h_engine._get_conn_str()
-
-        # Assert
-        assert (
-            result
-            == "test_url;sslTrustStore=1;trustStorePassword=4;sslKeyStore=3;keyStorePassword=4"
-        )


### PR DESCRIPTION
Switching to connecting to the Hive Metastore instead of using the JDBC connection allows us to better handle certificates rotation. HiveServer2 through JDBC doesn't support application certificates, HMS does.

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
