### PR TITLE
[FSTORE-526] Made data type conversion an experimental feature

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -106,7 +106,13 @@ class Query:
         """
         sql_query, online_conn = self._prep_read(online, read_options)
 
-        schema = self._collect_features()
+        if "pandas_types" in read_options and read_options["pandas_types"]:
+            schema = self._collect_features()
+            for f in schema:
+                if f.type is None:
+                    raise ValueError(
+                        "Pandas types casting only supported for query.select_all()"
+                    )
 
         return engine.get_instance().sql(
             sql_query,

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -106,13 +106,13 @@ class Query:
         """
         sql_query, online_conn = self._prep_read(online, read_options)
 
+        schema = None
         if "pandas_types" in read_options and read_options["pandas_types"]:
             schema = self._collect_features()
-            for f in schema:
-                if f.type is None:
-                    raise ValueError(
-                        "Pandas types casting only supported for query.select_all()"
-                    )
+            if None in [f.type for f in schema]:
+                raise ValueError(
+                    "Pandas types casting only supported for query.select_all()"
+                )
 
         return engine.get_instance().sql(
             sql_query,

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -104,15 +104,15 @@ class Query:
         # Returns
             `DataFrame`: DataFrame depending on the chosen type.
         """
+        sql_query, online_conn = self._prep_read(online, read_options)
+
         schema = None
         if "pandas_types" in read_options and read_options["pandas_types"]:
             schema = self._collect_features()
-            if None in [f.type for f in schema]:
+            if len(self.joins) > 0 or None in [f.type for f in schema]:
                 raise ValueError(
                     "Pandas types casting only supported for feature_group.read()/query.select_all()"
                 )
-
-        sql_query, online_conn = self._prep_read(online, read_options)
 
         return engine.get_instance().sql(
             sql_query,

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -104,15 +104,15 @@ class Query:
         # Returns
             `DataFrame`: DataFrame depending on the chosen type.
         """
-        sql_query, online_conn = self._prep_read(online, read_options)
-
         schema = None
         if "pandas_types" in read_options and read_options["pandas_types"]:
             schema = self._collect_features()
             if None in [f.type for f in schema]:
                 raise ValueError(
-                    "Pandas types casting only supported for query.select_all()"
+                    "Pandas types casting only supported for feature_group.read()/query.select_all()"
                 )
+
+        sql_query, online_conn = self._prep_read(online, read_options)
 
         return engine.get_instance().sql(
             sql_query,

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -365,22 +365,14 @@ class FeatureViewEngine:
             result = {}
             for split in splits:
                 path = training_data_obj.location + "/" + str(split.name)
-                result[split.name] = self._cast_columns(
-                    training_data_obj.data_format,
-                    self._read_dir_from_storage_connector(
-                        training_data_obj, path, read_options
-                    ),
-                    schema,
+                result[split.name] = self._read_dir_from_storage_connector(
+                    training_data_obj, path, read_options
                 )
             return result
         else:
             path = training_data_obj.location + "/" + training_data_obj.name
-            return self._cast_columns(
-                training_data_obj.data_format,
-                self._read_dir_from_storage_connector(
-                    training_data_obj, path, read_options
-                ),
-                schema,
+            return self._read_dir_from_storage_connector(
+                training_data_obj, path, read_options
             )
 
     def _cast_columns(self, data_format, df, schema):

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1042,13 +1042,14 @@ class Engine:
                 if (x is not None and x != "")
                 else None
             ).astype(pd.BooleanDtype())
+        elif offline_type == "string":
+            return feature_column.apply(lambda x: str(x) if x is not None else None)
         elif offline_type.startswith("decimal"):
             return feature_column.apply(
                 lambda x: decimal.Decimal(x) if (x is not None) else None
             )
         else:
             offline_dtype_mapping = {
-                "string": np.dtype("str"),
                 "bigint": pd.Int64Dtype(),
                 "int": pd.Int32Dtype(),
                 "smallint": pd.Int16Dtype(),
@@ -1073,7 +1074,7 @@ class Engine:
         elif online_type == "date":
             return pd.to_datetime(feature_column, utc=True).dt.date
         elif online_type.startswith("varchar") or online_type == "text":
-            return feature_column.astype(np.dtype("str"))
+            return feature_column.apply(lambda x: str(x) if x is not None else None)
         elif online_type == "boolean":
             return feature_column.apply(
                 lambda x: (ast.literal_eval(x) if type(x) is str else x)

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -60,7 +60,6 @@ from hsfs.client import exceptions, hopsworks
 from hsfs.feature_group import FeatureGroup
 from thrift.transport.TTransport import TTransportException
 from pyhive.exc import OperationalError
-from hsfs.engine.spark import Engine as SparkEngine
 
 HAS_FAST = False
 try:
@@ -762,11 +761,8 @@ class Engine:
             dataset[feature_name] = dataset[feature_name].map(
                 transformation_fn.transformation_fn
             )
-            offline_type = SparkEngine.convert_spark_type_to_offline_type(
-                SparkEngine.convert_spark_type_string_to_spark_type(
-                    transformation_fn.output_type
-                ),
-                True,
+            offline_type = Engine.convert_spark_type_to_offline_type(
+                transformation_fn.output_type
             )
             dataset[feature_name] = Engine._cast_column_to_offline_type(
                 dataset[feature_name], offline_type
@@ -954,6 +950,35 @@ class Engine:
             return Engine._convert_pandas_object_type_to_offline_type(arrow_type)
 
         return Engine._convert_simple_pandas_dtype_to_offline_type(dtype)
+
+    @staticmethod
+    def convert_spark_type_to_offline_type(spark_type_string):
+        if spark_type_string == "STRING":
+            return "STRING"
+        elif spark_type_string == "BINARY":
+            return "BINARY"
+        elif spark_type_string == "BYTE":
+            return "INT"
+        elif spark_type_string == "SHORT":
+            return "INT"
+        elif spark_type_string == "INT":
+            return "INT"
+        elif spark_type_string == "LONG":
+            return "BIGINT"
+        elif spark_type_string == "FLOAT":
+            return "FLOAT"
+        elif spark_type_string == "DOUBLE":
+            return "DOUBLE"
+        elif spark_type_string == "TIMESTAMP":
+            return "TIMESTAMP"
+        elif spark_type_string == "DATE":
+            return "DATE"
+        elif spark_type_string == "BOOLEAN":
+            return "BOOLEAN"
+        else:
+            raise ValueError(
+                f"Return type {spark_type_string} not supported for transformation functions."
+            )
 
     @staticmethod
     def _convert_simple_pandas_dtype_to_offline_type(dtype):

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -1086,6 +1086,8 @@ class Engine:
                     StructField("index", IntegerType(), True),
                 ]
             )
+        elif offline_type.startswith("decimal"):
+            return DecimalType()
         else:
             offline_type_spark_type_mapping = {
                 "string": StringType(),
@@ -1099,7 +1101,6 @@ class Engine:
                 "boolean": BooleanType(),
                 "date": DateType(),
                 "binary": BinaryType(),
-                "decimal": DecimalType(),
             }
             if offline_type in offline_type_spark_type_mapping:
                 return offline_type_spark_type_mapping[offline_type]

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -1015,35 +1015,6 @@ class Engine:
         return [field[feature_name] for field in unique_values]
 
     @staticmethod
-    def convert_spark_type_string_to_spark_type(spark_type_string):
-        if spark_type_string == "STRING":
-            return StringType()
-        elif spark_type_string == "BINARY":
-            return BooleanType()
-        elif spark_type_string == "BYTE":
-            return ByteType()
-        elif spark_type_string == "SHORT":
-            return ShortType()
-        elif spark_type_string == "INT":
-            return IntegerType()
-        elif spark_type_string == "LONG":
-            return LongType()
-        elif spark_type_string == "FLOAT":
-            return FloatType()
-        elif spark_type_string == "DOUBLE":
-            return DoubleType()
-        elif spark_type_string == "TIMESTAMP":
-            return TimestampType()
-        elif spark_type_string == "DATE":
-            return DateType()
-        elif spark_type_string == "BOOLEAN":
-            return BooleanType()
-        else:
-            raise ValueError(
-                f"Spark type {str(type(spark_type_string))} not supported."
-            )
-
-    @staticmethod
     def convert_spark_type_to_offline_type(spark_type, using_hudi):
         # The HiveSyncTool is strict and does not support schema evolution from tinyint/short to
         # int. Avro, on the other hand, does not support tinyint/short and delivers them as int

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1270,6 +1270,10 @@ class FeatureGroup(FeatureGroupBase):
             dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
                 `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
             read_options: Additional read options as key/value pairs, defaults to `{}`.
+                Only for Python engine: Set `read_options={"pandas_types": True}`
+                to retrieve columns as Pandas nullable types
+                rather than numpy/object(string) types (experimental).
+                (see https://pandas.pydata.org/docs/user_guide/integer_na.html).
 
         # Returns
             `DataFrame`: The spark dataframe containing the feature data.

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -308,7 +308,7 @@ class FeatureView:
 
     def get_feature_vector(
         self,
-        entry: List[Dict[str, Any]],
+        entry: Dict[str, Any],
         passed_features: Optional[Dict[str, Any]] = {},
         external: Optional[bool] = None,
     ):


### PR DESCRIPTION
This PR adds/fixes/changes...
- revokes automatic type conversions for csv files (now that .parquet is default tds format, it is not essential)
- revokes automatic type conversions for reading sql / jdbc 
- adds flag to activate experimental type casting for fg.read() (read_options={"pandas_types":True})
- removed dependency between python and spark engine
- small fixes

JIRA Issue: FSTORE-526

Priority for Review: -

Related PRs: https://github.com/logicalclocks/logicalclocks.github.io/pull/160, https://github.com/logicalclocks/loadtest/pull/37

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
