### PR TITLE
[FSTORE-526] changed nullable boolean type

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -829,6 +829,8 @@ class Engine:
                     row[k] = row[k].to_pydatetime()
                 if isinstance(row[k], datetime) and row[k].tzinfo is None:
                     row[k] = row[k].replace(tzinfo=timezone.utc)
+                if isinstance(row[k], pd._libs.missing.NAType):
+                    row[k] = None
 
             # encode complex features
             row = self._encode_complex_features(feature_writers, row)
@@ -1017,8 +1019,6 @@ class Engine:
                 return "int"
             elif dtype == pd.Int64Dtype():
                 return "bigint"
-            elif dtype == pd.BooleanDtype():
-                return "boolean"
 
         raise ValueError(f"dtype '{dtype}' not supported")
 
@@ -1044,6 +1044,8 @@ class Engine:
             return "binary"
         elif pa.types.is_string(arrow_type) or pa.types.is_unicode(arrow_type):
             return "string"
+        elif pa.types.is_boolean(arrow_type):
+            return "boolean"
 
         raise ValueError(f"dtype 'O' (arrow_type '{str(arrow_type)}') not supported")
 
@@ -1066,7 +1068,7 @@ class Engine:
                 lambda x: (ast.literal_eval(x) if type(x) is str else x)
                 if (x is not None and x != "")
                 else None
-            ).astype(pd.BooleanDtype())
+            )
         elif offline_type == "string":
             return feature_column.apply(lambda x: str(x) if x is not None else None)
         elif offline_type.startswith("decimal"):
@@ -1105,7 +1107,7 @@ class Engine:
                 lambda x: (ast.literal_eval(x) if type(x) is str else x)
                 if (x is not None and x != "")
                 else None
-            ).astype(pd.BooleanDtype())
+            )
         elif online_type.startswith("decimal"):
             return feature_column.apply(
                 lambda x: decimal.Decimal(x) if (x is not None) else None


### PR DESCRIPTION
This PR adds/fixes/changes...
- switches tfrom usig pd.BooleanDtype to object(boolen) to support nullable booleans

JIRA Issue: FSTORE-526

Priority for Review: -

Related PRs: [-](https://github.com/logicalclocks/logicalclocks.github.io/pull/160)

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [s] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
