### PR TITLE
[FSTORE-538] Redshift connector read throws validation error for query argument inspite of table name specified on connector

### DIFF
--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -153,6 +153,28 @@ class TestRedshiftConnector:
         assert sc.arguments is None
         assert sc.expiration is None
 
+    def test_read_query_option(self, mocker):
+        sc = storage_connector.RedshiftConnector(
+            id=1,
+            name="redshiftconn",
+            featurestore_id=1,
+            table_name="abc",
+            cluster_identifier="cluster",
+            database_endpoint="us-east-2",
+            database_port=5439,
+            database_name="db",
+        )
+
+        mocker.patch("hsfs.engine.get_instance", return_value=spark.Engine())
+        mocker.patch("hsfs.core.storage_connector_api.StorageConnectorApi.refetch")
+        mock_engine_read = mocker.patch("hsfs.engine.spark.Engine.read")
+
+        query = "select * from table"
+        sc.read(query=query)
+
+        assert mock_engine_read.call_args[0][2].get("dbtable", None) is None
+        assert mock_engine_read.call_args[0][2].get("query") == query
+
 
 class TestAdlsConnector:
     def test_from_response_json(self, backend_fixtures):


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
