### PR TITLE
[FSTORE-542][FSTORE-548] Enable python client 3.1 to app 3.0 compatibility for data validation api

### DIFF
--- a/python/hsfs/core/expectation_suite_api.py
+++ b/python/hsfs/core/expectation_suite_api.py
@@ -17,6 +17,7 @@
 from typing import Optional
 from hsfs import client
 from hsfs import expectation_suite as es
+from hsfs.core import variable_api
 
 
 class ExpectationSuiteApi:
@@ -50,10 +51,18 @@ class ExpectationSuiteApi:
             "expectationsuite",
         ]
 
+        _, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+
+        method = "POST"
+        if minor == "0":
+            method = "PUT"
+
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
         return es.ExpectationSuite.from_response_json(
-            _client._send_request("POST", path_params, headers=headers, data=payload)
+            _client._send_request(method, path_params, headers=headers, data=payload)
         )
 
     def update(self, expectation_suite: es.ExpectationSuite) -> es.ExpectationSuite:
@@ -78,8 +87,17 @@ class ExpectationSuiteApi:
 
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
+
+        _, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        method = "PUT"
+        if minor == "0":
+            method = "POST"
+            del path_params[-1]
+
         return es.ExpectationSuite.from_response_json(
-            _client._send_request("PUT", path_params, headers=headers, data=payload)
+            _client._send_request(method, path_params, headers=headers, data=payload)
         )
 
     def update_metadata(
@@ -107,8 +125,18 @@ class ExpectationSuiteApi:
 
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
+
+        _, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        method = "PUT"
+        if minor == "0":
+            method = "POST"
+            del path_params[-1]
+            del path_params[-1]
+
         return es.ExpectationSuite.from_response_json(
-            _client._send_request("PUT", path_params, headers=headers, data=payload)
+            _client._send_request(method, path_params, headers=headers, data=payload)
         )
 
     def delete(self, expectation_suite_id: int) -> None:
@@ -124,6 +152,12 @@ class ExpectationSuiteApi:
             "expectationsuite",
             expectation_suite_id,
         ]
+
+        _, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if minor == "0":
+            del path_params[-1]
 
         _client._send_request("DELETE", path_params)
 

--- a/python/hsfs/core/expectation_suite_api.py
+++ b/python/hsfs/core/expectation_suite_api.py
@@ -51,12 +51,11 @@ class ExpectationSuiteApi:
             "expectationsuite",
         ]
 
-        _, minor = variable_api.parse_major_and_minor(
+        major, minor = variable_api.parse_major_and_minor(
             variable_api.get_version("hopsworks")
         )
-
         method = "POST"
-        if minor == "0":
+        if major == "3" and minor == "0":
             method = "PUT"
 
         headers = {"content-type": "application/json"}
@@ -88,11 +87,11 @@ class ExpectationSuiteApi:
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
 
-        _, minor = variable_api.parse_major_and_minor(
+        major, minor = variable_api.parse_major_and_minor(
             variable_api.get_version("hopsworks")
         )
         method = "PUT"
-        if minor == "0":
+        if major == "3" and minor == "0":
             method = "POST"
             del path_params[-1]
 
@@ -126,11 +125,11 @@ class ExpectationSuiteApi:
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
 
-        _, minor = variable_api.parse_major_and_minor(
+        major, minor = variable_api.parse_major_and_minor(
             variable_api.get_version("hopsworks")
         )
         method = "PUT"
-        if minor == "0":
+        if major == "3" and minor == "0":
             method = "POST"
             del path_params[-1]
             del path_params[-1]
@@ -153,10 +152,10 @@ class ExpectationSuiteApi:
             expectation_suite_id,
         ]
 
-        _, minor = variable_api.parse_major_and_minor(
+        major, minor = variable_api.parse_major_and_minor(
             variable_api.get_version("hopsworks")
         )
-        if minor == "0":
+        if major == "3" and minor == "0":
             del path_params[-1]
 
         _client._send_request("DELETE", path_params)

--- a/python/hsfs/core/expectation_suite_api.py
+++ b/python/hsfs/core/expectation_suite_api.py
@@ -17,7 +17,7 @@
 from typing import Optional
 from hsfs import client
 from hsfs import expectation_suite as es
-from hsfs.core import variable_api
+from hsfs.core.variable_api import VariableApi
 
 
 class ExpectationSuiteApi:
@@ -51,8 +51,8 @@ class ExpectationSuiteApi:
             "expectationsuite",
         ]
 
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         method = "POST"
         if major == "3" and minor == "0":
@@ -87,8 +87,8 @@ class ExpectationSuiteApi:
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
 
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         method = "PUT"
         if major == "3" and minor == "0":
@@ -125,8 +125,8 @@ class ExpectationSuiteApi:
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
 
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         method = "PUT"
         if major == "3" and minor == "0":
@@ -152,8 +152,8 @@ class ExpectationSuiteApi:
             expectation_suite_id,
         ]
 
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             del path_params[-1]

--- a/python/hsfs/core/expectation_suite_api.py
+++ b/python/hsfs/core/expectation_suite_api.py
@@ -31,6 +31,7 @@ class ExpectationSuiteApi:
         """
         self._feature_store_id = feature_store_id
         self._feature_group_id = feature_group_id
+        self._variable_api = VariableApi()
 
     def create(self, expectation_suite: es.ExpectationSuite) -> es.ExpectationSuite:
         """Create an expectation suite attached to a Feature Group.
@@ -51,8 +52,8 @@ class ExpectationSuiteApi:
             "expectationsuite",
         ]
 
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         method = "POST"
         if major == "3" and minor == "0":
@@ -87,8 +88,8 @@ class ExpectationSuiteApi:
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
 
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         method = "PUT"
         if major == "3" and minor == "0":
@@ -125,8 +126,8 @@ class ExpectationSuiteApi:
         headers = {"content-type": "application/json"}
         payload = expectation_suite.json()
 
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         method = "PUT"
         if major == "3" and minor == "0":
@@ -152,8 +153,8 @@ class ExpectationSuiteApi:
             expectation_suite_id,
         ]
 
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             del path_params[-1]

--- a/python/hsfs/core/expectation_suite_engine.py
+++ b/python/hsfs/core/expectation_suite_engine.py
@@ -84,7 +84,7 @@ class ExpectationSuiteEngine:
                 meta=meta,
                 feature_group_id=feature_group_id,
                 feature_store_id=feature_store_id,
-                expectations=[],
+                expectations=expectations,
             )
         )
 

--- a/python/hsfs/core/transformation_function_engine.py
+++ b/python/hsfs/core/transformation_function_engine.py
@@ -261,7 +261,7 @@ class TransformationFunctionEngine:
             return "TIMESTAMP"
         elif output_type in (datetime.date, "date"):
             return "DATE"
-        elif output_type in (bool, "boolean", "bool", numpy.bool):
+        elif output_type in (bool, "boolean", "bool"):
             return "BOOLEAN"
         else:
             raise TypeError("Not supported type %s." % output_type)

--- a/python/hsfs/core/validation_report_api.py
+++ b/python/hsfs/core/validation_report_api.py
@@ -17,6 +17,7 @@
 from typing import Union, List
 from hsfs import client
 from hsfs.validation_report import ValidationReport
+from hsfs.core import variable_api
 
 
 class ValidationReportApi:
@@ -51,8 +52,15 @@ class ValidationReportApi:
             "validationreport",
         ]
 
+        major, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if major == "3" and minor == "0":
+            validation_report.ingestion_result = None
+
         headers = {"content-type": "application/json"}
         payload = validation_report.json()
+
         return ValidationReport.from_response_json(
             _client._send_request("PUT", path_params, headers=headers, data=payload)
         )

--- a/python/hsfs/core/validation_report_api.py
+++ b/python/hsfs/core/validation_report_api.py
@@ -31,6 +31,7 @@ class ValidationReportApi:
         """
         self._feature_store_id = feature_store_id
         self._feature_group_id = feature_group_id
+        self._variable_api = VariableApi()
 
     def create(self, validation_report: ValidationReport) -> ValidationReport:
         """Create an validation report attached to a featuregroup.
@@ -52,8 +53,8 @@ class ValidationReportApi:
             "validationreport",
         ]
 
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             validation_report.ingestion_result = None

--- a/python/hsfs/core/validation_report_api.py
+++ b/python/hsfs/core/validation_report_api.py
@@ -17,7 +17,7 @@
 from typing import Union, List
 from hsfs import client
 from hsfs.validation_report import ValidationReport
-from hsfs.core import variable_api
+from hsfs.core.variable_api import VariableApi
 
 
 class ValidationReportApi:
@@ -52,8 +52,8 @@ class ValidationReportApi:
             "validationreport",
         ]
 
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             validation_report.ingestion_result = None

--- a/python/hsfs/core/validation_report_api.py
+++ b/python/hsfs/core/validation_report_api.py
@@ -57,7 +57,8 @@ class ValidationReportApi:
             self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
-            validation_report.ingestion_result = None
+            # You must bypass the setter otherwise it ends up as "UNKNOWN"
+            validation_report._ingestion_result = None
 
         headers = {"content-type": "application/json"}
         payload = validation_report.json()

--- a/python/hsfs/core/variable_api.py
+++ b/python/hsfs/core/variable_api.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-from hopsworks import client
+from hsfs import client
 import re
 
 

--- a/python/hsfs/core/variable_api.py
+++ b/python/hsfs/core/variable_api.py
@@ -38,7 +38,7 @@ class VariableApi:
 
     def parse_major_and_minor(self, backend_version):
 
-        versionPattern = r"\d+\.\d+"
-        regexMatcher = re.compile(versionPattern)
+        version_pattern = r"(\d+)\.(\d+)"
+        matches = re.match(version_pattern, backend_version)
 
-        return regexMatcher.search(backend_version).group(0)
+        return matches.group(1), matches.group(2)

--- a/python/hsfs/core/variable_api.py
+++ b/python/hsfs/core/variable_api.py
@@ -1,0 +1,44 @@
+#
+#   Copyright 2022 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+from hopsworks import client
+import re
+
+
+class VariableApi:
+    def __init__(self):
+        pass
+
+    def get_version(self, software: str):
+
+        _client = client.get_instance()
+        path_params = [
+            "variables",
+            "versions",
+        ]
+
+        resp = _client._send_request("GET", path_params)
+        for entry in resp:
+            if entry["software"] == software:
+                return entry["version"]
+        return None
+
+    def parse_major_and_minor(self, backend_version):
+
+        versionPattern = r"\d+\.\d+"
+        regexMatcher = re.compile(versionPattern)
+
+        return regexMatcher.search(backend_version).group(0)

--- a/python/hsfs/expectation_suite.py
+++ b/python/hsfs/expectation_suite.py
@@ -262,8 +262,10 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        _, minor = variable_api.get_version("hopsworks")
-        if minor == "0":
+        major, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if major == "3" and minor == "0":
             raise FeatureStoreException(
                 "The hopsworks server does not support this operation. Update server to hopsworks >3.1 to enable support."
             )
@@ -322,8 +324,10 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        _, minor = variable_api.get_version("hopsworks")
-        if minor == "0":
+        major, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if major == "3" and minor == "0":
             raise FeatureStoreException(
                 "The hopsworks server does not support this operation. Update server to hopsworks >3.1 to enable support."
             )
@@ -367,8 +371,10 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        _, minor = variable_api.get_version("hopsworks")
-        if minor == "0":
+        major, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if major == "3" and minor == "0":
             raise FeatureStoreException(
                 "The hopsworks server does not support this operation. Update server to hopsworks >3.1 to enable support."
             )
@@ -408,8 +414,10 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        _, minor = variable_api.get_version("hopsworks")
-        if minor == "0":
+        major, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if major == "3" and minor == "0":
             raise FeatureStoreException(
                 "The hopsworks server does not support this operation. Update server to hopsworks >3.1 to enable support."
             )

--- a/python/hsfs/expectation_suite.py
+++ b/python/hsfs/expectation_suite.py
@@ -71,6 +71,8 @@ class ExpectationSuite:
             self._feature_group_id = None
             self._feature_store_id = None
 
+        self._variable_api = VariableApi()
+
         # use setters because these need to be transformed from stringified json
         self.expectations = expectations
         self.meta = meta
@@ -263,8 +265,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(
@@ -325,8 +327,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(
@@ -372,8 +374,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(
@@ -415,8 +417,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(

--- a/python/hsfs/expectation_suite.py
+++ b/python/hsfs/expectation_suite.py
@@ -24,7 +24,8 @@ import re
 from hsfs import util
 from hsfs.ge_expectation import GeExpectation
 from hsfs.core.expectation_engine import ExpectationEngine
-from hsfs.core import expectation_suite_engine, variable_api
+from hsfs.core.variable_api import VariableApi
+from hsfs.core import expectation_suite_engine
 from hsfs.client.exceptions import FeatureStoreException
 
 
@@ -262,8 +263,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(
@@ -324,8 +325,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(
@@ -371,8 +372,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(
@@ -414,8 +415,8 @@ class ExpectationSuite:
             `RestAPIException`
             `hsfs.client.exceptions.FeatureStoreException`
         """
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -864,7 +864,7 @@ class FeatureGroupBase:
         ```python3
         validation_history = fg.get_validation_history(
             expectation_id=1,
-            fliter_by=["REJECTED", "UNKNOWN"],
+            filter_by=["REJECTED", "UNKNOWN"],
             start_validation_time="2022-01-01 00:00:00",
             end_validation_time=datetime.datetime.now(),
             ge_type=False

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -36,6 +36,7 @@ from hsfs.core import (
     code_engine,
     external_feature_group_engine,
     validation_result_engine,
+    variable_api,
 )
 
 from hsfs.statistics_config import StatisticsConfig
@@ -883,6 +884,12 @@ class FeatureGroupBase:
         # Return
             Union[List[`ValidationResult`], List[`ExpectationValidationResult`]] A list of validation result connected to the expectation_id
         """
+        _, minor = variable_api.get_version("hopsworks")
+        if minor == "0":
+            raise FeatureStoreException(
+                "The hopsworks server does not support this operation. Update server to hopsworks >3.1 to enable support."
+            )
+
         if self._id:
             return self._validation_result_engine.get_validation_history(
                 expectation_id=expectation_id,

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -884,8 +884,10 @@ class FeatureGroupBase:
         # Return
             Union[List[`ValidationResult`], List[`ExpectationValidationResult`]] A list of validation result connected to the expectation_id
         """
-        _, minor = variable_api.get_version("hopsworks")
-        if minor == "0":
+        major, minor = variable_api.parse_major_and_minor(
+            variable_api.get_version("hopsworks")
+        )
+        if major == "3" and minor == "0":
             raise FeatureStoreException(
                 "The hopsworks server does not support this operation. Update server to hopsworks >3.1 to enable support."
             )

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -60,6 +60,7 @@ class FeatureGroupBase:
             great_expectation_engine.GreatExpectationEngine(featurestore_id)
         )
         self._feature_store_id = featurestore_id
+        self._variable_api = VariableApi()
 
     def delete(self):
         """Drop the entire feature group along with its feature data.
@@ -884,8 +885,8 @@ class FeatureGroupBase:
         # Return
             Union[List[`ValidationResult`], List[`ExpectationValidationResult`]] A list of validation result connected to the expectation_id
         """
-        major, minor = VariableApi.parse_major_and_minor(
-            VariableApi.get_version("hopsworks")
+        major, minor = self._variable_api.parse_major_and_minor(
+            self._variable_api.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -36,7 +36,6 @@ from hsfs.core import (
     code_engine,
     external_feature_group_engine,
     validation_result_engine,
-    variable_api,
 )
 
 from hsfs.statistics_config import StatisticsConfig
@@ -45,6 +44,7 @@ from hsfs.validation_report import ValidationReport
 from hsfs.constructor import query, filter
 from hsfs.client.exceptions import FeatureStoreException
 from hsfs.core.job import Job
+from hsfs.core.variable_api import VariableApi
 from hsfs.core import great_expectation_engine
 
 
@@ -884,8 +884,8 @@ class FeatureGroupBase:
         # Return
             Union[List[`ValidationResult`], List[`ExpectationValidationResult`]] A list of validation result connected to the expectation_id
         """
-        major, minor = variable_api.parse_major_and_minor(
-            variable_api.get_version("hopsworks")
+        major, minor = VariableApi.parse_major_and_minor(
+            VariableApi.get_version("hopsworks")
         )
         if major == "3" and minor == "0":
             raise FeatureStoreException(

--- a/python/hsfs/validation_report.py
+++ b/python/hsfs/validation_report.py
@@ -17,6 +17,7 @@
 import json
 
 import humps
+from typing import Optional
 import great_expectations as ge
 
 from hsfs import util
@@ -203,8 +204,10 @@ class ValidationReport:
         return self._ingestion_result
 
     @ingestion_result.setter
-    def ingestion_result(self, ingestion_result: str):
+    def ingestion_result(self, ingestion_result: Optional[str]):
         allowed_values = ["INGESTED", "REJECTED", "UNKNOWN", "EXPERIMENT", "FG_DATA"]
+        if ingestion_result is None:
+            ingestion_result = "UNKNOWN"
         if ingestion_result.upper() in allowed_values:
             self._ingestion_result = ingestion_result
         else:

--- a/python/tests/core/test_transformation_function_engine.py
+++ b/python/tests/core/test_transformation_function_engine.py
@@ -1049,20 +1049,6 @@ class TestTransformationFunctionEngine:
         )
 
         # Act
-        result = tf_engine.infer_spark_type(numpy.int)
-
-        # Assert
-        assert result == "INT"
-
-    def test_infer_spark_type_int_type_4(self):
-        # Arrange
-        feature_store_id = 99
-
-        tf_engine = transformation_function_engine.TransformationFunctionEngine(
-            feature_store_id
-        )
-
-        # Act
         result = tf_engine.infer_spark_type(numpy.int32)
 
         # Assert
@@ -1148,20 +1134,6 @@ class TestTransformationFunctionEngine:
 
         # Act
         result = tf_engine.infer_spark_type("float")
-
-        # Assert
-        assert result == "FLOAT"
-
-    def test_infer_spark_type_float_type_3(self):
-        # Arrange
-        feature_store_id = 99
-
-        tf_engine = transformation_function_engine.TransformationFunctionEngine(
-            feature_store_id
-        )
-
-        # Act
-        result = tf_engine.infer_spark_type(numpy.float)
 
         # Assert
         assert result == "FLOAT"
@@ -1288,20 +1260,6 @@ class TestTransformationFunctionEngine:
 
         # Act
         result = tf_engine.infer_spark_type("bool")
-
-        # Assert
-        assert result == "BOOLEAN"
-
-    def test_infer_spark_type_bool_type_4(self):
-        # Arrange
-        feature_store_id = 99
-
-        tf_engine = transformation_function_engine.TransformationFunctionEngine(
-            feature_store_id
-        )
-
-        # Act
-        result = tf_engine.infer_spark_type(numpy.bool)
 
         # Assert
         assert result == "BOOLEAN"

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -16,7 +16,7 @@
 
 import pytest
 import pandas as pd
-import numpy as np
+import numpy
 from pyspark.sql.types import (
     ByteType,
     ShortType,
@@ -390,7 +390,7 @@ class TestSpark:
 
         # Act
         result = spark_engine.convert_to_default_dataframe(
-            dataframe=np.array([[1, "test_1"], [2, "test_2"]]),
+            dataframe=numpy.array([[1, "test_1"], [2, "test_2"]]),
         )
 
         # Assert


### PR DESCRIPTION
This PR also remove deprecated np.int, np.float and np.bool from TransformationFunctionEngine infer_spark_type

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
