### PR TITLE
[3.1][FSTORE-639] Adjust for sqlalchemy 2.0.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs</artifactId>
-    <version>3.1.0-RC0</version>
+    <version>3.1.0-RC1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -176,7 +176,7 @@ class VectorServer:
 
                 for row in result_proxy:
                     result_dict = self.deserialize_complex_features(
-                        self._complex_features, dict(row.items())
+                        self._complex_features, row._asdict()
                     )
                     if not result_dict:
                         raise Exception(
@@ -221,13 +221,13 @@ class VectorServer:
 
                 result_proxy = mysql_conn.execute(
                     prepared_statement,
-                    batch_ids=entry_values_tuples,
+                    {"batch_ids": entry_values_tuples},
                 ).fetchall()
 
                 statement_results = []
                 for row in result_proxy:
                     result_dict = self.deserialize_complex_features(
-                        self._complex_features, dict(row.items())
+                        self._complex_features, row._asdict()
                     )
 
                     if not result_dict:

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -39,6 +39,7 @@ from typing import TypeVar, Optional, Dict, Any
 from confluent_kafka import Producer, KafkaError
 from tqdm.auto import tqdm
 from botocore.response import StreamingBody
+from sqlalchemy import sql
 
 from hsfs import client, feature, util
 from hsfs.client.exceptions import FeatureStoreException
@@ -114,7 +115,7 @@ class Engine:
                 ),
             )
         with self._mysql_online_fs_engine.connect() as mysql_conn:
-            result_df = pd.read_sql(sql_query, mysql_conn)
+            result_df = pd.read_sql(sql.text(sql_query), mysql_conn)
             if schema:
                 result_df = Engine.cast_columns(result_df, schema, online=True)
         return self._return_dataframe_type(result_df, dataframe_type)

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.1.0rc0"
+__version__ = "3.1.0rc1"

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -110,12 +110,13 @@ class TestPython:
         mock_python_engine_return_dataframe_type = mocker.patch(
             "hsfs.engine.python.Engine._return_dataframe_type"
         )
+        query = "SELECT * FROM TABLE"
 
         python_engine = python.Engine()
 
         # Act
         python_engine._jdbc(
-            sql_query=None, connector=None, dataframe_type=None, read_options={}
+            sql_query=query, connector=None, dataframe_type=None, read_options={}
         )
 
         # Assert
@@ -130,12 +131,13 @@ class TestPython:
         mock_python_engine_return_dataframe_type = mocker.patch(
             "hsfs.engine.python.Engine._return_dataframe_type"
         )
+        query = "SELECT * FROM TABLE"
 
         python_engine = python.Engine()
 
         # Act
         python_engine._jdbc(
-            sql_query=None,
+            sql_query=query,
             connector=None,
             dataframe_type=None,
             read_options={"external": ""},

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.1.0-RC0</version>
+    <version>3.1.0-RC1</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>


### PR DESCRIPTION
This PR adds/fixes/changes...

the new sql alchemy version introduced new APIs, since the previous version was already forward compatible, we don't need to pin the version, but instead make hsfs work with both sqlalchemy 1.4.46 and 2.0.0 until pandas upgrades.

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```


[FSTORE-555]: https://hopsworks.atlassian.net/browse/FSTORE-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSTORE-556]: https://hopsworks.atlassian.net/browse/FSTORE-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSTORE-589]: https://hopsworks.atlassian.net/browse/FSTORE-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FSTORE-639]: https://hopsworks.atlassian.net/browse/FSTORE-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ