### PR TITLE
[FSTORE-682] fix fg.save expectation suite

### DIFF
--- a/python/hsfs/expectation_suite.py
+++ b/python/hsfs/expectation_suite.py
@@ -137,8 +137,8 @@ class ExpectationSuite:
             "validationIngestionPolicy": self._validation_ingestion_policy,
         }
 
-    def to_json_dict(self) -> dict:
-        return {
+    def to_json_dict(self, decamelize=False) -> dict:
+        the_dict = {
             "id": self._id,
             "expectationSuiteName": self._expectation_suite_name,
             "expectations": [
@@ -150,6 +150,11 @@ class ExpectationSuite:
             "runValidation": self._run_validation,
             "validationIngestionPolicy": self._validation_ingestion_policy,
         }
+
+        if decamelize:
+            return humps.decamelize(the_dict)
+        else:
+            return the_dict
 
     def json(self) -> str:
         return json.dumps(self, cls=util.FeatureStoreEncoder)
@@ -167,7 +172,7 @@ class ExpectationSuite:
 
     def _init_feature_store_and_feature_group_ids_from_href(self, href: str) -> None:
         feature_store_id, feature_group_id = re.search(
-            r"\/featurestores\/([0-9]+)\/featuregroups\/([0-9]+)\/expectationsuite*",
+            r"\/featurestores\/(\d+)\/featuregroups\/(\d+)\/expectationsuite*",
             href,
         ).groups(0)
         self._feature_store_id = int(feature_store_id)

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -656,7 +656,7 @@ class FeatureGroupBase:
 
     def get_expectation_suite(
         self, ge_type: bool = True
-    ) -> Union[ExpectationSuite, ge.core.ExpectationSuite]:
+    ) -> Union[ExpectationSuite, ge.core.ExpectationSuite, None]:
         """Return the expectation suite attached to the feature group if it exists.
 
         !!! example
@@ -773,7 +773,7 @@ class FeatureGroupBase:
         # Raises
             `hsfs.client.exceptions.RestAPIError`.
         """
-        if self._expectation_suite.id:
+        if self.get_expectation_suite() is not None:
             self._expectation_suite_engine.delete(self._expectation_suite.id)
         self._expectation_suite = None
 

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -733,7 +733,7 @@ class FeatureGroupBase:
                 feature_group_id=self._id,
             )
         elif isinstance(expectation_suite, ExpectationSuite):
-            tmp_expectation_suite = expectation_suite.to_json_dict()
+            tmp_expectation_suite = expectation_suite.to_json_dict(decamelize=True)
             tmp_expectation_suite["featuregroup_id"] = self._id
             tmp_expectation_suite["featurestore_id"] = self._feature_store_id
             tmp_expectation_suite = ExpectationSuite(**tmp_expectation_suite)

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -734,8 +734,8 @@ class FeatureGroupBase:
             )
         elif isinstance(expectation_suite, ExpectationSuite):
             tmp_expectation_suite = expectation_suite.to_json_dict(decamelize=True)
-            tmp_expectation_suite["featuregroup_id"] = self._id
-            tmp_expectation_suite["featurestore_id"] = self._feature_store_id
+            tmp_expectation_suite["feature_group_id"] = self._id
+            tmp_expectation_suite["feature_store_id"] = self._feature_store_id
             tmp_expectation_suite = ExpectationSuite(**tmp_expectation_suite)
         else:
             raise TypeError(

--- a/python/hsfs/ge_expectation.py
+++ b/python/hsfs/ge_expectation.py
@@ -74,13 +74,18 @@ class GeExpectation:
             "meta": json.dumps(self._meta),
         }
 
-    def to_json_dict(self) -> Dict[str, Any]:
-        return {
+    def to_json_dict(self, decamelize=False) -> Dict[str, Any]:
+        the_dict = {
             "id": self._id,
             "expectationType": self._expectation_type,
             "kwargs": self._kwargs,
             "meta": self._meta,
         }
+
+        if decamelize:
+            return humps.decamelize(the_dict)
+        else:
+            return the_dict
 
     def json(self) -> str:
         return json.dumps(self, cls=util.FeatureStoreEncoder)

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -420,13 +420,13 @@ class TestExternalFeatureGroup:
 
         # to mock delete we need get_expectation_suite to not return none
         mock_get_expectation_suite_api = mocker.patch(
-            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.get"
+            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.get",
+            return_value=es,
         )
-        mock_get_expectation_suite_api.return_value = es
         mock_create_expectation_suite_api = mocker.patch(
-            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.create"
+            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.create",
+            return_value=es,
         )
-        mock_create_expectation_suite_api.return_value = es
         mock_delete_expectation_suite_api = mocker.patch(
             "hsfs.core.expectation_suite_api.ExpectationSuiteApi.delete"
         )


### PR DESCRIPTION
Save expectation suite was failing with hopsworks object instead of GE object. Added unittest to ensure proper working, loadtest was also amended to go through the smart update code branch (both python and backend)

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
