### PR TITLE
[FSTORE-689] Shallow dataframe copy hides TZ bug

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -382,15 +382,17 @@ class Engine:
                     util.FeatureGroupWarning,
                 )
 
+            # make shallow copy so the original df does not get changed
+            dataframe_copy = dataframe.copy(deep=False)
+
             # convert timestamps with timezone to UTC
             for col in dataframe.columns:
                 if isinstance(
-                    dataframe[col].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
+                    dataframe_copy[col].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
                 ):
-                    dataframe[col] = dataframe[col].dt.tz_convert(None)
+                    dataframe_copy[col] = dataframe_copy[col].dt.tz_convert(None)
 
             # making a shallow copy of the dataframe so that column names are unchanged
-            dataframe_copy = dataframe.copy(deep=False)
             dataframe_copy.columns = [x.lower() for x in dataframe_copy.columns]
             return dataframe_copy
 

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -194,16 +194,21 @@ class Engine:
         if isinstance(dataframe, pd.DataFrame):
             # convert timestamps to current timezone
             local_tz = tzlocal.get_localzone()
-            for c in dataframe.columns:
+            # make shallow copy so the original df does not get changed
+            dataframe_copy = dataframe.copy(deep=False)
+            for c in dataframe_copy.columns:
                 if isinstance(
-                    dataframe[c].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
+                        dataframe_copy[c].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
                 ):
-                    dataframe[c] = dataframe[c].dt.tz_convert(str(local_tz))
-                elif dataframe[c].dtype == np.dtype("datetime64[ns]"):
-                    dataframe[c] = dataframe[c].dt.tz_localize(
+                    # convert to utc timestamp
+                    dataframe_copy[c] = dataframe_copy[c].dt.tz_convert(None)
+                if dataframe_copy[c].dtype == np.dtype("datetime64[ns]"):
+                    # set the timezone to the client's timezone because that is
+                    # what spark expects.
+                    dataframe_copy[c] = dataframe_copy[c].dt.tz_localize(
                         str(local_tz), ambiguous="infer", nonexistent="shift_forward"
                     )
-            dataframe = self._spark_session.createDataFrame(dataframe)
+            dataframe = self._spark_session.createDataFrame(dataframe_copy)
         elif isinstance(dataframe, RDD):
             dataframe = dataframe.toDF()
 

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -198,7 +198,7 @@ class Engine:
             dataframe_copy = dataframe.copy(deep=False)
             for c in dataframe_copy.columns:
                 if isinstance(
-                        dataframe_copy[c].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
+                    dataframe_copy[c].dtype, pd.core.dtypes.dtypes.DatetimeTZDtype
                 ):
                     # convert to utc timestamp
                     dataframe_copy[c] = dataframe_copy[c].dt.tz_convert(None)


### PR DESCRIPTION
This PR adds/fixes/changes...
- makes shallow copy of dataframe _before_ applying the timestamp conversion in python and spark engine
- use tzconvert(None)->tzlocalize(localtimezone) instead of tzconversion(localtimezone) in spark engine.

JIRA Issue: FSTORE-689

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
