### PR TITLE
[FSTORE-693] Fix validation_time with timezone

### DIFF
--- a/python/hsfs/ge_validation_result.py
+++ b/python/hsfs/ge_validation_result.py
@@ -16,7 +16,8 @@
 
 import json
 from typing import Any, Dict, Optional, Union
-from datetime import date, datetime
+import datetime
+import dateutil
 
 import humps
 import great_expectations as ge
@@ -33,7 +34,7 @@ class ValidationResult:
         result: Dict[str, Any],
         expectation_config: str,
         exception_info: Dict[str, Any],
-        meta: Optional[Dict[str, Any]] = {},
+        meta: Optional[Dict[str, Any]] = None,
         id: Optional[int] = None,
         observed_value: Optional[Any] = None,
         expectation_id: Optional[int] = None,
@@ -146,7 +147,9 @@ class ValidationResult:
         return self._meta
 
     @meta.setter
-    def meta(self, meta: Dict[str, Any] = {}):
+    def meta(self, meta: Dict[str, Any] = None):
+        if meta is None:
+            self._meta = {}
         if isinstance(meta, dict):
             self._meta = meta
         elif isinstance(meta, str):
@@ -190,7 +193,7 @@ class ValidationResult:
 
     @validation_time.setter
     def validation_time(
-        self, validation_time: Union[str, int, datetime, date, None]
+        self, validation_time: Union[str, int, datetime.datetime, datetime.date, None]
     ) -> None:
         """
         Time at which validation was run using Great Expectations.
@@ -199,6 +202,14 @@ class ValidationResult:
             validation_time: The time at which validation was performed.
             Supported format include timestamps(int), datetime, date or string formatted to be datutils parsable.
         """
+        if isinstance(validation_time, str):
+            try:
+                self._validation_time = dateutil.parser.parse(
+                    validation_time
+                ).astimezone(datetime.timezone.utc)
+                return
+            except ValueError:
+                pass
         if validation_time:
             self._validation_time = util.convert_event_time_to_timestamp(
                 validation_time

--- a/python/tests/test_ge_validation_result.py
+++ b/python/tests/test_ge_validation_result.py
@@ -90,3 +90,24 @@ class TestValidationResult:
 
         # Assert
         assert len(vr_list) == 0
+
+    def test_timezone_support_validation_time(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["ge_validation_result"]["get"]["response"]
+        json["validation_time"] = "2023-02-15T09:20:03.000414-05"
+
+        # Act
+        vr = ge_validation_result.ValidationResult.from_response_json(json)
+
+        # Assert
+        assert vr.id == 11
+        assert vr.success is True
+        assert vr._observed_value == "test_observed_value"
+        assert vr._expectation_id == 22
+        assert vr._validation_report_id == 33
+        assert vr.result == {"result_key": "result_value"}
+        assert vr.meta == {"meta_key": "meta_value"}
+        assert vr.exception_info == {"exception_info_key": "exception_info_value"}
+        assert vr.expectation_config == {
+            "expectation_config_key": "expectation_config_value"
+        }


### PR DESCRIPTION
This PR adds/fixes/changes...
Add dateutil parsing for validation_time provided as str to support timezone

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
