### PR TITLE
[FSTORE-682] fg.save_expectation_suite fix cherry-pick

### DIFF
--- a/python/hsfs/expectation_suite.py
+++ b/python/hsfs/expectation_suite.py
@@ -137,8 +137,8 @@ class ExpectationSuite:
             "validationIngestionPolicy": self._validation_ingestion_policy,
         }
 
-    def to_json_dict(self) -> dict:
-        return {
+    def to_json_dict(self, decamelize=False) -> dict:
+        the_dict = {
             "id": self._id,
             "expectationSuiteName": self._expectation_suite_name,
             "expectations": [
@@ -150,6 +150,11 @@ class ExpectationSuite:
             "runValidation": self._run_validation,
             "validationIngestionPolicy": self._validation_ingestion_policy,
         }
+
+        if decamelize:
+            return humps.decamelize(the_dict)
+        else:
+            return the_dict
 
     def json(self) -> str:
         return json.dumps(self, cls=util.FeatureStoreEncoder)
@@ -167,7 +172,7 @@ class ExpectationSuite:
 
     def _init_feature_store_and_feature_group_ids_from_href(self, href: str) -> None:
         feature_store_id, feature_group_id = re.search(
-            r"\/featurestores\/([0-9]+)\/featuregroups\/([0-9]+)\/expectationsuite*",
+            r"\/featurestores\/(\d+)\/featuregroups\/(\d+)\/expectationsuite*",
             href,
         ).groups(0)
         self._feature_store_id = int(feature_store_id)

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -656,7 +656,7 @@ class FeatureGroupBase:
 
     def get_expectation_suite(
         self, ge_type: bool = True
-    ) -> Union[ExpectationSuite, ge.core.ExpectationSuite]:
+    ) -> Union[ExpectationSuite, ge.core.ExpectationSuite, None]:
         """Return the expectation suite attached to the feature group if it exists.
 
         !!! example
@@ -733,9 +733,9 @@ class FeatureGroupBase:
                 feature_group_id=self._id,
             )
         elif isinstance(expectation_suite, ExpectationSuite):
-            tmp_expectation_suite = expectation_suite.to_json_dict()
-            tmp_expectation_suite["featuregroup_id"] = self._id
-            tmp_expectation_suite["featurestore_id"] = self._feature_store_id
+            tmp_expectation_suite = expectation_suite.to_json_dict(decamelize=True)
+            tmp_expectation_suite["feature_group_id"] = self._id
+            tmp_expectation_suite["feature_store_id"] = self._feature_store_id
             tmp_expectation_suite = ExpectationSuite(**tmp_expectation_suite)
         else:
             raise TypeError(
@@ -773,7 +773,7 @@ class FeatureGroupBase:
         # Raises
             `hsfs.client.exceptions.RestAPIError`.
         """
-        if self._expectation_suite.id:
+        if self.get_expectation_suite() is not None:
             self._expectation_suite_engine.delete(self._expectation_suite.id)
         self._expectation_suite = None
 

--- a/python/hsfs/ge_expectation.py
+++ b/python/hsfs/ge_expectation.py
@@ -74,13 +74,18 @@ class GeExpectation:
             "meta": json.dumps(self._meta),
         }
 
-    def to_json_dict(self) -> Dict[str, Any]:
-        return {
+    def to_json_dict(self, decamelize=False) -> Dict[str, Any]:
+        the_dict = {
             "id": self._id,
             "expectationType": self._expectation_type,
             "kwargs": self._kwargs,
             "meta": self._meta,
         }
+
+        if decamelize:
+            return humps.decamelize(the_dict)
+        else:
+            return the_dict
 
     def json(self) -> str:
         return json.dumps(self, cls=util.FeatureStoreEncoder)

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-
+import hsfs
 from hsfs import (
     feature_store,
     feature_group,
@@ -408,3 +408,79 @@ class TestExternalFeatureGroup:
         assert isinstance(fg.statistics_config, statistics_config.StatisticsConfig)
         assert fg.event_time is None
         assert fg.expectation_suite is None
+
+    def test_feature_group_save_expectation_suite_from_ge_type(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["expectation_suite"]["get"]["response"]
+        es = expectation_suite.ExpectationSuite.from_response_json(json)
+        json = backend_fixtures["feature_group"]["get_stream_basic_info"]["response"]
+        fg = feature_group.FeatureGroup.from_response_json(json)
+
+        # to mock delete we need get_expectation_suite to not return none
+        mock_get_expectation_suite_api = mocker.patch(
+            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.get",
+            return_value=es,
+        )
+        mock_create_expectation_suite_api = mocker.patch(
+            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.create",
+            return_value=es,
+        )
+        mock_delete_expectation_suite_api = mocker.patch(
+            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.delete"
+        )
+
+        version_api = mocker.patch("hsfs.core.variable_api.VariableApi.get_version")
+        version_api.return_value = hsfs.__version__
+
+        mock_es_engine_get_expectation_suite_url = mocker.patch(
+            "hsfs.core.expectation_suite_engine.ExpectationSuiteEngine._get_expectation_suite_url"
+        )
+        mock_print = mocker.patch("builtins.print")
+
+        # Act
+        fg.save_expectation_suite(es.to_ge_type(), overwrite=True)
+        # Assert
+        assert mock_delete_expectation_suite_api.call_count == 1
+        assert mock_create_expectation_suite_api.call_count == 1
+        assert mock_get_expectation_suite_api.call_count == 1
+        assert mock_es_engine_get_expectation_suite_url.call_count == 1
+        assert mock_print.call_count == 1
+        assert (
+            mock_print.call_args[0][0][:55]
+            == "Attached expectation suite to Feature Group, edit it at"
+        )
+
+    def test_feature_group_save_expectation_suite_from_hopsworks_type(
+        self, mocker, backend_fixtures
+    ):
+        # Arrange
+        json = backend_fixtures["expectation_suite"]["get"]["response"]
+        es = expectation_suite.ExpectationSuite.from_response_json(json)
+        json = backend_fixtures["feature_group"]["get_stream_basic_info"]["response"]
+        fg = feature_group.FeatureGroup.from_response_json(json)
+
+        mock_update_expectation_suite_api = mocker.patch(
+            "hsfs.core.expectation_suite_api.ExpectationSuiteApi.update"
+        )
+
+        version_api = mocker.patch("hsfs.core.variable_api.VariableApi.get_version")
+        version_api.return_value = hsfs.__version__
+
+        mock_es_engine_get_expectation_suite_url = mocker.patch(
+            "hsfs.core.expectation_suite_engine.ExpectationSuiteEngine._get_expectation_suite_url"
+        )
+        mock_print = mocker.patch("builtins.print")
+
+        # Act
+        fg.save_expectation_suite(es)
+        # Assert
+
+        assert mock_update_expectation_suite_api.call_count == 1
+        assert mock_es_engine_get_expectation_suite_url.call_count == 1
+        assert mock_print.call_count == 1
+        assert (
+            mock_print.call_args[0][0][:63]
+            == "Updated expectation suite attached to Feature Group, edit it at"
+        )


### PR DESCRIPTION
* Add decamelize option to to_json_dict + use it in fg.save_expectation_suite

* Fix keywords name

* Add unit test for fg.save_expectation_suite

* Update python/tests/test_feature_group.py



---------

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
