### PR TITLE
[FSTORE-693] fix validation time parsing with timezone cherry-pick

### DIFF
--- a/python/tests/test_ge_validation_result.py
+++ b/python/tests/test_ge_validation_result.py
@@ -90,3 +90,15 @@ class TestValidationResult:
 
         # Assert
         assert len(vr_list) == 0
+
+    def test_timezone_support_validation_time(self, backend_fixtures):
+        # Arrange
+        json = backend_fixtures["ge_validation_result"]["get"]["response"]
+        json["validation_time"] = "2023-02-15T09:20:03.000414-05"
+
+        # Act
+        vr = ge_validation_result.ValidationResult.from_response_json(json)
+
+        # Assert
+        assert vr.id == 11
+        assert vr.validation_time == 1676470803000


### PR DESCRIPTION
* Fix validation_time with timezone

* Convert to timestamp

* Add comment to clarify

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
