### PR TITLE
[FSTORE-684] Add start time to hsfs_util

### DIFF
--- a/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
+++ b/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
@@ -73,6 +73,12 @@ public class MainClass {
         .hasArg()
         .build());
 
+    options.addOption(Option.builder("start_time")
+        .argName("start_time")
+        .required(false)
+        .hasArg()
+        .build());
+
     CommandLineParser parser = new DefaultParser();
     CommandLine commandLine = parser.parse(options, args);
 

--- a/utils/python/hsfs_utils.py
+++ b/utils/python/hsfs_utils.py
@@ -215,6 +215,11 @@ if __name__ == "__main__":
         type=str,
         help="Location on HopsFS of the JSON containing the full configuration",
     )
+    parser.add_argument(
+        "-start_time",
+        type=int,
+        help="Job start time",
+    )
 
     args = parser.parse_args()
     job_conf = read_job_conf(args.path)


### PR DESCRIPTION
Add start time to hsfs_util because scheduler will pass start time to job.
https://github.com/kennethmhc/hopsworks-ee/blob/871e5cfb22b59bb59e6079a2be070e8bb0e4639a/hopsworks-common/src/main/java/io/hops/hopsworks/common/jobs/JobScheduleV2Controller.java#L73

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
