### PR TITLE
[FSTORE-758] Fix serialise timestamp

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs</artifactId>
-    <version>3.1.1-RC1</version>
+    <version>3.1.1-RC2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.1.1rc1"
+__version__ = "3.1.1rc2"

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,7 @@ setup(
         "requests",
         "furl",
         "boto3",
-        "pandas>=1.2.0",
+        "pandas>=1.2.0,<2.0.0",
         "numpy",
         "pyjks",
         "mock",

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.1.1-RC1</version>
+    <version>3.1.1-RC2</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>


### PR DESCRIPTION
This PR adds/fixes/changes...
- In pandas==2.0.0rc0, timestamp is treated as numerical value. This breaks the current statistics. 

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
