### PR TITLE
[FSTORE-782] Allow resetting kafka offsets for stream feature groups after backup/restore

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs</artifactId>
-    <version>3.1.1-RC3</version>
+    <version>3.1.1-RC4</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/DeltaStreamerKafkaSource.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/DeltaStreamerKafkaSource.java
@@ -79,8 +79,9 @@ public class DeltaStreamerKafkaSource extends AvroSource {
   protected InputBatch<JavaRDD<GenericRecord>> fetchNewData(Option<String> lastCheckpointStr, long sourceLimit) {
     OffsetRange[] offsetRanges = this.offsetGen.getNextOffsetRanges(lastCheckpointStr, sourceLimit, this.metrics);
     long totalNewMsgs = KafkaOffsetGen.CheckpointUtils.totalNewMessages(offsetRanges);
-    LOG.info("About to read " + totalNewMsgs + " from Kafka for topic :" + this.offsetGen.getTopicName()
-        + " from lastCheckpointStr " + lastCheckpointStr);
+    LOG.info("About to read " + totalNewMsgs + " from Kafka for topic: " + this.offsetGen.getTopicName()
+        + " from lastCheckpointStr " + lastCheckpointStr + " Offset range: "
+        + KafkaOffsetGen.CheckpointUtils.offsetsToStr(offsetRanges));
     if (totalNewMsgs <= 0L) {
       return new InputBatch(Option.empty(), KafkaOffsetGen.CheckpointUtils.offsetsToStr(offsetRanges));
     } else {

--- a/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/HudiEngine.java
+++ b/java/src/main/java/com/logicalclocks/hsfs/engine/hudi/HudiEngine.java
@@ -38,6 +38,7 @@ import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.HoodieDataSourceHelpers;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.parquet.Strings;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.Dataset;
@@ -123,6 +124,7 @@ public class HudiEngine {
   protected static final String FEATURE_STORE_NAME = "featureStoreName";
   protected static final String FEATURE_GROUP_NAME = "featureGroupName";
   protected static final String FEATURE_GROUP_VERSION = "featureGroupVersion";
+  protected static final String FEATURE_GROUP_KAFKA_OFFSET_RESET = "kafkaOffsetReset";
   protected static final String FUNCTION_TYPE = "functionType";
   protected static final String STREAMING_QUERY = "streamingQuery";
 
@@ -375,22 +377,27 @@ public class HudiEngine {
         new JSONArray(streamFeatureGroup.getComplexFeatures()).toString());
     hudiWriteOpts.put(DELTA_SOURCE_ORDERING_FIELD_OPT_KEY,
         hudiWriteOpts.get(HUDI_PRECOMBINE_FIELD));
-    writeOptions.putAll(hudiWriteOpts);
 
     // check if table was initiated and if not initiate
     Path basePath = new Path(streamFeatureGroup.getLocation());
     FileSystem fs = basePath.getFileSystem(sparkSession.sparkContext().hadoopConfiguration());
     if (!fs.exists(new Path(basePath, HoodieTableMetaClient.METAFOLDER_NAME))) {
       createEmptyTable(sparkSession, streamFeatureGroup);
-      writeOptions.put(HudiEngine.INITIAL_CHECKPOINT_STRING, generetaInitialCheckPointStr(streamFeatureGroup));
+      // set "kafka.auto.offset.reset": "earliest"
+      hudiWriteOpts.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     }
 
     // it is possible that table was generated from empty topic, thus we need to generate InitialCheckPointStr
     if (getLastCommitMetadata(sparkSession, streamFeatureGroup.getLocation()) == null) {
-      writeOptions.put(HudiEngine.INITIAL_CHECKPOINT_STRING, generetaInitialCheckPointStr(streamFeatureGroup));
+      // set "kafka.auto.offset.reset": "earliest"
+      hudiWriteOpts.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     }
 
-    deltaStreamerConfig.streamToHoodieTable(writeOptions, sparkSession);
+    if (writeOptions.getOrDefault(HudiEngine.FEATURE_GROUP_KAFKA_OFFSET_RESET, "false").equalsIgnoreCase("true")) {
+      hudiWriteOpts.put(HudiEngine.INITIAL_CHECKPOINT_STRING, generetaInitialCheckPointStr(streamFeatureGroup));
+    }
+
+    deltaStreamerConfig.streamToHoodieTable(hudiWriteOpts, sparkSession);
     FeatureGroupCommit fgCommit = getLastCommitMetadata(sparkSession, streamFeatureGroup.getLocation());
     if (fgCommit != null) {
       featureGroupApi.featureGroupCommit(streamFeatureGroup, fgCommit);

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -908,7 +908,7 @@ class Engine:
                 if transformation_fn.output_type != "TIMESTAMP":
                     return func
 
-                current_timezone = datetime.now().astimezone().tzinfo
+                current_timezone = tzlocal.get_localzone()
 
                 def decorated_func(x):
                     result = func(x)

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.1.1rc3"
+__version__ = "3.1.1rc4"

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.1.1-RC3</version>
+    <version>3.1.1-RC4</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>

--- a/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
+++ b/utils/java/src/main/java/com/logicalclocks/utils/MainClass.java
@@ -73,11 +73,18 @@ public class MainClass {
         .hasArg()
         .build());
 
+    options.addOption(Option.builder("kafkaOffsetReset")
+        .argName("kafkaOffsetReset")
+        .required(false)
+        .hasArg()
+        .build());
+
     CommandLineParser parser = new DefaultParser();
     CommandLine commandLine = parser.parse(options, args);
 
     String op = commandLine.getOptionValue("op");
     String path = commandLine.getOptionValue("path");
+    String kafkaOffsetsReset = commandLine.getOptionValue("kafkaOffsetReset");
 
     // read jobs config
     Map<String, Object> jobConf = readJobConf(path);
@@ -92,6 +99,13 @@ public class MainClass {
         jobConf.get("version")));
 
     Map<String, String> writeOptions = (Map<String, String>) jobConf.get("write_options");
+    if (kafkaOffsetsReset != null) {
+      if (writeOptions == null) {
+        writeOptions = new HashMap<>();
+      }
+      writeOptions.put("kafkaOffsetReset", kafkaOffsetsReset);
+    }
+    LOGGER.info("Hsfs utils write options: {}", writeOptions);
 
     if (op.equals("offline_fg_backfill")) {
       SparkEngine.getInstance().streamToHudiTable(streamFeatureGroup, writeOptions);


### PR DESCRIPTION
- [FSTORE-782] Allow resetting kafka offsets for stream feature groups after backup/restore (#971)
- Release hsfs 3.1.1rc4

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```


[FSTORE-782]: https://hopsworks.atlassian.net/browse/FSTORE-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ