### PR TITLE
[FSTORE-836] Show "Reading data with..." message and remove Hive warning

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -21,6 +21,7 @@ import time
 import re
 import ast
 import warnings
+import logging
 import avro
 import socket
 import pyarrow as pa
@@ -65,6 +66,9 @@ from hsfs.client import exceptions, hopsworks
 from hsfs.feature_group import FeatureGroup
 from thrift.transport.TTransport import TTransportException
 from pyhive.exc import OperationalError
+
+# Disable pyhive INFO logging
+logging.getLogger("pyhive").setLevel(logging.WARNING)
 
 HAS_FAST = False
 try:
@@ -121,12 +125,21 @@ class Engine:
         hive_config=None,
     ):
         if arrow_flight_client.get_instance().is_flyingduck_query_object(sql_query):
-            result_df = arrow_flight_client.get_instance().read_query(sql_query)
+            result_df = util.run_with_loading_animation(
+                "Reading data with FlyingDuck",
+                arrow_flight_client.get_instance().read_query,
+                sql_query,
+            )
         else:
             with self._create_hive_connection(
                 feature_store, hive_config=hive_config
             ) as hive_conn:
-                result_df = pd.read_sql(sql_query, hive_conn)
+                # Suppress SQLAlchemy pandas warning
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    result_df = util.run_with_loading_animation(
+                        "Reading data with Hive", pd.read_sql, sql_query, hive_conn
+                    )
 
         if schema:
             result_df = Engine.cast_columns(result_df, schema)

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -136,7 +136,7 @@ class Engine:
             ) as hive_conn:
                 # Suppress SQLAlchemy pandas warning
                 with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
+                    warnings.simplefilter("ignore", UserWarning)
                     result_df = util.run_with_loading_animation(
                         "Reading data from Hopsworks, using Hive",
                         pd.read_sql,

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -126,7 +126,7 @@ class Engine:
     ):
         if arrow_flight_client.get_instance().is_flyingduck_query_object(sql_query):
             result_df = util.run_with_loading_animation(
-                "Reading data with FlyingDuck",
+                "Reading data from Hopsworks, using FlyingDuck",
                 arrow_flight_client.get_instance().read_query,
                 sql_query,
             )
@@ -138,7 +138,10 @@ class Engine:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     result_df = util.run_with_loading_animation(
-                        "Reading data with Hive", pd.read_sql, sql_query, hive_conn
+                        "Reading data from Hopsworks, using Hive",
+                        pd.read_sql,
+                        sql_query,
+                        hive_conn,
                     )
 
         if schema:


### PR DESCRIPTION
This PR:
- adds an animated printout "Reading data with FlyingDuck..."/ "Reading data with Hive..." in python-only client
- prints "Finished ... (0.2s)" with runtime when finished
- removed printed query and warnings when querying with hive.

JIRA Issue: FSTORE-836

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
