### PR TITLE
[FSTORE-854] Accept datetime object in filter and support unbinded features

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 #
 
+import datetime
 import json
 import base64
 import warnings
@@ -305,10 +306,14 @@ class ArrowFlightClient:
             return None
 
     def _resolve_filter(self, filter, featuregroups):
+        if isinstance(filter._value, datetime.datetime):
+            filter_value = filter._value.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            filter_value = filter._value
         return {
             "type": "filter",
             "condition": filter._condition,
-            "value": filter._value,
+            "value": filter_value,
             "feature": f"{featuregroups[filter._feature._feature_group_id]}.{filter._feature._name}",
             "numeric": (
                 filter._feature._type in ArrowFlightClient.FILTER_NUMERIC_TYPES

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -309,8 +309,8 @@ class ArrowFlightClient:
         featuregroup_name = None
 
         if feature._feature_group_id is None:
-            for fg_name in features:
-                if feature._name in features[fg_name]:
+            for fg_name, fg_features in features.items():
+                if feature._name in fg_features:
                     featuregroup_name = fg_name
                     break
         elif feature._feature_group_id in featuregroups:

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -236,7 +236,7 @@ class ArrowFlightClient:
             features,
             filters,
         ) = self._collect_featuregroups_features_and_filters_rec(query)
-        filters = self._filter_to_expression(filters, featuregroups)
+        filters = self._filter_to_expression(filters, featuregroups, features)
         for feature in features:
             features[feature] = list(features[feature])
         return featuregroups, features, filters
@@ -280,44 +280,61 @@ class ArrowFlightClient:
 
         return featuregroups, features, filters
 
-    def _filter_to_expression(self, filters, featuregroups):
+    def _filter_to_expression(self, filters, featuregroups, features):
         if not filters:
             return None
-        return self._resolve_logic(filters, featuregroups)
+        return self._resolve_logic(filters, featuregroups, features)
 
-    def _resolve_logic(self, logic, featuregroups):
+    def _resolve_logic(self, logic, featuregroups, features):
         return {
             "type": "logic",
             "logic_type": logic._type,
             "left_filter": self._resolve_filter_or_logic(
-                logic._left_f, logic._left_l, featuregroups
+                logic._left_f, logic._left_l, featuregroups, features
             ),
             "right_filter": self._resolve_filter_or_logic(
-                logic._right_f, logic._right_l, featuregroups
+                logic._right_f, logic._right_l, featuregroups, features
             ),
         }
 
-    def _resolve_filter_or_logic(self, filter, logic, featuregroups):
+    def _resolve_filter_or_logic(self, filter, logic, featuregroups, features):
         if filter:
-            return self._resolve_filter(filter, featuregroups)
+            return self._resolve_filter(filter, featuregroups, features)
         elif logic:
-            return self._resolve_logic(logic, featuregroups)
+            return self._resolve_logic(logic, featuregroups, features)
         else:
             return None
 
-    def _resolve_filter(self, filter, featuregroups):
+    def _get_full_feature_name(self, feature, featuregroups, features):
+        featuregroup_name = None
+
+        if feature._feature_group_id is None:
+            for fg_name in features:
+                if feature._name in features[fg_name]:
+                    featuregroup_name = fg_name
+                    break
+        elif feature._feature_group_id in featuregroups:
+            featuregroup_name = featuregroups[feature._feature_group_id]
+
+        if featuregroup_name is None:
+            raise FeatureStoreException(f"Feature {feature._name} not found in query")
+
+        return f"{featuregroup_name}.{feature._name}"
+
+    def _resolve_filter(self, filter, featuregroups, features):
         if isinstance(filter._value, datetime.datetime):
             filter_value = filter._value.strftime("%Y-%m-%d %H:%M:%S")
         else:
             filter_value = filter._value
+
         return {
             "type": "filter",
             "condition": filter._condition,
             "value": filter_value,
-            "feature": f"{featuregroups[filter._feature._feature_group_id]}.{filter._feature._name}",
-            "numeric": (
-                filter._feature._type in ArrowFlightClient.FILTER_NUMERIC_TYPES
+            "feature": self._get_full_feature_name(
+                filter._feature, featuregroups, features
             ),
+            "numeric": False,  # For backwards compatibility
         }
 
     def _info_to_ticket(self, info):

--- a/python/tests/core/test_arrow_flight_client.py
+++ b/python/tests/core/test_arrow_flight_client.py
@@ -347,8 +347,6 @@ class TestArrowFlightClient:
         self._arrange_engine_mocks(mocker, backend_fixtures)
         json1 = backend_fixtures["feature_group"]["get"]["response"]
         test_fg1 = feature_group.FeatureGroup.from_response_json(json1)
-        json2 = backend_fixtures["feature_group"]["get_stream"]["response"]
-        test_fg2 = feature_group.FeatureGroup.from_response_json(json2)
         mocker.patch("hsfs.constructor.query.Query.to_string", return_value="")
         mocker.patch("hsfs.constructor.query.Query._to_string", return_value="")
         query = test_fg1.select_all().filter(

--- a/python/tests/core/test_arrow_flight_client.py
+++ b/python/tests/core/test_arrow_flight_client.py
@@ -396,7 +396,6 @@ class TestArrowFlightClient:
             query, "SELECT * FROM..."
         )
 
-        print(query_object)
 
         # Assert
         query_object_reference = {

--- a/python/tests/core/test_arrow_flight_client.py
+++ b/python/tests/core/test_arrow_flight_client.py
@@ -417,7 +417,6 @@ class TestArrowFlightClient:
             },
         }
 
-        print(query_object_reference)
 
         diff = self._find_diff(query_object, query_object_reference)
         assert diff == {}


### PR DESCRIPTION
This PR adds:
- support for datetime objects in flyingduck query filters
- support for unbinded features (i.e. `Feature("name")`)

JIRA Issue: FSTORE-854, FSTORE-853

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
