### PR TITLE
[FSTORE-836][append] Stop loading animation on error

### DIFF
--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -323,16 +323,20 @@ def run_with_loading_animation(message, func, *args, **kwargs):
     t.daemon = True
     t.start()
     start = time.time()
+    end = None
 
-    result = func(*args, **kwargs)
-
-    end = time.time()
-    # Stop the animation and print the "Finished Querying" message
-    stop_event.set()
-    t.join()
-    print(f"\rFinished: {message} ({(end-start):.2f}s) ", end="\n")
-
-    return result
+    try:
+        result = func(*args, **kwargs)
+        end = time.time()
+        return result
+    finally:
+        # Stop the animation and print the "Finished Querying" message
+        stop_event.set()
+        t.join()
+        if not end:
+            print(f"\rError: {message}           ", end="\n")
+        else:
+            print(f"\rFinished: {message} ({(end-start):.2f}s) ", end="\n")
 
 
 class VersionWarning(Warning):


### PR DESCRIPTION
This PR stops loading animation of fg.read()/query.read() when it encouters an error.

JIRA Issue: FSTORE-836

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
