### PR TITLE
[FSTORE-922] Python join deserialization reads join_type instead of type

### DIFF
--- a/python/hsfs/constructor/join.py
+++ b/python/hsfs/constructor/join.py
@@ -56,7 +56,7 @@ class Join:
             on=json_decamelized.get("on", None),
             left_on=json_decamelized.get("left_on", None),
             right_on=json_decamelized.get("right_on", None),
-            join_type=json_decamelized.get("join_type", None),
+            join_type=json_decamelized.get("type", None),
             prefix=json_decamelized.get("prefix", None),
         )
 

--- a/python/tests/constructor/test_join.py
+++ b/python/tests/constructor/test_join.py
@@ -57,3 +57,21 @@ class TestJoin:
         assert len(j._right_on) == 0
         assert j._join_type == "INNER"
         assert j._prefix is None
+
+    def test_from_response_json_left_join(self, mocker, backend_fixtures):
+        # Arrange
+        mocker.patch("hsfs.engine.get_type", return_value="python")
+        json = backend_fixtures["join"]["left_on_right_on"]["response"]
+
+        # Act
+        j = join.Join.from_response_json(json)
+
+        # Assert
+        assert isinstance(j.query, query.Query)
+        assert len(j._on) == 0
+        assert len(j._left_on) == 1
+        assert j._left_on[0] == "job_id"
+        assert len(j._right_on) == 1
+        assert j._right_on[0] == "internal_id"
+        assert j._join_type == "LEFT"
+        assert j._prefix is None

--- a/python/tests/fixtures/feature_view_fixtures.json
+++ b/python/tests/fixtures/feature_view_fixtures.json
@@ -138,7 +138,7 @@
             "on": "test_on",
             "left_on": "test_left_on",
             "right_on": "test_right_on",
-            "join_type": "test_join_type",
+            "type": "test_join_type",
             "prefix": "test_prefix"
           }
         ],
@@ -314,7 +314,7 @@
             "on": "test_on",
             "left_on": "test_left_on",
             "right_on": "test_right_on",
-            "join_type": "test_join_type",
+            "type": "test_join_type",
             "prefix": "test_prefix"
           }
         ],

--- a/python/tests/fixtures/join_fixtures.json
+++ b/python/tests/fixtures/join_fixtures.json
@@ -71,7 +71,7 @@
       "on": "test_on",
       "left_on": "test_left_on",
       "right_on": "test_right_on",
-      "join_type": "test_join_type",
+      "type": "test_join_type",
       "prefix": "test_prefix"
     }
   },
@@ -144,6 +144,95 @@
         "joins": [],
         "filter": null
       }
+    }
+  },
+  "left_on_right_on" : {
+    "response":{
+      "query": {
+          "featureStoreId": 71,
+          "featureStoreName": "test_fabio_featurestore",
+          "leftFeatureGroup": {
+              "type": "streamFeatureGroupDTO",
+              "featurestoreId": 71,
+              "featurestoreName": "test_fabio_featurestore",
+              "description": "",
+              "created": "2023-06-18T16:42:34.000Z",
+              "creator": {
+                  "email": "admin@hopsworks.ai",
+                  "firstName": "Admin",
+                  "lastName": "Admin",
+                  "status": 0,
+                  "tos": false,
+                  "twoFactor": false,
+                  "toursState": 0,
+                  "maxNumProjects": 0,
+                  "numCreatedProjects": 0,
+                  "testUser": false,
+                  "numActiveProjects": 0,
+                  "numRemainingProjects": 0
+              },
+              "version": 1,
+              "name": "company",
+              "id": 40,
+              "location": "hopsfs://172.16.4.123:8020/apps/hive/warehouse/test_fabio_featurestore.db/company_1",
+              "statisticsConfig": {
+                  "enabled": false,
+                  "histograms": false,
+                  "correlations": false,
+                  "exactUniqueness": false,
+                  "columns": []
+              },
+              "features": [
+                  {
+                      "name": "company_id",
+                      "type": "bigint",
+                      "primary": true,
+                      "partition": false,
+                      "hudiPrecombineKey": true,
+                      "featureGroupId": 40
+                  },
+                  {
+                      "name": "cfeat",
+                      "type": "string",
+                      "primary": false,
+                      "partition": false,
+                      "hudiPrecombineKey": false,
+                      "featureGroupId": 40
+                  }
+              ],
+              "onlineTopicName": "126_40_company_1",
+              "onlineEnabled": false,
+              "timeTravelFormat": "HUDI"
+          },
+          "leftFeatures": [
+              {
+                  "name": "cfeat",
+                  "type": "string",
+                  "primary": false,
+                  "partition": false,
+                  "hudiPrecombineKey": false,
+                  "featureGroupId": 40
+              }
+          ],
+          "hiveEngine": false
+      },
+      "leftOn": [
+          {
+              "name": "job_id",
+              "primary": false,
+              "partition": false,
+              "hudiPrecombineKey": false
+          }
+      ],
+      "rightOn": [
+          {
+              "name": "internal_id",
+              "primary": false,
+              "partition": false,
+              "hudiPrecombineKey": false
+          }
+      ],
+      "type": "LEFT"
     }
   }
 }

--- a/python/tests/fixtures/join_fixtures.json
+++ b/python/tests/fixtures/join_fixtures.json
@@ -150,11 +150,11 @@
     "response":{
       "query": {
           "featureStoreId": 71,
-          "featureStoreName": "test_fabio_featurestore",
+          "featureStoreName": "test_featurestore",
           "leftFeatureGroup": {
               "type": "streamFeatureGroupDTO",
               "featurestoreId": 71,
-              "featurestoreName": "test_fabio_featurestore",
+              "featurestoreName": "test_featurestore",
               "description": "",
               "created": "2023-06-18T16:42:34.000Z",
               "creator": {
@@ -174,7 +174,7 @@
               "version": 1,
               "name": "company",
               "id": 40,
-              "location": "hopsfs://172.16.4.123:8020/apps/hive/warehouse/test_fabio_featurestore.db/company_1",
+              "location": "hopsfs://172.16.4.123:8020/apps/hive/warehouse/test_featurestore.db/company_1",
               "statisticsConfig": {
                   "enabled": false,
                   "histograms": false,

--- a/python/tests/fixtures/query_fixtures.json
+++ b/python/tests/fixtures/query_fixtures.json
@@ -136,7 +136,7 @@
           "on": "test_on",
           "left_on": "test_left_on",
           "right_on": "test_right_on",
-          "join_type": "test_join_type",
+          "type": "test_join_type",
           "prefix": "test_prefix"
         }
       ],
@@ -334,7 +334,7 @@
           "on": "test_on",
           "left_on": "test_left_on",
           "right_on": "test_right_on",
-          "join_type": "test_join_type",
+          "type": "test_join_type",
           "prefix": "test_prefix"
         }
       ],

--- a/python/tests/test_feature_group_writer.py
+++ b/python/tests/test_feature_group_writer.py
@@ -20,7 +20,6 @@ from hsfs.engine import python
 
 class TestFeatureGroupWriter:
     def test_fg_writer_context_manager(self, mocker, dataframe_fixture_basic):
-
         mock_insert = mocker.patch("hsfs.feature_group.FeatureGroup.insert")
 
         fg = feature_group.FeatureGroup(

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -585,7 +585,6 @@ class TestBigQueryConnector:
         )
 
     def test_python_support_validation(self, backend_fixtures):
-
         engine.set_instance("python", python.Engine())
         json = backend_fixtures["storage_connector"]["get_big_query_basic_info"][
             "response"
@@ -595,7 +594,6 @@ class TestBigQueryConnector:
             sc.read()
 
     def test_query_validation(self, backend_fixtures, tmp_path):
-
         engine.set_instance("spark", spark.Engine())
         credentials = '{"type": "service_account", "project_id": "test"}'
         credentialsFile = tmp_path / "bigquery.json"


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
