### PR TITLE
[FSTORE-1072] Configure timeout for arrow flight

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -127,6 +127,8 @@ class Query:
                 Only for python engine:
                 * key `"use_hive"` and value `True` to read query with Hive instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key "hive_config" to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 Defaults to `{}`.

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -54,6 +54,7 @@ class ArrowFlightClient:
     FILTER_NUMERIC_TYPES = ["bigint", "tinyint", "smallint", "int", "float", "double"]
     READ_ERROR = 'Could not read data using ArrowFlight. If the issue persists, use read_options={"use_hive": True} instead.'
     WRITE_ERROR = 'Could not write data using ArrowFlight. If the issue persists, use write_options={"use_spark": True} instead.'
+    DEFAULT_TIMEOUT = 900
 
     def __init__(self):
         try:
@@ -202,25 +203,31 @@ class ArrowFlightClient:
 
         return decorator
 
-    def _get_dataset(self, descriptor):
+    def _get_dataset(self, descriptor, timeout=DEFAULT_TIMEOUT):
         info = self._connection.get_flight_info(descriptor)
-        reader = self._connection.do_get(self._info_to_ticket(info))
+        options = pyarrow.flight.FlightCallOptions(timeout=timeout)
+        reader = self._connection.do_get(self._info_to_ticket(info), options)
         return reader.read_pandas()
 
     @_handle_afs_exception(user_message=READ_ERROR)
-    def read_query(self, query_object):
+    def read_query(self, query_object, arrow_flight_config):
         query_encoded = json.dumps(query_object).encode("ascii")
         descriptor = pyarrow.flight.FlightDescriptor.for_command(query_encoded)
-        return self._get_dataset(descriptor)
+        return self._get_dataset(
+            descriptor,
+            arrow_flight_config.get("timeout")
+            if arrow_flight_config
+            else self.DEFAULT_TIMEOUT,
+        )
 
     @_handle_afs_exception(user_message=READ_ERROR)
-    def read_path(self, path):
+    def read_path(self, path, arrow_flight_config):
         descriptor = pyarrow.flight.FlightDescriptor.for_path(path)
-        return self._get_dataset(descriptor)
+        return self._get_dataset(descriptor, arrow_flight_config)
 
     @_handle_afs_exception(user_message=WRITE_ERROR)
     def create_training_dataset(
-        self, feature_view_obj, training_dataset_obj, query_obj
+        self, feature_view_obj, training_dataset_obj, query_obj, arrow_flight_config
     ):
         training_dataset = {}
         training_dataset["fs_name"] = util.strip_feature_store_suffix(
@@ -237,7 +244,13 @@ class ArrowFlightClient:
             action = pyarrow.flight.Action(
                 "create-training-dataset", training_dataset_buf
             )
-            for result in self._connection.do_action(action):
+            timeout = (
+                arrow_flight_config.get("timeout", self.DEFAULT_TIMEOUT)
+                if arrow_flight_config
+                else self.DEFAULT_TIMEOUT
+            )
+            options = pyarrow.flight.FlightCallOptions(timeout=timeout)
+            for result in self._connection.do_action(action, options):
                 return result.body.to_pybytes()
         except pyarrow.lib.ArrowIOError as e:
             print("Error calling action:", e)

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -109,6 +109,9 @@ class Engine:
                 dataframe_type,
                 schema,
                 hive_config=read_options.get("hive_config") if read_options else None,
+                arrow_flight_config=read_options.get("arrow_flight_config", {})
+                if read_options
+                else {},
             )
         else:
             return self._jdbc(
@@ -127,12 +130,14 @@ class Engine:
         dataframe_type,
         schema=None,
         hive_config=None,
+        arrow_flight_config={},
     ):
         if arrow_flight_client.get_instance().is_flyingduck_query_object(sql_query):
             result_df = util.run_with_loading_animation(
                 "Reading data from Hopsworks, using ArrowFlight",
                 arrow_flight_client.get_instance().read_query,
                 sql_query,
+                arrow_flight_config,
             )
         else:
             with self._create_hive_connection(
@@ -239,7 +244,10 @@ class Engine:
                     if arrow_flight_client.get_instance().is_data_format_supported(
                         data_format, read_options
                     ):
-                        df = arrow_flight_client.get_instance().read_path(inode.path)
+                        arrow_flight_config = read_options.get("arrow_flight_config")
+                        df = arrow_flight_client.get_instance().read_path(
+                            inode.path, arrow_flight_config
+                        )
                     else:
                         content_stream = self._dataset_api.read_content(inode.path)
                         df = self._read_pandas(
@@ -688,6 +696,7 @@ class Engine:
                 feature_view_obj,
                 training_dataset,
                 query_obj,
+                user_write_options.get("arrow_flight_config", {}),
             )
 
             return response

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1616,6 +1616,8 @@ class FeatureGroup(FeatureGroupBase):
                 For python engine:
                 * key `"use_hive"` and value `True` to read feature group
                   with Hive instead of [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 * key `"pandas_types"` and value `True` to retrieve columns as

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -574,6 +574,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to read batch data with Hive instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
                 Defaults to `{}`.
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
             spine: Spine dataframe with primary key, event time and
                 label column to use for point in time join when fetching features. Defaults to `None` and is only required
                 when feature view was created with spine group in the feature query.
@@ -1637,6 +1639,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to create in-memory training dataset
                   with Hive instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 * key `spark` and value an object of type
@@ -1782,6 +1786,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to create in-memory training dataset
                   with Hive instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 * key `spark` and value an object of type
@@ -1964,6 +1970,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to create in-memory training dataset
                   with Hive instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 * key `spark` and value an object of type
@@ -2085,6 +2093,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to read training dataset
                   with the Hopsworks API instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 Defaults to `{}`.
@@ -2127,6 +2137,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to read training dataset
                   with the Hopsworks API instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 Defaults to `{}`.
@@ -2173,6 +2185,8 @@ class FeatureView:
                 * key `"use_hive"` and value `True` to read training dataset
                   with the Hopsworks API instead of
                   [ArrowFlight Server](https://docs.hopsworks.ai/latest/setup_installation/common/arrow_flight_duckdb/).
+                * key `"arrow_flight_config"` to pass a dictionary of arrow flight configurations.
+                  For example: `{"arrow_flight_config": {"timeout": 900}}`
                 * key `"hive_config"` to pass a dictionary of hive or tez configurations.
                   For example: `{"hive_config": {"hive.tez.cpu.vcores": 2, "tez.grouping.split-count": "3"}}`
                 Defaults to `{}`.


### PR DESCRIPTION
This PR allows to configure the timeout for arrow flight which currently defaults to 30 seconds which is too short. The server has a queue timeout of 10 minutes which means the default should be longer than 10 minutes. Set it to 15 minutes and allow the user to configure it so that long running queries can be supported.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1072

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
