### PR TITLE
[FSTORE-1087] add timeout config to get_flight_info

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -204,8 +204,8 @@ class ArrowFlightClient:
         return decorator
 
     def _get_dataset(self, descriptor, timeout=DEFAULT_TIMEOUT):
-        info = self._connection.get_flight_info(descriptor)
         options = pyarrow.flight.FlightCallOptions(timeout=timeout)
+        info = self._connection.get_flight_info(descriptor, options)
         reader = self._connection.do_get(self._info_to_ticket(info), options)
         return reader.read_pandas()
 


### PR DESCRIPTION
This PR fixes a timeout during the nightly tests caused by the timeout config not being set in all places.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1087

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
