### PR TITLE
added strip to authentication headers

### DIFF
--- a/python/hsfs/client/auth.py
+++ b/python/hsfs/client/auth.py
@@ -21,7 +21,7 @@ class BearerAuth(requests.auth.AuthBase):
     """Class to encapsulate a Bearer token."""
 
     def __init__(self, token):
-        self._token = token
+        self._token = token.strip()
 
     def __call__(self, r):
         r.headers["Authorization"] = "Bearer " + self._token
@@ -32,7 +32,7 @@ class ApiKeyAuth(requests.auth.AuthBase):
     """Class to encapsulate an API key."""
 
     def __init__(self, token):
-        self._token = token
+        self._token = token.strip()
 
     def __call__(self, r):
         r.headers["Authorization"] = "ApiKey " + self._token


### PR DESCRIPTION
This PR adds a stripping of the authentication headers. 
- Analog to https://github.com/logicalclocks/hopsworks-api/pull/185, this PR changes the authentication header to strip the API key before handing it to the underlying HTTP library. This is simply due to the fact that if there is, for example, a trailing or a leading newline, the HTTP library performs a check on the validity of the header and sees that it is not valid (since newline characters are not allowed to be sent as part of the header) and therefore throws a ValueError, which prints the Invalid header value (in the tested case, the API key). 
- No changes have been made to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: https://github.com/logicalclocks/hopsworks-api/pull/185

**How Has This Been Tested?**

- [x] Unit Tests (on the hopsworks-api tests)
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [ ] (Checked if all type annotations were added and/or updated appropriately)
```
