### PR TITLE
[FSTORE-1110] Recreation of Training dataset throwing exception due to NULL reference

### DIFF
--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -1656,7 +1656,7 @@ class FeatureView:
     def recreate_training_dataset(
         self,
         training_dataset_version: int,
-        write_options: Optional[Dict[Any, Any]] = None,
+        write_options: Optional[Dict[Any, Any]] = {},
         spine: Optional[
             Union[
                 pd.DataFrame,


### PR DESCRIPTION
This PR fixes the function recreate_training_data

- Correcting default value for write_options to an empty dictionary in recreate_training_data.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1110

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
