### PR TITLE
Added support for converting pandas arrow types

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -31,6 +31,7 @@ import decimal
 import numbers
 import math
 import os
+import pytz
 from datetime import datetime, timezone
 
 import great_expectations as ge
@@ -468,11 +469,11 @@ class Engine:
     def parse_schema_feature_group(self, dataframe, time_travel_format=None):
         arrow_schema = pa.Schema.from_pandas(dataframe)
         features = []
-        for feat_name, feat_type in dataframe.dtypes.items():
+        for feat_name, _ in dataframe.dtypes.items():
             name = feat_name.lower()
             try:
                 converted_type = self._convert_pandas_dtype_to_offline_type(
-                    feat_type, arrow_schema.field(feat_name).type
+                    arrow_schema.field(feat_name).type
                 )
             except ValueError as e:
                 raise FeatureStoreException(f"Feature '{name}': {str(e)}")
@@ -1154,14 +1155,17 @@ class Engine:
         return config
 
     @staticmethod
-    def _convert_pandas_dtype_to_offline_type(dtype, arrow_type):
+    def _convert_pandas_dtype_to_offline_type(arrow_type):
         # This is a simple type conversion between pandas dtypes and pyspark (hive) types,
-        # using pyarrow types to convert "O (object)"-typed fields.
+        # using pyarrow types obatined from pandas dataframe to convert pandas typed fields,
+        # A recurisive function  "_convert_pandas_object_type_to_offline_type" is used to convert complex types like lists and structures
+        # "_convert_simple_pandas_dtype_to_offline_type" is used to convert simple types
         # In the backend, the types specified here will also be used for mapping to Avro types.
-        if dtype == np.dtype("O"):
+
+        if pa.types.is_list(arrow_type) or pa.types.is_struct(arrow_type):
             return Engine._convert_pandas_object_type_to_offline_type(arrow_type)
 
-        return Engine._convert_simple_pandas_dtype_to_offline_type(dtype)
+        return Engine._convert_simple_pandas_dtype_to_offline_type(arrow_type)
 
     @staticmethod
     def convert_spark_type_to_offline_type(spark_type_string):
@@ -1195,89 +1199,53 @@ class Engine:
             )
 
     @staticmethod
-    def _convert_simple_pandas_dtype_to_offline_type(dtype):
-        if dtype == np.dtype("uint8"):
-            return "int"
-        elif dtype == np.dtype("uint16"):
-            return "int"
-        elif dtype == np.dtype("int8"):
-            return "int"
-        elif dtype == np.dtype("int16"):
-            return "int"
-        elif dtype == np.dtype("int32"):
-            return "int"
-        elif dtype == np.dtype("uint32"):
-            return "bigint"
-        elif dtype == np.dtype("int64"):
-            return "bigint"
-        elif dtype == np.dtype("float16"):
-            return "float"
-        elif dtype == np.dtype("float32"):
-            return "float"
-        elif dtype == np.dtype("float64"):
-            return "double"
-        elif dtype == np.dtype("datetime64[ns]"):
-            return "timestamp"
-        elif dtype == np.dtype("bool"):
-            return "boolean"
-        elif dtype == "category":
-            return "string"
-        elif str(dtype) == "string":
-            return "string"
-        elif not isinstance(dtype, np.dtype):
-            if dtype == pd.Int8Dtype():
-                return "int"
-            elif dtype == pd.Int16Dtype():
-                return "int"
-            elif dtype == pd.Int32Dtype():
-                return "int"
-            elif dtype == pd.Int64Dtype():
-                return "bigint"
+    def _convert_simple_pandas_dtype_to_offline_type(arrow_type):
+        arrow_type = str(arrow_type).lower()
+        # Decimal types are currently not supported
+        pyarrow_hopswork_dtype_mapping = {
+            **dict.fromkeys(["uint8", "uint16", "int8", "int16", "int32"], "int"),
+            **dict.fromkeys(["uint32", "int64"], "bigint"),
+            **dict.fromkeys(
+                ["float", "halffloat"], "float"
+            ),  # float16 is represented as halffloat in pyarrow type
+            **dict.fromkeys(["double"], "double"),
+            **dict.fromkeys(
+                ["timestamp[ns]"]
+                + [f"timestamp[ns, tz={tz}]".lower() for tz in pytz.all_timezones],
+                "timestamp",
+            ),  # datetime64[ns] represented as timestamp[ns] in pyarrow type
+            **dict.fromkeys(["bool"], "boolean"),
+            **dict.fromkeys(["string", "category"], "string"),
+            **dict.fromkeys(["date32[day]", "date64[ms]"], "date"),
+            **dict.fromkeys(["binary"], "binary"),
+        }
 
-        raise ValueError(f"dtype '{dtype}' not supported")
+        try:
+            return pyarrow_hopswork_dtype_mapping[arrow_type]
+        except KeyError:
+            raise ValueError(f"dtype '{arrow_type}' not supported")
 
     @staticmethod
     def _convert_pandas_object_type_to_offline_type(arrow_type):
         if pa.types.is_list(arrow_type):
             # figure out sub type
             sub_arrow_type = arrow_type.value_type
-            try:
-                sub_dtype = np.dtype(sub_arrow_type.to_pandas_dtype())
-            except NotImplementedError:
-                sub_dtype = np.dtype("object")
-            subtype = Engine._convert_pandas_dtype_to_offline_type(
-                sub_dtype, sub_arrow_type
-            )
+            subtype = Engine._convert_pandas_dtype_to_offline_type(sub_arrow_type)
             return "array<{}>".format(subtype)
         if pa.types.is_struct(arrow_type):
             struct_schema = {}
             for index in range(arrow_type.num_fields):
                 sub_arrow_type = arrow_type.field(index).type
-                try:
-                    sub_dtype = np.dtype(sub_arrow_type.to_pandas_dtype())
-                except NotImplementedError:
-                    sub_dtype = np.dtype("object")
                 struct_schema[
                     arrow_type.field(index).name
                 ] = Engine._convert_pandas_dtype_to_offline_type(
-                    sub_dtype, arrow_type.field(index).type
+                    arrow_type.field(index).type
                 )
             return (
                 "struct<"
                 + ",".join([f"{key}:{value}" for key, value in struct_schema.items()])
                 + ">"
             )
-        # Currently not supported
-        # elif pa.types.is_decimal(arrow_type):
-        #    return str(arrow_type).replace("decimal128", "decimal")
-        elif pa.types.is_date(arrow_type):
-            return "date"
-        elif pa.types.is_binary(arrow_type):
-            return "binary"
-        elif pa.types.is_string(arrow_type) or pa.types.is_unicode(arrow_type):
-            return "string"
-        elif pa.types.is_boolean(arrow_type):
-            return "boolean"
 
         raise ValueError(f"dtype 'O' (arrow_type '{str(arrow_type)}') not supported")
 

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -1572,6 +1572,346 @@ class TestPython:
             == "struct<user0:array<struct<value:array<double>>>,user1:array<struct<value:array<double>>>>"
         )
 
+    def test_infer_type_pandas_pyarrow_int8(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="int8[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "int"
+
+    def test_infer_type_pandas_pyarrow_int16(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="int16[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "int"
+
+    def test_infer_type_pandas_pyarrow_int32(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="int32[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "int"
+
+    def test_infer_type_pandas_pyarrow_int64(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="int64[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "bigint"
+
+    def test_infer_type_pandas_pyarrow_uint8(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="uint8[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "int"
+
+    def test_infer_type_pandas_pyarrow_uint16(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="uint16[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "int"
+
+    def test_infer_type_pandas_pyarrow_uint32(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="uint32[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "bigint"
+
+    def test_infer_type_pandas_pyarrow_float32(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="float32[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "float"
+
+    def test_infer_type_pandas_pyarrow_float64(self):
+        # Arrange
+        pdf = pd.DataFrame({"data": pd.Series([1, 5], dtype="float64[pyarrow]")})
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "double"
+
+    def test_infer_type_pandas_pyarrow_datetime_ns(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    [datetime(2016, 3, 21), datetime(2012, 1, 1)],
+                    dtype=pd.ArrowDtype(pa.timestamp("ns")),
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "timestamp"
+
+    def test_infer_type_pandas_pyarrow_datetime_ns_tz(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    [datetime(2006, 12, 12), datetime(2011, 11, 11)],
+                    dtype=pd.ArrowDtype(pa.timestamp("ns", tz="UTC")),
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "timestamp"
+
+    def test_infer_type_pandas_pyarrow_date32(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    [date(year=2001, month=1, day=1), date(year=2002, month=2, day=2)],
+                    dtype=pd.ArrowDtype(pa.date32()),
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "date"
+
+    def test_infer_type_pandas_pyarrow_date64(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    [date(year=2001, month=1, day=1), date(year=2002, month=2, day=2)],
+                    dtype=pd.ArrowDtype(pa.date64()),
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "date"
+
+    def test_infer_type_pandas_pyarrow_binary(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {"data": pd.Series(["Test1 ", "Test2 longer"], dtype="binary[pyarrow]")}
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "binary"
+
+    def test_infer_type_pandas_pyarrow_string(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    ["Test1 ", "Test2 longer"], dtype=pd.ArrowDtype(pa.string())
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "string"
+
+    def test_infer_type_pandas_pyarrow_utf8(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {"data": pd.Series(["Test1 ", "Test2 longer"], dtype="utf8[pyarrow]")}
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_simple_pandas_dtype_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "string"
+
+    def test_infer_type_pandas_pyarrow_list(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    [["l1", "l2", "l3", "l4"], ["l5", "l6", "l7", "l8"]],
+                    dtype=pd.ArrowDtype(pa.list_(pa.string())),
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_pandas_object_type_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "array<string>"
+
+    def test_infer_type_pandas_pyarrow_struct(self):
+        # Arrange
+        pdf = pd.DataFrame(
+            {
+                "data": pd.Series(
+                    [{"x": 0, "y": "test1"}, {"x": 99, "y": "test99"}],
+                    dtype=pd.ArrowDtype(pa.struct({"x": pa.int32(), "y": pa.string()})),
+                )
+            }
+        )
+        arrow_schema = pa.Schema.from_pandas(pdf)
+
+        python_engine = python.Engine()
+
+        # Act
+        arrow_type = python_engine._convert_pandas_object_type_to_offline_type(
+            arrow_schema.field("data").type
+        )
+        print(arrow_type)
+
+        # Assert
+        assert arrow_type == "struct<x:int,y:string>"
+
     def test_save_dataframe(self, mocker):
         # Arrange
         mock_python_engine_write_dataframe_kafka = mocker.patch(

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -1070,7 +1070,9 @@ class TestPython:
         python_engine = python.Engine()
 
         # Act
-        python_engine._convert_pandas_dtype_to_offline_type(dtype=None, arrow_type=None)
+        python_engine._convert_pandas_dtype_to_offline_type(
+            arrow_type=pa.from_numpy_dtype(np.int64)
+        )
 
         # Assert
         assert mock_python_engine_infer_type_pyarrow.call_count == 0
@@ -1088,12 +1090,13 @@ class TestPython:
         python_engine = python.Engine()
 
         # Act
+        python_engine._convert_pandas_dtype_to_offline_type(arrow_type=pa.struct({}))
         python_engine._convert_pandas_dtype_to_offline_type(
-            dtype=np.dtype("O"), arrow_type=None
+            arrow_type=pa.list_(pa.int32())
         )
 
         # Assert
-        assert mock_python_engine_infer_type_pyarrow.call_count == 1
+        assert mock_python_engine_infer_type_pyarrow.call_count == 2
         assert mock_python_engine_convert_simple_pandas_type.call_count == 0
 
     def test_convert_simple_pandas_type_uint8(self):
@@ -1102,7 +1105,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("uint8")
+            arrow_type=pa.from_numpy_dtype(np.dtype("uint8"))
         )
 
         # Assert
@@ -1114,7 +1117,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("uint16")
+            arrow_type=pa.from_numpy_dtype(np.dtype("uint16"))
         )
 
         # Assert
@@ -1126,7 +1129,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("int8")
+            arrow_type=pa.from_numpy_dtype(np.dtype("int8"))
         )
 
         # Assert
@@ -1138,7 +1141,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("int16")
+            arrow_type=pa.from_numpy_dtype(np.dtype("int16"))
         )
 
         # Assert
@@ -1150,7 +1153,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("int32")
+            arrow_type=pa.from_numpy_dtype(np.dtype("int32"))
         )
 
         # Assert
@@ -1162,7 +1165,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("uint32")
+            arrow_type=pa.from_numpy_dtype(np.dtype("uint32"))
         )
 
         # Assert
@@ -1174,7 +1177,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("int64")
+            arrow_type=pa.from_numpy_dtype(np.dtype("int64"))
         )
 
         # Assert
@@ -1186,7 +1189,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("float16")
+            arrow_type=pa.from_numpy_dtype(np.dtype("float16"))
         )
 
         # Assert
@@ -1198,7 +1201,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("float32")
+            arrow_type=pa.from_numpy_dtype(np.dtype("float32"))
         )
 
         # Assert
@@ -1210,7 +1213,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("float64")
+            arrow_type=pa.from_numpy_dtype(np.dtype("float64"))
         )
 
         # Assert
@@ -1222,7 +1225,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("datetime64[ns]")
+            arrow_type=pa.from_numpy_dtype(np.dtype("datetime64[ns]"))
         )
 
         # Assert
@@ -1234,7 +1237,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype=np.dtype("bool")
+            arrow_type=pa.from_numpy_dtype(np.dtype("bool"))
         )
 
         # Assert
@@ -1246,7 +1249,7 @@ class TestPython:
 
         # Act
         result = python_engine._convert_simple_pandas_dtype_to_offline_type(
-            dtype="category"
+            arrow_type="category"
         )
 
         # Assert
@@ -1258,7 +1261,9 @@ class TestPython:
 
         # Act
         with pytest.raises(ValueError) as e_info:
-            python_engine._convert_simple_pandas_dtype_to_offline_type(dtype="other")
+            python_engine._convert_simple_pandas_dtype_to_offline_type(
+                arrow_type="other"
+            )
 
         # Assert
         assert str(e_info.value) == "dtype 'other' not supported"
@@ -1310,7 +1315,7 @@ class TestPython:
         mock_python_engine_convert_pandas_type.return_value = "test"
 
         # Act
-        result = python_engine._convert_pandas_object_type_to_offline_type(
+        result = python_engine._convert_simple_pandas_dtype_to_offline_type(
             arrow_type=pa.date32()
         )
 
@@ -1328,7 +1333,7 @@ class TestPython:
         mock_python_engine_convert_pandas_type.return_value = "test"
 
         # Act
-        result = python_engine._convert_pandas_object_type_to_offline_type(
+        result = python_engine._convert_simple_pandas_dtype_to_offline_type(
             arrow_type=pa.binary()
         )
 
@@ -1346,7 +1351,7 @@ class TestPython:
         mock_python_engine_convert_pandas_type.return_value = "test"
 
         # Act
-        result = python_engine._convert_pandas_object_type_to_offline_type(
+        result = python_engine._convert_simple_pandas_dtype_to_offline_type(
             arrow_type=pa.string()
         )
 
@@ -1364,7 +1369,7 @@ class TestPython:
         mock_python_engine_convert_pandas_type.return_value = "test"
 
         # Act
-        result = python_engine._convert_pandas_object_type_to_offline_type(
+        result = python_engine._convert_simple_pandas_dtype_to_offline_type(
             arrow_type=pa.utf8()
         )
 
@@ -1383,12 +1388,12 @@ class TestPython:
 
         # Act
         with pytest.raises(ValueError) as e_info:
-            python_engine._convert_pandas_object_type_to_offline_type(
+            python_engine._convert_simple_pandas_dtype_to_offline_type(
                 arrow_type=pa.time32("s")
             )
 
         # Assert
-        assert str(e_info.value) == "dtype 'O' (arrow_type 'time32[s]') not supported"
+        assert str(e_info.value) == "dtype 'time32[s]' not supported"
 
     def test_infer_type_pyarrow_struct_with_decimal_fields(self):
         # Arrange


### PR DESCRIPTION
This PR fixes issue of pyarrow types introduced as part of pandas 2.0 not being insterted into the feature store.

- Changes were made in this PR adds support to convert for arrow datatype introduced in pandas 2.0.
- This PR changes the way the conversion between pandas datatypes were performed to increase readability and maintainability of the code. Dicussion done in design log - https://hopsworks.atlassian.net/wiki/spaces/FST/pages/279314450/Conversion+of+Pandas+arrow+datatypes+to+hopsworks+internal+Datatypes
- Testing involved checking if all types and corresponding arrow types mentioned as part of hopsworks documentation is inserted into the feature group.
- Some datatypes present introducted as part of pyarrow in pandas are not added since they were not explicitly mentioned in the hopsworks documentation. The datatypes not added are mentioned are - uint64, large_binary, large_string, large_utf8, large_list, fixed_size_list (pyarrow list with max size mentioned), maps, dictonary (used for efficent array storage in pyarrow)  



JIRA Issue: - https://hopsworks.atlassian.net/browse/FSTORE-1118

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
