### PR TITLE
[FSTORE-1118][APPEND] Disable preserve_index for pyarrow from_pandas

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -499,7 +499,7 @@ class Engine:
         )
 
     def parse_schema_feature_group(self, dataframe, time_travel_format=None):
-        arrow_schema = pa.Schema.from_pandas(dataframe)
+        arrow_schema = pa.Schema.from_pandas(dataframe, preserve_index=False)
         features = []
         for feat_name in arrow_schema.names:
             name = feat_name.lower()


### PR DESCRIPTION
This PR fixes:
```
HTTP code: 400, HTTP reason: Bad Request, body: b'{"errorCode":270040,"usrMsg":", the provided feature name __index_level_0__ is invalid. Feature names can only contain lower case characters, numbers and underscores, have to start with a letter and cannot be longer than 63 characters or empty."
```

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
