### PR TITLE
[FSTORE-1184] Kafka storage connector confluent_options method uses wrong certificates

### DIFF
--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -996,7 +996,10 @@ class KafkaConnector(StorageConnector):
             "ssl.endpoint.identification.algorithm"
         ] = self._ssl_endpoint_identification_algorithm
 
-        if not self._external_kafka:
+        # Here we cannot use `not self._external_kafka` as for normal kafka connectors
+        # this option is not set and so the `not self._external_kafka` would return true
+        # overwriting the user specified certificates
+        if self._external_kafka is False:
             self._ssl_truststore_location = (
                 client.get_instance()._get_jks_trust_store_path()
             )
@@ -1007,7 +1010,7 @@ class KafkaConnector(StorageConnector):
             self._ssl_keystore_password = client.get_instance()._cert_key
             self._ssl_key_password = client.get_instance()._cert_key
 
-        if self.ssl_truststore_location is not None:
+        if self._ssl_truststore_location is not None:
             config["ssl.truststore.location"] = self._ssl_truststore_location
         if self._ssl_truststore_password is not None:
             config["ssl.truststore.password"] = self._ssl_truststore_password

--- a/python/tests/fixtures/storage_connector_fixtures.json
+++ b/python/tests/fixtures/storage_connector_fixtures.json
@@ -341,6 +341,38 @@
             "ssl_keystore_password": "test_ssl_keystore_password",
             "ssl_key_password": "test_ssl_key_password",
             "ssl_endpoint_identification_algorithm": "test_ssl_endpoint_identification_algorithm",
+            "options": [{"name":  "test_option_name", "value":  "test_option_value"}]
+        },
+        "method": "GET",
+        "path_params": [
+            "project",
+            "119",
+            "featurestores",
+            67,
+            "storageconnectors",
+            "test_kafka"
+        ],
+        "query_params": {
+            "temporaryCredentials": true
+        },
+        "headers": null
+    },
+    "get_kafka_internal": {
+        "response": {
+            "type": "featurestoreKafkaConnectorDTO",
+            "description": "Kafka connector description",
+            "featurestoreId": 67,
+            "id": 1,
+            "name": "test_kafka",
+            "storageConnectorType": "KAFKA",
+            "bootstrap_servers": "test_bootstrap_servers",
+            "security_protocol": "test_security_protocol",
+            "ssl_truststore_location": "test_ssl_truststore_location",
+            "ssl_truststore_password": "test_ssl_truststore_password",
+            "ssl_keystore_location": "test_ssl_keystore_location",
+            "ssl_keystore_password": "test_ssl_keystore_password",
+            "ssl_key_password": "test_ssl_key_password",
+            "ssl_endpoint_identification_algorithm": "test_ssl_endpoint_identification_algorithm",
             "options": [{"name":  "test_option_name", "value":  "test_option_value"}],
             "externalKafka": false
         },

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -446,7 +446,7 @@ class TestKafkaConnector:
     def test_from_response_json(self, mocker, backend_fixtures):
         # Arrange
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        json = backend_fixtures["storage_connector"]["get_kafka"]["response"]
+        json = backend_fixtures["storage_connector"]["get_kafka_internal"]["response"]
 
         mock_engine_get_instance.return_value.add_file.return_value = (
             "result_from_add_file"
@@ -500,11 +500,40 @@ class TestKafkaConnector:
         assert sc.ssl_endpoint_identification_algorithm is None
         assert sc.options == {}
 
-    def test_kafka_options(self, mocker, backend_fixtures):
+    # Unit test for storage connector created by user (i.e. without the external flag)
+    def test_kafka_options_user_sc(self, mocker, backend_fixtures):
+        # Arrange
+        mocker.patch("hsfs.client.get_instance")
+        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
+        json = backend_fixtures["storage_connector"]["get_kafka"]["response"]
+
+        mock_engine_get_instance.return_value.add_file.return_value = (
+            "result_from_add_file"
+        )
+
+        sc = storage_connector.StorageConnector.from_response_json(json)
+
+        # Act
+        config = sc.kafka_options()
+
+        # Assert
+        assert config == {
+            "test_option_name": "test_option_value",
+            "bootstrap.servers": "test_bootstrap_servers",
+            "security.protocol": "test_security_protocol",
+            "ssl.endpoint.identification.algorithm": "test_ssl_endpoint_identification_algorithm",
+            "ssl.truststore.location": "result_from_add_file",
+            "ssl.truststore.password": "test_ssl_truststore_password",
+            "ssl.keystore.location": "result_from_add_file",
+            "ssl.keystore.password": "test_ssl_keystore_password",
+            "ssl.key.password": "test_ssl_key_password",
+        }
+
+    def test_kafka_options_intenral(self, mocker, backend_fixtures):
         # Arrange
         mocker.patch("hsfs.engine.get_instance")
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        json = backend_fixtures["storage_connector"]["get_kafka"]["response"]
+        json = backend_fixtures["storage_connector"]["get_kafka_internal"]["response"]
 
         mock_client_get_instance.return_value._get_jks_trust_store_path.return_value = (
             "result_from_get_jks_trust_store_path"
@@ -563,7 +592,7 @@ class TestKafkaConnector:
         # Arrange
         mocker.patch("hsfs.engine.get_instance")
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        json = backend_fixtures["storage_connector"]["get_kafka"]["response"]
+        json = backend_fixtures["storage_connector"]["get_kafka_internal"]["response"]
 
         mock_client_get_instance.return_value._get_jks_trust_store_path.return_value = (
             "result_from_get_jks_trust_store_path"
@@ -621,7 +650,7 @@ class TestKafkaConnector:
     def test_confluent_options(self, mocker, backend_fixtures):
         # Arrange
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
-        json = backend_fixtures["storage_connector"]["get_kafka"]["response"]
+        json = backend_fixtures["storage_connector"]["get_kafka_internal"]["response"]
 
         mock_engine_get_instance.return_value.add_file.return_value = (
             "result_from_add_file"


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
