### PR TITLE
[FSTORE-1186] Polars Integration into Hopsworks - Writing DataFrames

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -217,18 +217,18 @@ class ArrowFlightClient:
         return self._connection.get_flight_info(descriptor)
 
     def _get_dataset(
-        self, descriptor, timeout=DEFAULT_TIMEOUT, dataframe_type="pandas"
+        self, descriptor, timeout=DEFAULT_TIMEOUT, dataframe_type="default"
     ):
         info = self.get_flight_info(descriptor)
         options = pyarrow.flight.FlightCallOptions(timeout=timeout)
         reader = self._connection.do_get(self._info_to_ticket(info), options)
-        if dataframe_type.lower() == "pandas":
-            return reader.read_pandas()
-        else:
+        if dataframe_type.lower() == "polars":
             return pl.from_arrow(reader.read_all())
+        else:
+            return reader.read_pandas()
 
     @_handle_afs_exception(user_message=READ_ERROR)
-    def read_query(self, query_object, arrow_flight_config, dataframe_type="pandas"):
+    def read_query(self, query_object, arrow_flight_config, dataframe_type):
         query_encoded = json.dumps(query_object).encode("ascii")
         descriptor = pyarrow.flight.FlightDescriptor.for_command(query_encoded)
         return self._get_dataset(

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -233,9 +233,11 @@ class ArrowFlightClient:
         descriptor = pyarrow.flight.FlightDescriptor.for_command(query_encoded)
         return self._get_dataset(
             descriptor,
-            arrow_flight_config.get("timeout")
-            if arrow_flight_config
-            else self.DEFAULT_TIMEOUT,
+            (
+                arrow_flight_config.get("timeout")
+                if arrow_flight_config
+                else self.DEFAULT_TIMEOUT
+            ),
             dataframe_type,
         )
 

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -61,9 +61,11 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
             engine.get_instance().save_dataframe(
                 feature_group,
                 feature_dataframe,
-                hudi_engine.HudiEngine.HUDI_BULK_INSERT
-                if feature_group.time_travel_format in ["HUDI", "DELTA"]
-                else None,
+                (
+                    hudi_engine.HudiEngine.HUDI_BULK_INSERT
+                    if feature_group.time_travel_format in ["HUDI", "DELTA"]
+                    else None
+                ),
                 feature_group.online_enabled,
                 None,
                 offline_write_options,
@@ -271,9 +273,11 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
                 engine.get_instance().save_dataframe(
                     feature_group,
                     engine.get_instance().create_empty_df(dataframe),
-                    hudi_engine.HudiEngine.HUDI_BULK_INSERT
-                    if feature_group.time_travel_format == "HUDI"
-                    else None,
+                    (
+                        hudi_engine.HudiEngine.HUDI_BULK_INSERT
+                        if feature_group.time_travel_format == "HUDI"
+                        else None
+                    ),
                     feature_group.online_enabled,
                     None,
                     offline_write_options,

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -287,7 +287,7 @@ class FeatureViewEngine:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
-        dataframe_type="default"
+        dataframe_type="default",
     ):
         # check if provided td version has already existed.
         if training_dataset_version:
@@ -329,7 +329,11 @@ class FeatureViewEngine:
                 feature_view_features=[
                     feature.name for feature in feature_view_obj.features
                 ],
-                dataframe_type="default" if  dataframe_type.lower() in ["numpy", "python"] else dataframe_type# forcing dataframe type to default here since dataframe operations are required for training data split. 
+                dataframe_type=(
+                    "default"
+                    if dataframe_type.lower() in ["numpy", "python"]
+                    else dataframe_type
+                ),  # forcing dataframe type to default here since dataframe operations are required for training data split.
             )
         else:
             self._check_feature_group_accessibility(feature_view_obj)
@@ -345,7 +349,7 @@ class FeatureViewEngine:
                 training_helper_columns=training_helper_columns,
                 spine=spine,
             )
-            # Forcing dataframe type as default for 
+            # Forcing dataframe type as default for
             split_df = engine.get_instance().get_training_data(
                 td_updated, feature_view_obj, query, read_options, dataframe_type
             )
@@ -441,7 +445,7 @@ class FeatureViewEngine:
         with_training_helper_columns,
         training_helper_columns,
         feature_view_features,
-        dataframe_type
+        dataframe_type,
     ):
         if splits:
             result = {}
@@ -458,7 +462,7 @@ class FeatureViewEngine:
                     with_training_helper_columns,
                     training_helper_columns,
                     feature_view_features,
-                    dataframe_type
+                    dataframe_type,
                 )
             return result
         else:
@@ -474,7 +478,7 @@ class FeatureViewEngine:
                 with_training_helper_columns,
                 training_helper_columns,
                 feature_view_features,
-                dataframe_type
+                dataframe_type,
             )
 
     def _cast_columns(self, data_format, df, schema):
@@ -497,7 +501,7 @@ class FeatureViewEngine:
         with_training_helper_columns,
         training_helper_columns,
         feature_view_features,
-        dataframe_type
+        dataframe_type,
     ):
         try:
             df = training_data_obj.storage_connector.read(
@@ -506,7 +510,7 @@ class FeatureViewEngine:
                 data_format=training_data_obj.data_format,
                 options=read_options,
                 path=path,
-                dataframe_type=dataframe_type
+                dataframe_type=dataframe_type,
             )
 
             df = self._drop_helper_columns(
@@ -713,7 +717,7 @@ class FeatureViewEngine:
         primary_keys=False,
         event_time=False,
         inference_helper_columns=False,
-        dataframe_type="default"
+        dataframe_type="default",
     ):
         self._check_feature_group_accessibility(feature_view_obj)
 

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -287,6 +287,7 @@ class FeatureViewEngine:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type="default"
     ):
         # check if provided td version has already existed.
         if training_dataset_version:
@@ -328,6 +329,7 @@ class FeatureViewEngine:
                 feature_view_features=[
                     feature.name for feature in feature_view_obj.features
                 ],
+                dataframe_type="default" if  dataframe_type.lower() in ["numpy", "python"] else dataframe_type# forcing dataframe type to default here since dataframe operations are required for training data split. 
             )
         else:
             self._check_feature_group_accessibility(feature_view_obj)
@@ -343,8 +345,9 @@ class FeatureViewEngine:
                 training_helper_columns=training_helper_columns,
                 spine=spine,
             )
+            # Forcing dataframe type as default for 
             split_df = engine.get_instance().get_training_data(
-                td_updated, feature_view_obj, query, read_options
+                td_updated, feature_view_obj, query, read_options, dataframe_type
             )
             self.compute_training_dataset_statistics(
                 feature_view_obj, td_updated, split_df
@@ -355,7 +358,7 @@ class FeatureViewEngine:
             for split in td_updated.splits:
                 split_name = split.name
                 split_df[split_name] = engine.get_instance().split_labels(
-                    split_df[split_name], feature_view_obj.labels
+                    split_df[split_name], feature_view_obj.labels, dataframe_type
                 )
             feature_dfs = []
             label_dfs = []
@@ -365,7 +368,7 @@ class FeatureViewEngine:
             return td_updated, feature_dfs + label_dfs
         else:
             split_df = engine.get_instance().split_labels(
-                split_df, feature_view_obj.labels
+                split_df, feature_view_obj.labels, dataframe_type
             )
             return td_updated, split_df
 
@@ -438,6 +441,7 @@ class FeatureViewEngine:
         with_training_helper_columns,
         training_helper_columns,
         feature_view_features,
+        dataframe_type
     ):
         if splits:
             result = {}
@@ -454,6 +458,7 @@ class FeatureViewEngine:
                     with_training_helper_columns,
                     training_helper_columns,
                     feature_view_features,
+                    dataframe_type
                 )
             return result
         else:
@@ -469,6 +474,7 @@ class FeatureViewEngine:
                 with_training_helper_columns,
                 training_helper_columns,
                 feature_view_features,
+                dataframe_type
             )
 
     def _cast_columns(self, data_format, df, schema):
@@ -491,6 +497,7 @@ class FeatureViewEngine:
         with_training_helper_columns,
         training_helper_columns,
         feature_view_features,
+        dataframe_type
     ):
         try:
             df = training_data_obj.storage_connector.read(
@@ -499,6 +506,7 @@ class FeatureViewEngine:
                 data_format=training_data_obj.data_format,
                 options=read_options,
                 path=path,
+                dataframe_type=dataframe_type
             )
 
             df = self._drop_helper_columns(
@@ -705,6 +713,7 @@ class FeatureViewEngine:
         primary_keys=False,
         event_time=False,
         inference_helper_columns=False,
+        dataframe_type="default"
     ):
         self._check_feature_group_accessibility(feature_view_obj)
 
@@ -719,7 +728,7 @@ class FeatureViewEngine:
             training_helper_columns=False,
             training_dataset_version=training_dataset_version,
             spine=spine,
-        ).read(read_options=read_options)
+        ).read(read_options=read_options, dataframe_type=dataframe_type)
         if transformation_functions:
             return engine.get_instance()._apply_transformation_function(
                 transformation_functions, dataset=feature_dataframe

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -20,6 +20,7 @@ import avro.io
 from sqlalchemy import sql, bindparam, exc, text
 import numpy as np
 import pandas as pd
+import polars as pl
 from hsfs import util
 from hsfs import training_dataset, feature_view, client
 from hsfs.serving_key import ServingKey
@@ -292,6 +293,10 @@ class VectorServer:
             pandas_df = pd.DataFrame(vector).transpose()
             pandas_df.columns = self._feature_vector_col_name
             return pandas_df
+        elif return_type.lower() == "polars":
+            # Polar considers one dimensional list as a single columns so passed vector as 2d list 
+            polars_df = pl.DataFrame([vector], schema=self._feature_vector_col_name, orient="row") 
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'list', 'pandas' and 'numpy'"
@@ -337,6 +342,9 @@ class VectorServer:
             pandas_df = pd.DataFrame(vectors)
             pandas_df.columns = self._feature_vector_col_name
             return pandas_df
+        elif return_type.lower() == "polars":
+            polars_df = pl.DataFrame(vectors, schema=self._feature_vector_col_name, orient="row")
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'list', 'pandas' and 'numpy'"
@@ -353,6 +361,10 @@ class VectorServer:
             return pd.DataFrame([serving_vector])
         elif return_type.lower() == "dict":
             return serving_vector
+        elif return_type.lower() == "polars":
+            # Polar considers one dimensional list as a single columns so passed vector as 2d list 
+            polars_df = pl.DataFrame([serving_vector], schema=self._feature_vector_col_name, orient="row") 
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'pandas' and 'dict'"
@@ -386,6 +398,9 @@ class VectorServer:
             return batch_results
         elif return_type.lower() == "pandas":
             return pd.DataFrame(batch_results)
+        elif return_type.lower() == "polars":
+            polars_df = pl.DataFrame(batch_results, schema=self._feature_vector_col_name, orient="row")
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'dict' and 'pandas'"

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -169,9 +169,9 @@ class VectorServer:
 
         self._prefix_by_serving_index = prefix_by_serving_index
         for sk in self._serving_keys:
-            self._serving_key_by_serving_index[
-                sk.join_index
-            ] = self._serving_key_by_serving_index.get(sk.join_index, []) + [sk]
+            self._serving_key_by_serving_index[sk.join_index] = (
+                self._serving_key_by_serving_index.get(sk.join_index, []) + [sk]
+            )
         # sort the serving by PreparedStatementParameter.index
         for join_index in self._serving_key_by_serving_index:
             # feature_name_order_by_psp do not include the join index when the joint feature only contains label only
@@ -199,9 +199,9 @@ class VectorServer:
             if prepared_statement.feature_group_id in self._skip_fg_ids:
                 continue
             query_online = str(prepared_statement.query_online).replace("\n", " ")
-            prefix_by_serving_index[
-                prepared_statement.prepared_statement_index
-            ] = prepared_statement.prefix
+            prefix_by_serving_index[prepared_statement.prepared_statement_index] = (
+                prepared_statement.prefix
+            )
 
             # In java prepared statement `?` is used for parametrization.
             # In sqlalchemy `:feature_name` is used instead of `?`
@@ -212,13 +212,13 @@ class VectorServer:
                     key=lambda psp: psp.index,
                 )
             ]
-            feature_name_order_by_psp[
-                prepared_statement.prepared_statement_index
-            ] = dict(
-                [
-                    (psp.name, psp.index)
-                    for psp in prepared_statement.prepared_statement_parameters
-                ]
+            feature_name_order_by_psp[prepared_statement.prepared_statement_index] = (
+                dict(
+                    [
+                        (psp.name, psp.index)
+                        for psp in prepared_statement.prepared_statement_parameters
+                    ]
+                )
             )
             # construct serving key if it is not provided.
             if self._serving_keys is None:
@@ -245,9 +245,9 @@ class VectorServer:
                     batch_ids=bindparam("batch_ids", expanding=True)
                 )
 
-            prepared_statements_dict[
-                prepared_statement.prepared_statement_index
-            ] = query_online
+            prepared_statements_dict[prepared_statement.prepared_statement_index] = (
+                query_online
+            )
 
         # assign serving key if it is not provided.
         if self._serving_keys is None:
@@ -294,8 +294,10 @@ class VectorServer:
             pandas_df.columns = self._feature_vector_col_name
             return pandas_df
         elif return_type.lower() == "polars":
-            # Polar considers one dimensional list as a single columns so passed vector as 2d list 
-            polars_df = pl.DataFrame([vector], schema=self._feature_vector_col_name, orient="row") 
+            # Polar considers one dimensional list as a single columns so passed vector as 2d list
+            polars_df = pl.DataFrame(
+                [vector], schema=self._feature_vector_col_name, orient="row"
+            )
             return polars_df
         else:
             raise Exception(
@@ -343,7 +345,9 @@ class VectorServer:
             pandas_df.columns = self._feature_vector_col_name
             return pandas_df
         elif return_type.lower() == "polars":
-            polars_df = pl.DataFrame(vectors, schema=self._feature_vector_col_name, orient="row")
+            polars_df = pl.DataFrame(
+                vectors, schema=self._feature_vector_col_name, orient="row"
+            )
             return polars_df
         else:
             raise Exception(
@@ -362,8 +366,10 @@ class VectorServer:
         elif return_type.lower() == "dict":
             return serving_vector
         elif return_type.lower() == "polars":
-            # Polar considers one dimensional list as a single columns so passed vector as 2d list 
-            polars_df = pl.DataFrame([serving_vector], schema=self._feature_vector_col_name, orient="row") 
+            # Polar considers one dimensional list as a single columns so passed vector as 2d list
+            polars_df = pl.DataFrame(
+                [serving_vector], schema=self._feature_vector_col_name, orient="row"
+            )
             return polars_df
         else:
             raise Exception(
@@ -399,7 +405,9 @@ class VectorServer:
         elif return_type.lower() == "pandas":
             return pd.DataFrame(batch_results)
         elif return_type.lower() == "polars":
-            polars_df = pl.DataFrame(batch_results, schema=self._feature_vector_col_name, orient="row")
+            polars_df = pl.DataFrame(
+                batch_results, schema=self._feature_vector_col_name, orient="row"
+            )
             return polars_df
         else:
             raise Exception(
@@ -473,9 +481,9 @@ class VectorServer:
             if prepared_statement_index not in self._serving_key_by_serving_index:
                 continue
 
-            prepared_stmts_to_execute[
-                prepared_statement_index
-            ] = prepared_statement_objects[prepared_statement_index]
+            prepared_stmts_to_execute[prepared_statement_index] = (
+                prepared_statement_objects[prepared_statement_index]
+            )
             entry_values_tuples = list(
                 map(
                     lambda e: tuple(
@@ -522,9 +530,9 @@ class VectorServer:
                 )
                 # note: should used serialized value
                 # as it is from users' input
-                statement_results[
-                    self._get_result_key(prefix_features, row_dict)
-                ] = result_dict
+                statement_results[self._get_result_key(prefix_features, row_dict)] = (
+                    result_dict
+                )
 
             # add partial results to the global results
             for i, entry in enumerate(entries):
@@ -684,9 +692,11 @@ class VectorServer:
         transformation_fns = (
             self._transformation_function_engine.populate_builtin_attached_fns(
                 transformation_functions,
-                td_tffn_stats.feature_descriptive_statistics
-                if td_tffn_stats is not None
-                else None,
+                (
+                    td_tffn_stats.feature_descriptive_statistics
+                    if td_tffn_stats is not None
+                    else None
+                ),
             )
         )
         return transformation_fns

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -182,6 +182,17 @@ class Engine:
         hive_config=None,
         arrow_flight_config={},
     ):
+        if not isinstance(dataframe_type, str) or dataframe_type.lower() not in [
+            "pandas",
+            "polars",
+            "numpy",
+            "python",
+            "default",
+        ]:
+            raise FeatureStoreException(
+                f'dataframe_type : {dataframe_type} not supported. Possible values are "default", "spark", "pandas", "polars", "numpy" or "python"'
+            )
+
         if arrow_flight_client.get_instance().is_flyingduck_query_object(sql_query):
             result_df = util.run_with_loading_animation(
                 "Reading data from Hopsworks, using ArrowFlight",
@@ -216,6 +227,17 @@ class Engine:
         return self._return_dataframe_type(result_df, dataframe_type)
 
     def _jdbc(self, sql_query, connector, dataframe_type, read_options, schema=None):
+        if not isinstance(dataframe_type, str) or dataframe_type.lower() not in [
+            "pandas",
+            "polars",
+            "numpy",
+            "python",
+            "default",
+        ]:
+            raise FeatureStoreException(
+                f'dataframe_type : {dataframe_type} not supported. Possible values are "default", "spark", "pandas", "polars", "numpy" or "python"'
+            )
+
         if self._mysql_online_fs_engine is None:
             self._mysql_online_fs_engine = util.create_mysql_engine(
                 connector,

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -510,7 +510,7 @@ class Engine:
         )
 
     def get_training_data(
-        self, training_dataset, feature_view_obj, query_obj, read_options
+        self, training_dataset, feature_view_obj, query_obj, read_options, dataframe_type
     ):
         return self.write_training_dataset(
             training_dataset,
@@ -522,13 +522,13 @@ class Engine:
             feature_view_obj=feature_view_obj,
         )
 
-    def split_labels(self, df, labels):
+    def split_labels(self, df, labels, dataframe_type):
         if labels:
             labels_df = df.select(*labels)
             df_new = df.drop(*labels)
-            return df_new, labels_df
+            return self._return_dataframe_type(df_new, dataframe_type), self._return_dataframe_type(labels_df, dataframe_type)
         else:
-            return df, None
+            return self._return_dataframe_type(df, dataframe_type), None
 
     def drop_columns(self, df, drop_cols):
         return df.drop(*drop_cols)
@@ -693,7 +693,7 @@ class Engine:
 
         feature_dataframe.unpersist()
 
-    def read(self, storage_connector, data_format, read_options, location):
+    def read(self, storage_connector, data_format, read_options, location, dataframe_type):
         if not data_format:
             raise FeatureStoreException("data_format is not specified")
 
@@ -714,10 +714,10 @@ class Engine:
 
         path = self.setup_storage_connector(storage_connector, path)
 
-        return (
+        return self._return_dataframe_type(
             self._spark_session.read.format(data_format)
             .options(**(read_options if read_options else {}))
-            .load(path)
+            .load(path), dataframe_type=dataframe_type
         )
 
     def read_stream(

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -385,13 +385,15 @@ class Engine:
             .format(self.KAFKA_FORMAT)
             .option(
                 "checkpointLocation",
-                "/Projects/"
-                + client.get_instance()._project_name
-                + "/Resources/"
-                + query_name
-                + "-checkpoint"
-                if checkpoint_dir is None
-                else checkpoint_dir,
+                (
+                    "/Projects/"
+                    + client.get_instance()._project_name
+                    + "/Resources/"
+                    + query_name
+                    + "-checkpoint"
+                    if checkpoint_dir is None
+                    else checkpoint_dir
+                ),
             )
             .options(**write_options)
             .option("topic", feature_group._online_topic_name)
@@ -473,11 +475,14 @@ class Engine:
         """Encodes all complex type features to binary using their avro type as schema."""
         return dataframe.select(
             [
-                field["name"]
-                if field["name"] not in feature_group.get_complex_features()
-                else to_avro(
-                    field["name"], feature_group._get_feature_avro_schema(field["name"])
-                ).alias(field["name"])
+                (
+                    field["name"]
+                    if field["name"] not in feature_group.get_complex_features()
+                    else to_avro(
+                        field["name"],
+                        feature_group._get_feature_avro_schema(field["name"]),
+                    ).alias(field["name"])
+                )
                 for field in json.loads(feature_group.avro_schema)["fields"]
             ]
         )
@@ -510,7 +515,12 @@ class Engine:
         )
 
     def get_training_data(
-        self, training_dataset, feature_view_obj, query_obj, read_options, dataframe_type
+        self,
+        training_dataset,
+        feature_view_obj,
+        query_obj,
+        read_options,
+        dataframe_type,
     ):
         return self.write_training_dataset(
             training_dataset,
@@ -526,7 +536,9 @@ class Engine:
         if labels:
             labels_df = df.select(*labels)
             df_new = df.drop(*labels)
-            return self._return_dataframe_type(df_new, dataframe_type), self._return_dataframe_type(labels_df, dataframe_type)
+            return self._return_dataframe_type(
+                df_new, dataframe_type
+            ), self._return_dataframe_type(labels_df, dataframe_type)
         else:
             return self._return_dataframe_type(df, dataframe_type), None
 
@@ -693,7 +705,9 @@ class Engine:
 
         feature_dataframe.unpersist()
 
-    def read(self, storage_connector, data_format, read_options, location, dataframe_type):
+    def read(
+        self, storage_connector, data_format, read_options, location, dataframe_type
+    ):
         if not data_format:
             raise FeatureStoreException("data_format is not specified")
 
@@ -717,7 +731,8 @@ class Engine:
         return self._return_dataframe_type(
             self._spark_session.read.format(data_format)
             .options(**(read_options if read_options else {}))
-            .load(path), dataframe_type=dataframe_type
+            .load(path),
+            dataframe_type=dataframe_type,
         )
 
     def read_stream(

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1787,7 +1787,7 @@ class FeatureGroup(FeatureGroupBase):
             online: bool, optional. If `True` read from online feature store, defaults
                 to `False`.
             dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
             read_options: Additional options as key/value pairs to pass to the execution engine.
                 For spark engine: Dictionary of read options for Spark.
                 For python engine:
@@ -1806,6 +1806,7 @@ class FeatureGroup(FeatureGroupBase):
             `DataFrame`: The spark dataframe containing the feature data.
             `pyspark.DataFrame`. A Spark DataFrame.
             `pandas.DataFrame`. A Pandas DataFrame.
+            `polars.DataFrame`. A Polars DataFrame.
             `numpy.ndarray`. A two-dimensional Numpy array.
             `list`. A two-dimensional Python list.
 

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -30,6 +30,7 @@ from hsfs.constructor.filter import Filter, Logic
 from typing import Optional, Union, Any, Dict, List, TypeVar, Tuple
 
 from datetime import datetime, date
+import polars as pl
 
 from hsfs import (
     util,
@@ -1980,6 +1981,7 @@ class FeatureGroup(FeatureGroupBase):
         self,
         features: Union[
             pd.DataFrame,
+            pl.DataFrame,
             TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
             TypeVar("pyspark.RDD"),  # noqa: F821
             np.ndarray,
@@ -1996,14 +1998,14 @@ class FeatureGroup(FeatureGroupBase):
             To achieve the old behaviour, set `wait` argument to `True`.
 
         Calling `save` creates the metadata for the feature group in the feature store.
-        If a DataFrame, RDD or Ndarray is provided, the data is written to the
+        If a Pandas DataFrame, Polars DatFrame, RDD or Ndarray is provided, the data is written to the
         online/offline feature store as specified.
         By default, this writes the feature group to the offline storage, and if
         `online_enabled` for the feature group, also to the online feature store.
         The `features` dataframe can be a Spark DataFrame or RDD, a Pandas DataFrame,
         or a two-dimensional Numpy array or a two-dimensional Python nested list.
         # Arguments
-            features: DataFrame, RDD, Ndarray or a list of features. Features to be saved.
+            features: Pandas DataFrame, Polars DataFrame, RDD, Ndarray or a list of features. Features to be saved.
                 This argument is optional if the feature list is provided in the create_feature_group or
                 in the get_or_create_feature_group method invokation.
             write_options: Additional write options as key-value pairs, defaults to `{}`.
@@ -2104,6 +2106,7 @@ class FeatureGroup(FeatureGroupBase):
         self,
         features: Union[
             pd.DataFrame,
+            pl.DataFrame,
             TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
             TypeVar("pyspark.RDD"),  # noqa: F821
             np.ndarray,
@@ -2124,7 +2127,7 @@ class FeatureGroup(FeatureGroupBase):
         default, the data is inserted into the offline storage as well as the online storage if the feature group is
         `online_enabled=True`.
 
-        The `features` dataframe can be a Spark DataFrame or RDD, a Pandas DataFrame,
+        The `features` dataframe can be a Spark DataFrame or RDD, a Pandas DataFrame, a Polars DataFrame
         or a two-dimensional Numpy array or a two-dimensional Python nested list.
         If statistics are enabled, statistics are recomputed for the entire feature
         group.
@@ -2183,7 +2186,7 @@ class FeatureGroup(FeatureGroupBase):
             ```
 
         # Arguments
-            features: DataFrame, RDD, Ndarray, list. Features to be saved.
+            features: Pandas DataFrame, Polars DataFrame, RDD, Ndarray, list. Features to be saved.
             overwrite: Drop all data in the feature group before
                 inserting new data. This does not affect metadata, defaults to False.
             operation: Apache Hudi operation type `"insert"` or `"upsert"`.
@@ -2270,6 +2273,7 @@ class FeatureGroup(FeatureGroupBase):
         self,
         features: Union[
             pd.DataFrame,
+            pl.DataFrame,
             TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
             TypeVar("pyspark.RDD"),  # noqa: F821
             np.ndarray,
@@ -2340,7 +2344,7 @@ class FeatureGroup(FeatureGroupBase):
             ```
 
         # Arguments
-            features: DataFrame, RDD, Ndarray, list. Features to be saved.
+            features: Pandas DataFrame, Polars DataFrame, RDD, Ndarray, list. Features to be saved.
             overwrite: Drop all data in the feature group before
                 inserting new data. This does not affect metadata, defaults to False.
             operation: Apache Hudi operation type `"insert"` or `"upsert"`.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2839,9 +2839,9 @@ class FeatureGroup(FeatureGroupBase):
             "timeTravelFormat": self._time_travel_format,
             "features": self._features,
             "featurestoreId": self._feature_store_id,
-            "type": "cachedFeaturegroupDTO"
-            if not self._stream
-            else "streamFeatureGroupDTO",
+            "type": (
+                "cachedFeaturegroupDTO" if not self._stream else "streamFeatureGroupDTO"
+            ),
             "statisticsConfig": self._statistics_config,
             "eventTime": self.event_time,
             "expectationSuite": self._expectation_suite,
@@ -3050,9 +3050,11 @@ class ExternalFeatureGroup(FeatureGroupBase):
             # Got from Hopsworks, deserialize features and storage connector
             self._features = (
                 [
-                    feature.Feature.from_response_json(feat)
-                    if isinstance(feat, dict)
-                    else feat
+                    (
+                        feature.Feature.from_response_json(feat)
+                        if isinstance(feat, dict)
+                        else feat
+                    )
                     for feat in features
                 ]
                 if features
@@ -3275,9 +3277,11 @@ class ExternalFeatureGroup(FeatureGroupBase):
             "query": self._query,
             "dataFormat": self._data_format,
             "path": self._path,
-            "options": [{"name": k, "value": v} for k, v in self._options.items()]
-            if self._options
-            else None,
+            "options": (
+                [{"name": k, "value": v} for k, v in self._options.items()]
+                if self._options
+                else None
+            ),
             "storageConnector": self._storage_connector.to_dict(),
             "type": "onDemandFeaturegroupDTO",
             "statisticsConfig": self._statistics_config,
@@ -3402,9 +3406,11 @@ class SpineGroup(FeatureGroupBase):
             # Got from Hopsworks, deserialize features and storage connector
             self._features = (
                 [
-                    feature.Feature.from_response_json(feat)
-                    if isinstance(feat, dict)
-                    else feat
+                    (
+                        feature.Feature.from_response_json(feat)
+                        if isinstance(feat, dict)
+                        else feat
+                    )
                     for feat in features
                 ]
                 if features

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -797,7 +797,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         inference_helper_columns=False,
-        dataframe_type: Optional[str] = "default"
+        dataframe_type: Optional[str] = "default",
     ):
         """Get a batch of data from an event time interval from the offline feature store.
 
@@ -878,7 +878,7 @@ class FeatureView:
             primary_keys,
             event_time,
             inference_helper_columns,
-            dataframe_type
+            dataframe_type,
         )
 
     def add_tag(self, name: str, value):
@@ -2043,7 +2043,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
-            dataframe_type=dataframe_type
+            dataframe_type=dataframe_type,
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2220,7 +2220,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
-            dataframe_type=dataframe_type
+            dataframe_type=dataframe_type,
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2435,7 +2435,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
-            dataframe_type=dataframe_type
+            dataframe_type=dataframe_type,
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2472,7 +2472,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
-        dataframe_type: Optional[str] = "default"
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Get training data created by `feature_view.create_training_data`
@@ -2529,7 +2529,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
-            dataframe_type=dataframe_type
+            dataframe_type=dataframe_type,
         )
         return df
 
@@ -2541,7 +2541,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
-        dataframe_type: Optional[str] = "default"
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Get training data created by `feature_view.create_train_test_split`
@@ -2595,7 +2595,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
-            dataframe_type=dataframe_type
+            dataframe_type=dataframe_type,
         )
         return df
 
@@ -2607,7 +2607,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
-        dataframe_type: Optional[str] = "default"
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Get training data created by `feature_view.create_train_validation_test_split`
@@ -2665,7 +2665,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
-            dataframe_type=dataframe_type
+            dataframe_type=dataframe_type,
         )
         return df
 

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -443,13 +443,13 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"list"`, `"pandas"` or `"numpy"`. Defaults to `"list"`.
+            return_type: `"list"`, `"pandas"`, `"polars"` or `"numpy"`. Defaults to `"list"`.
             allow_missing: Setting to `True` returns feature vectors with missing values.
 
         # Returns
-            `list`, `pd.DataFrame` or `np.ndarray` if `return type` is set to `"list"`, `"pandas"` or `"numpy"`
+            `list`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` if `return type` is set to `"list"`, `"pandas"`, `"polars"` or `"numpy"`
             respectively. Defaults to `list`.
-            Returned `list`, `pd.DataFrame` or `np.ndarray` contains feature values related to provided primary keys,
+            Returned `list`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` contains feature values related to provided primary keys,
             ordered according to positions of this features in the feature view query.
 
         # Raises
@@ -537,14 +537,14 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"list"`, `"pandas"` or `"numpy"`. Defaults to `"list"`.
+            return_type: `"list"`, `"pandas"`, `"polars"` or `"numpy"`. Defaults to `"list"`.
             allow_missing: Setting to `True` returns feature vectors with missing values.
 
         # Returns
-            `List[list]`, `pd.DataFrame` or `np.ndarray` if `return type` is set to `"list", `"pandas"` or `"numpy"`
+            `List[list]`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` if `return type` is set to `"list", `"pandas"`,`"polars"` or `"numpy"`
             respectively. Defaults to `List[list]`.
 
-            Returned `List[list]`, `pd.DataFrame` or `np.ndarray` contains feature values related to provided primary
+            Returned `List[list]`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` contains feature values related to provided primary
             keys, ordered according to positions of this features in the feature view query.
 
         # Raises
@@ -596,10 +596,10 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"pandas"` or `"dict"`. Defaults to `"pandas"`.
+            return_type: `"pandas"`, `"polars"` or `"dict"`. Defaults to `"pandas"`.
 
         # Returns
-            `pd.DataFrame` or `dict`. Defaults to `pd.DataFrame`.
+            `pd.DataFrame`, `polars.DataFrame` or `dict`. Defaults to `pd.DataFrame`.
 
         # Raises
             `Exception`. When primary key entry cannot be found in one or more of the feature groups used by this
@@ -650,10 +650,10 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"pandas"` or `"dict"`. Defaults to `"dict"`.
+            return_type: `"pandas"`, `"polars"` or `"dict"`. Defaults to `"dict"`.
 
         # Returns
-            `pd.DataFrame` or `List[dict]`.  Defaults to `pd.DataFrame`.
+            `pd.DataFrame`, `polars.DataFrame` or `List[dict]`.  Defaults to `pd.DataFrame`.
 
             Returned `pd.DataFrame` or `List[dict]`  contains feature values related to provided primary
             keys, ordered according to positions of this features in the feature view query.
@@ -797,6 +797,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         inference_helper_columns=False,
+        dataframe_type: Optional[str] = "default"
     ):
         """Get a batch of data from an event time interval from the offline feature store.
 
@@ -852,8 +853,15 @@ class FeatureView:
                 that may not be used in training the model itself but can be used during batch or online inference
                 for extra information. If inference helper columns were not defined in the feature view
                 `inference_helper_columns=True` will not any effect. Defaults to `False`, no helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
-            `DataFrame`: A dataframe
+            `DataFrame`: The spark dataframe containing the feature data.
+            `pyspark.DataFrame`. A Spark DataFrame.
+            `pandas.DataFrame`. A Pandas DataFrame.
+            `polars.DataFrame`. A Polars DataFrame.
+            `numpy.ndarray`. A two-dimensional Numpy array.
+            `list`. A two-dimensional Python list.
         """
 
         if self._batch_scoring_server is None:
@@ -870,6 +878,7 @@ class FeatureView:
             primary_keys,
             event_time,
             inference_helper_columns,
+            dataframe_type
         )
 
     def add_tag(self, name: str, value):
@@ -1909,6 +1918,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Create the metadata for a training dataset and get the corresponding training data from the offline feature store.
@@ -2005,6 +2015,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X, y): Tuple of dataframe of features and labels. If there are no labels, y returns `None`.
         """
@@ -2031,6 +2043,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2063,6 +2076,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Create the metadata for a training dataset and get the corresponding training data from the offline feature store.
@@ -2169,6 +2183,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
@@ -2204,6 +2220,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2248,6 +2265,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Create the metadata for a training dataset and get the corresponding training data from the offline feature store.
@@ -2367,6 +2385,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
@@ -2415,6 +2435,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2451,6 +2472,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default"
     ):
         """
         Get training data created by `feature_view.create_training_data`
@@ -2495,6 +2517,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X, y): Tuple of dataframe of features and labels
         """
@@ -2505,6 +2529,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type
         )
         return df
 
@@ -2516,6 +2541,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default"
     ):
         """
         Get training data created by `feature_view.create_train_test_split`
@@ -2555,6 +2581,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
@@ -2567,6 +2595,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type
         )
         return df
 
@@ -2578,6 +2607,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default"
     ):
         """
         Get training data created by `feature_view.create_train_validation_test_split`
@@ -2617,6 +2647,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
@@ -2633,6 +2665,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type
         )
         return df
 

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -125,7 +125,9 @@ class StorageConnector(ABC):
         # Returns
             `DataFrame`.
         """
-        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
     def refetch(self):
         """
@@ -312,7 +314,9 @@ class S3Connector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
     def _get_path(self, sub_path: str):
         return os.path.join(self.path, sub_path)
@@ -496,7 +500,9 @@ class RedshiftConnector(StorageConnector):
             # if table also specified we override to use query
             options.pop("dbtable", None)
 
-        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None, dataframe_type)
+        return engine.get_instance().read(
+            self, self.JDBC_FORMAT, options, None, dataframe_type
+        )
 
     def refetch(self):
         """
@@ -636,7 +642,9 @@ class AdlsConnector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
 
 class SnowflakeConnector(StorageConnector):
@@ -831,7 +839,9 @@ class SnowflakeConnector(StorageConnector):
             # if table also specified we override to use query
             options.pop("dbtable", None)
 
-        return engine.get_instance().read(self, self.SNOWFLAKE_FORMAT, options, None, dataframe_type)
+        return engine.get_instance().read(
+            self, self.SNOWFLAKE_FORMAT, options, None, dataframe_type
+        )
 
 
 class JdbcConnector(StorageConnector):
@@ -911,7 +921,9 @@ class JdbcConnector(StorageConnector):
         if query:
             options["query"] = query
 
-        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None, dataframe_type)
+        return engine.get_instance().read(
+            self, self.JDBC_FORMAT, options, None, dataframe_type
+        )
 
 
 class KafkaConnector(StorageConnector):
@@ -1010,9 +1022,9 @@ class KafkaConnector(StorageConnector):
         )
 
         # set ssl
-        config[
-            "ssl.endpoint.identification.algorithm"
-        ] = self._ssl_endpoint_identification_algorithm
+        config["ssl.endpoint.identification.algorithm"] = (
+            self._ssl_endpoint_identification_algorithm
+        )
 
         # Here we cannot use `not self._external_kafka` as for normal kafka connectors
         # this option is not set and so the `not self._external_kafka` would return true
@@ -1343,7 +1355,9 @@ class GcsConnector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
     def prepare_spark(self, path: Optional[str] = None):
         """Prepare Spark to use this Storage Connector.
@@ -1543,4 +1557,6 @@ class BigQueryConnector(StorageConnector):
                 "or Query Project,Dataset and Table should be set"
             )
 
-        return engine.get_instance().read(self, self.BIGQUERY_FORMAT, options, path, dataframe_type)
+        return engine.get_instance().read(
+            self, self.BIGQUERY_FORMAT, options, path, dataframe_type
+        )

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -103,6 +103,7 @@ class StorageConnector(ABC):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a query or a path into a dataframe using the storage connector.
 
@@ -118,11 +119,13 @@ class StorageConnector(ABC):
             options: Any additional key/value options to be passed to the connector.
             path: Path to be read from within the bucket of the storage connector. Not relevant
                 for JDBC or database based connectors such as Snowflake, JDBC or Redshift.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
         """
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
 
     def refetch(self):
         """
@@ -277,6 +280,7 @@ class S3Connector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = "",
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a query or a path into a dataframe using the storage connector.
 
@@ -288,6 +292,8 @@ class S3Connector(StorageConnector):
             data_format: The file format of the files to be read, e.g. `csv`, `parquet`.
             options: Any additional key/value options to be passed to the S3 connector.
             path: Path within the bucket to be read.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -306,7 +312,7 @@ class S3Connector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
 
     def _get_path(self, sub_path: str):
         return os.path.join(self.path, sub_path)
@@ -461,6 +467,7 @@ class RedshiftConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a table or query into a dataframe using the storage connector.
 
@@ -471,6 +478,8 @@ class RedshiftConnector(StorageConnector):
             data_format: Not relevant for JDBC based connectors such as Redshift.
             options: Any additional key/value options to be passed to the JDBC connector.
             path: Not relevant for JDBC based connectors such as Redshift.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -487,7 +496,7 @@ class RedshiftConnector(StorageConnector):
             # if table also specified we override to use query
             options.pop("dbtable", None)
 
-        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None)
+        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None, dataframe_type)
 
     def refetch(self):
         """
@@ -603,6 +612,7 @@ class AdlsConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = "",
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a path into a dataframe using the storage connector.
         # Arguments
@@ -611,6 +621,8 @@ class AdlsConnector(StorageConnector):
             options: Any additional key/value options to be passed to the ADLS connector.
             path: Path within the bucket to be read. For example, path=`path` will read directly from the container specified on connector by constructing the URI as 'abfss://[container-name]@[account_name].dfs.core.windows.net/[path]'.
             If no path is specified default container path will be used from connector.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -624,7 +636,7 @@ class AdlsConnector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
 
 
 class SnowflakeConnector(StorageConnector):
@@ -792,6 +804,7 @@ class SnowflakeConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a table or query into a dataframe using the storage connector.
 
@@ -802,6 +815,8 @@ class SnowflakeConnector(StorageConnector):
             data_format: Not relevant for Snowflake connectors.
             options: Any additional key/value options to be passed to the engine.
             path: Not relevant for Snowflake connectors.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -816,7 +831,7 @@ class SnowflakeConnector(StorageConnector):
             # if table also specified we override to use query
             options.pop("dbtable", None)
 
-        return engine.get_instance().read(self, self.SNOWFLAKE_FORMAT, options, None)
+        return engine.get_instance().read(self, self.SNOWFLAKE_FORMAT, options, None, dataframe_type)
 
 
 class JdbcConnector(StorageConnector):
@@ -872,6 +887,7 @@ class JdbcConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a query into a dataframe using the storage connector.
 
@@ -880,6 +896,8 @@ class JdbcConnector(StorageConnector):
             data_format: Not relevant for JDBC based connectors.
             options: Any additional key/value options to be passed to the JDBC connector.
             path: Not relevant for JDBC based connectors.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -893,7 +911,7 @@ class JdbcConnector(StorageConnector):
         if query:
             options["query"] = query
 
-        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None)
+        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None, dataframe_type)
 
 
 class KafkaConnector(StorageConnector):
@@ -1140,6 +1158,7 @@ class KafkaConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """NOT SUPPORTED."""
         raise NotImplementedError(
@@ -1279,6 +1298,7 @@ class GcsConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = "",
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads GCS path into a dataframe using the storage connector.
 
@@ -1300,6 +1320,8 @@ class GcsConnector(StorageConnector):
             data_format: Spark data format. Defaults to `None`.
             options: Spark options. Defaults to `None`.
             path: GCS path. Defaults to `None`.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Raises
             `ValueError`: Malformed arguments.
 
@@ -1321,7 +1343,7 @@ class GcsConnector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(self, data_format, options, path, dataframe_type)
 
     def prepare_spark(self, path: Optional[str] = None):
         """Prepare Spark to use this Storage Connector.
@@ -1451,6 +1473,7 @@ class BigQueryConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads results from BigQuery into a spark dataframe using the storage connector.
 
@@ -1479,6 +1502,8 @@ class BigQueryConnector(StorageConnector):
             data_format: Spark data format. Defaults to `None`.
             options: Spark options. Defaults to `None`.
             path: BigQuery table path. Defaults to `None`.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Raises
             `ValueError`: Malformed arguments.
@@ -1518,4 +1543,4 @@ class BigQueryConnector(StorageConnector):
                 "or Query Project,Dataset and Table should be set"
             )
 
-        return engine.get_instance().read(self, self.BIGQUERY_FORMAT, options, path)
+        return engine.get_instance().read(self, self.BIGQUERY_FORMAT, options, path, dataframe_type)

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,7 @@ setup(
         "fsspec",
         "retrying",
         "aiomysql",
+        "polars",
         "opensearch-py>=1.1.0,<=2.4.2",
     ],
     extras_require={

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -1134,6 +1134,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=None,
             training_helper_columns=None,
             feature_view_features=[],
+            dataframe_type="default"
         )
 
         # Assert
@@ -1186,6 +1187,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=None,
             training_helper_columns=None,
             feature_view_features=[],
+            dataframe_type="default"
         )
 
         # Assert
@@ -1231,6 +1233,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=False,
             training_helper_columns=[],
             feature_view_features=[],
+            dataframe_type="default"
         )
 
         # Assert
@@ -1272,6 +1275,7 @@ class TestFeatureViewEngine:
                 with_training_helper_columns=None,
                 training_helper_columns=None,
                 feature_view_features=[],
+                 dataframe_type="default"
             )
 
         # Assert

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -99,12 +99,28 @@ class TestPython:
 
         # Act
         python_engine._sql_offline(
-            sql_query="", feature_store=None, dataframe_type=None
+            sql_query="", feature_store=None, dataframe_type="default"
         )
 
         # Assert
         assert mock_python_engine_create_hive_connection.call_count == 1
         assert mock_python_engine_return_dataframe_type.call_count == 1
+
+    def test_sql_offline_dataframe_type_none(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.engine.python.Engine._create_hive_connection")
+
+        python_engine = python.Engine()
+
+        with pytest.raises(exceptions.FeatureStoreException) as fstore_except:
+            # Act
+            python_engine._sql_offline(
+                sql_query="", feature_store=None, dataframe_type=None
+            )
+        assert (
+            str(fstore_except.value)
+            == 'dataframe_type : None not supported. Possible values are "default", "spark", "pandas", "polars", "numpy" or "python"'
+        )
 
     def test_jdbc(self, mocker):
         # Arrange
@@ -119,12 +135,32 @@ class TestPython:
 
         # Act
         python_engine._jdbc(
-            sql_query=query, connector=None, dataframe_type=None, read_options={}
+            sql_query=query, connector=None, dataframe_type="default", read_options={}
         )
 
         # Assert
         assert mock_util_create_mysql_engine.call_count == 1
         assert mock_python_engine_return_dataframe_type.call_count == 1
+
+    def test_jdbc_dataframe_type_none(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.util.create_mysql_engine")
+        mocker.patch("hsfs.client.get_instance")
+        query = "SELECT * FROM TABLE"
+
+        python_engine = python.Engine()
+
+        # Act
+        with pytest.raises(exceptions.FeatureStoreException) as fstore_except:
+            python_engine._jdbc(
+                sql_query=query, connector=None, dataframe_type=None, read_options={}
+            )
+
+        # Assert
+        assert (
+            str(fstore_except.value)
+            == 'dataframe_type : None not supported. Possible values are "default", "spark", "pandas", "polars", "numpy" or "python"'
+        )
 
     def test_jdbc_read_options(self, mocker):
         # Arrange
@@ -141,7 +177,7 @@ class TestPython:
         python_engine._jdbc(
             sql_query=query,
             connector=None,
-            dataframe_type=None,
+            dataframe_type="default",
             read_options={"external": ""},
         )
 

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -198,6 +198,7 @@ class TestPython:
                 data_format=None,
                 read_options=None,
                 location=None,
+                dataframe_type="default"
             )
 
         # Assert
@@ -216,6 +217,7 @@ class TestPython:
                 data_format="",
                 read_options=None,
                 location=None,
+                dataframe_type="default"
             )
 
         # Assert
@@ -241,6 +243,7 @@ class TestPython:
             data_format="csv",
             read_options=None,
             location=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -267,6 +270,7 @@ class TestPython:
             data_format="csv",
             read_options=None,
             location=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -293,6 +297,7 @@ class TestPython:
                 data_format="csv",
                 read_options=None,
                 location=None,
+            dataframe_type="default"
             )
 
         # Assert
@@ -932,7 +937,7 @@ class TestPython:
         }
 
         # Act
-        result = python_engine._convert_pandas_statistics(stat=stat)
+        result = python_engine._convert_pandas_statistics(stat=stat, dataType="Integer")
 
         # Assert
         assert result == {
@@ -1959,6 +1964,7 @@ class TestPython:
             feature_view_obj=None,
             query_obj=mocker.Mock(),
             read_options=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -1992,6 +1998,7 @@ class TestPython:
             feature_view_obj=None,
             query_obj=mocker.Mock(),
             read_options=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2005,7 +2012,7 @@ class TestPython:
         df = pd.DataFrame(data=d)
 
         # Act
-        result_df, result_df_split = python_engine.split_labels(df=df, labels=None)
+        result_df, result_df_split = python_engine.split_labels(df=df, dataframe_type="default", labels=None)
 
         # Assert
         assert str(result_df) == "   Col1  col2\n0     1     3\n1     2     4"
@@ -2019,7 +2026,7 @@ class TestPython:
         df = pd.DataFrame(data=d)
 
         # Act
-        result_df, result_df_split = python_engine.split_labels(df=df, labels="col1")
+        result_df, result_df_split = python_engine.split_labels(df=df, dataframe_type="default", labels="col1")
 
         # Assert
         assert str(result_df) == "   col2\n0     3\n1     4"
@@ -2065,6 +2072,7 @@ class TestPython:
             training_dataset_obj=td,
             feature_view_obj=None,
             read_option=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2130,6 +2138,7 @@ class TestPython:
             training_dataset_obj=td,
             feature_view_obj=None,
             read_option=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2194,6 +2203,7 @@ class TestPython:
             training_dataset_obj=td,
             feature_view_obj=None,
             read_option=None,
+            dataframe_type="default"
         )
 
         # Assert

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -1699,6 +1699,7 @@ class TestSpark:
             feature_view_obj=None,
             query_obj=None,
             read_options=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -1715,6 +1716,7 @@ class TestSpark:
         result = spark_engine.split_labels(
             df=df,
             labels=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2809,6 +2811,7 @@ class TestSpark:
                 data_format=None,
                 read_options=None,
                 location=None,
+                dataframe_type="default"
             )
 
         # Assert
@@ -2827,6 +2830,7 @@ class TestSpark:
                 data_format="",
                 read_options=None,
                 location=None,
+                dataframe_type="default"
             )
 
         # Assert
@@ -2849,6 +2853,7 @@ class TestSpark:
             data_format="csv",
             read_options={"name": "value"},
             location=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2881,6 +2886,7 @@ class TestSpark:
             data_format="delta",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2910,6 +2916,7 @@ class TestSpark:
             data_format="parquet",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2940,6 +2947,7 @@ class TestSpark:
             data_format="hudi",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2969,6 +2977,7 @@ class TestSpark:
             data_format="orc",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2998,6 +3007,7 @@ class TestSpark:
             data_format="bigquery",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -3028,6 +3038,7 @@ class TestSpark:
             data_format="csv",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -3058,6 +3069,7 @@ class TestSpark:
             data_format="csv",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert


### PR DESCRIPTION
This PR adds support for Polars, specifically writing polars dataframes to a feature group.

**Changes:**

1. Added support for pyarrow types : large_list, large_string and large_binary - Since lists, string and binary types are converted into  large_list, large_string and large_binary formats when a polars dataframe is created from a pandas dataframe.
2. Also added support for pyarrow dictionary types that has `value_type` which can be any strings type and `index_type` that can be any integer type. This done because category types are in Polars are represented as a dictionary `value_type` string and `index_type` integer
3. Modified function for `convert_to_default_dataframe`, `_write_dataframe_kafka`  and `parse_schema_feature_group` to perform same functionality using polars.
4. In function `_write_dataframe_kafka` conversion of return types of dataframe iterators to native python types are not performed for polars since `iter_rows` in polars already return data as python types. (https://docs.pola.rs/py-polars/html/reference/dataframe/api/polars.DataFrame.iter_rows.html)
5. `validate_with_great_expectations` function has a patch that converts dataframe to pandas when validating since expectations does not currently support polars.

LoadTest - https://github.com/logicalclocks/loadtest/pull/286

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1186

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
