### PR TITLE
[FSTORE-1218] Fix as_of and read_changes doc

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -260,8 +260,8 @@ class Query:
     ):
         """Perform time travel on the given Query.
 
-        !!! warning
-            HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
+        !!! warning "Pyspark/Spark Only"
+            Apache HUDI exclusively supports Time Travel and Incremental Query via Spark Context
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
         specified point in time can be excluded from the query. The Query can then either be read into a Dataframe
@@ -317,6 +317,9 @@ class Query:
             .join(query2.as_of(..., ...))  # as_of is not applied
             .as_of(..., ...)
         ```
+
+        !!! warning
+            This function only works for queries on feature groups with time_travel_format='HUDI'.
 
         !!! warning
             Excluding commits via exclude_until is only possible within the range of the Hudi active timeline.

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -253,7 +253,7 @@ class Query:
 
         return self
 
-    def (
+    def as_of(
         self,
         wallclock_time: Optional[Union[str, int, datetime, date]] = None,
         exclude_until: Optional[Union[str, int, datetime, date]] = None,
@@ -261,7 +261,7 @@ class Query:
         """Perform time travel on the given Query.
 
         !!! warning "Not available in Spark"
-            `as_of` method is available only in Python, not in Spark.
+            `as_of` method is available in Python but not in Spark.
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
         specified point in time can be excluded from the query. The Query can then either be read into a Dataframe

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -260,8 +260,8 @@ class Query:
     ):
         """Perform time travel on the given Query.
 
-        !!! warning "Not available in Python"
-            `as_of` method is available in Spark but not in Python.
+        !!! warning "Available only using Pyspark/Spark"
+            HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
         specified point in time can be excluded from the query. The Query can then either be read into a Dataframe

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -253,12 +253,15 @@ class Query:
 
         return self
 
-    def as_of(
+    def (
         self,
         wallclock_time: Optional[Union[str, int, datetime, date]] = None,
         exclude_until: Optional[Union[str, int, datetime, date]] = None,
     ):
         """Perform time travel on the given Query.
+
+        !!! warning "Not available in Spark"
+            `as_of` method is available only in Python, not in Spark.
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
         specified point in time can be excluded from the query. The Query can then either be read into a Dataframe

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -260,7 +260,7 @@ class Query:
     ):
         """Perform time travel on the given Query.
 
-        !!! warning "Available only using Pyspark/Spark"
+        !!! warning
             HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
@@ -317,9 +317,6 @@ class Query:
             .join(query2.as_of(..., ...))  # as_of is not applied
             .as_of(..., ...)
         ```
-
-        !!! warning
-            This function only works for queries on feature groups with time_travel_format='HUDI'.
 
         !!! warning
             Excluding commits via exclude_until is only possible within the range of the Hudi active timeline.

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -260,8 +260,8 @@ class Query:
     ):
         """Perform time travel on the given Query.
 
-        !!! warning "Not available in Spark"
-            `as_of` method is available in Python but not in Spark.
+        !!! warning "Not available in Python"
+            `as_of` method is available in Spark but not in Python.
 
         This method returns a new Query object at the specified point in time. Optionally, commits before a
         specified point in time can be excluded from the query. The Query can then either be read into a Dataframe

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2110,8 +2110,8 @@ class FeatureGroup(FeatureGroupBase):
                     `as_of(end_wallclock_time, exclude_until=start_wallclock_time).read(read_options=read_options)`
                     instead.
 
-        !!! warning "Not available in Python"
-            `read_changes` method is available in Spark but not in Python.
+        !!! warning "Available only using Pyspark/Spark"
+            HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
 
         This function only works on feature groups with `HUDI` time travel format.
 
@@ -2850,8 +2850,8 @@ class FeatureGroup(FeatureGroupBase):
     ):
         """Get Query object to retrieve all features of the group at a point in the past.
 
-        !!! warning "Not available in Python"
-            `as_of` method is available in Spark but not in Python.
+        !!! warning "Available only using Pyspark/Spark"
+            HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
 
         This method selects all features in the feature group and returns a Query object
         at the specified point in time. Optionally, commits before a specified point in time can be

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2110,8 +2110,8 @@ class FeatureGroup(FeatureGroupBase):
                     `as_of(end_wallclock_time, exclude_until=start_wallclock_time).read(read_options=read_options)`
                     instead.
 
-        !!! warning "Not available in Spark"
-            `read_changes` method is available in Python but not in Spark.
+        !!! warning "Not available in Python"
+            `read_changes` method is available in Spark but not in Python.
 
         This function only works on feature groups with `HUDI` time travel format.
 

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2110,8 +2110,11 @@ class FeatureGroup(FeatureGroupBase):
                     `as_of(end_wallclock_time, exclude_until=start_wallclock_time).read(read_options=read_options)`
                     instead.
 
-        !!! warning "Warning"
-            HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
+        !!! warning "Pyspark/Spark Only"
+            Apache HUDI exclusively supports Time Travel and Incremental Query via Spark Context
+
+        !!! warning
+            This function only works for feature groups with time_travel_format='HUDI'.
 
         # Arguments
             start_wallclock_time: Start time of the time travel query. Strings should be formatted in one of the following formats `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`,
@@ -2848,8 +2851,8 @@ class FeatureGroup(FeatureGroupBase):
     ):
         """Get Query object to retrieve all features of the group at a point in the past.
 
-        !!! warning
-            HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
+        !!! warning "Pyspark/Spark Only"
+            Apache HUDI exclusively supports Time Travel and Incremental Query via Spark Context
 
         This method selects all features in the feature group and returns a Query object
         at the specified point in time. Optionally, commits before a specified point in time can be
@@ -2914,6 +2917,9 @@ class FeatureGroup(FeatureGroupBase):
                 .join(fg2.select_all().as_of("2020-10-20", exclude_until="2020-10-15"))  # as_of is not applied
                 .as_of("2020-10-20", exclude_until="2020-10-19")
             ```
+
+        !!! warning
+            This function only works for feature groups with time_travel_format='HUDI'.
 
         !!! warning
             Excluding commits via exclude_until is only possible within the range of the Hudi active timeline.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2111,7 +2111,7 @@ class FeatureGroup(FeatureGroupBase):
                     instead.
 
         !!! warning "Not available in Spark"
-            `read_changes` method is available only in Python, not in Spark.
+            `read_changes` method is available in Python but not in Spark.
 
         This function only works on feature groups with `HUDI` time travel format.
 

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2110,10 +2110,8 @@ class FeatureGroup(FeatureGroupBase):
                     `as_of(end_wallclock_time, exclude_until=start_wallclock_time).read(read_options=read_options)`
                     instead.
 
-        !!! warning "Available only using Pyspark/Spark"
+        !!! warning "Warning"
             HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
-
-        This function only works on feature groups with `HUDI` time travel format.
 
         # Arguments
             start_wallclock_time: Start time of the time travel query. Strings should be formatted in one of the following formats `%Y-%m-%d`, `%Y-%m-%d %H`, `%Y-%m-%d %H:%M`,
@@ -2850,7 +2848,7 @@ class FeatureGroup(FeatureGroupBase):
     ):
         """Get Query object to retrieve all features of the group at a point in the past.
 
-        !!! warning "Available only using Pyspark/Spark"
+        !!! warning
             HUDI supports Time Travel and Incremental Query via Spark context, exclusively in PySpark/Spark
 
         This method selects all features in the feature group and returns a Query object
@@ -2916,9 +2914,6 @@ class FeatureGroup(FeatureGroupBase):
                 .join(fg2.select_all().as_of("2020-10-20", exclude_until="2020-10-15"))  # as_of is not applied
                 .as_of("2020-10-20", exclude_until="2020-10-19")
             ```
-
-        !!! warning
-            This function only works for feature groups with time_travel_format='HUDI'.
 
         !!! warning
             Excluding commits via exclude_until is only possible within the range of the Hudi active timeline.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2850,6 +2850,9 @@ class FeatureGroup(FeatureGroupBase):
     ):
         """Get Query object to retrieve all features of the group at a point in the past.
 
+        !!! warning "Not available in Python"
+            `as_of` method is available in Spark but not in Python.
+
         This method selects all features in the feature group and returns a Query object
         at the specified point in time. Optionally, commits before a specified point in time can be
         excluded from the query. The Query can then either be read into a Dataframe

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2110,6 +2110,9 @@ class FeatureGroup(FeatureGroupBase):
                     `as_of(end_wallclock_time, exclude_until=start_wallclock_time).read(read_options=read_options)`
                     instead.
 
+        !!! warning "Not available in Spark"
+            `read_changes` method is available only in Python, not in Spark.
+
         This function only works on feature groups with `HUDI` time travel format.
 
         # Arguments


### PR DESCRIPTION
Added banner in as_of and read_changes about the fact that the methods are not available in Python, but only in Spark.