### PR TITLE
[FSTORE-1222] Fix Feature Store API Contriburing.md instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 - Fork and clone the repository
 
-- Create a new Python environment with your favourite environment manager, e.g. virtualenv or conda
+- Create a new Python environment with your favourite environment manager (e.g. virtualenv or conda) and Python 3.9 (newer versions will return a library conflict in `auto_doc.py`)
 
 - Install repository in editable mode with development dependencies:
 
@@ -80,7 +80,7 @@ We use `mkdocs` together with `mike` ([for versioning](https://github.com/jimpor
 2. Install HSFS with `docs` extras:
 
     ```bash
-    pip install -e .[python,dev,docs]
+    pip install -e ".[python,dev,docs]"
     ```
 
 3. To build the docs, first run the auto doc script:


### PR DESCRIPTION
In the instruction to build the documentation (`Contriburing.md`) the following command does not work:

`pip install -e .[python,dev,docs]`

The working command is:

`pip install -e ".[python,dev,docs]"`

2. The Python version should not be higher than 3.9. Otherwise, the following command will fail due to library conflicts:

`python auto_doc.py`