### PR TITLE
[FSTORE-1074] Expand documentation on filter logic

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -380,7 +380,7 @@ class Query:
         query.filter(fg.feature1 == 1).show(10)
         ```
 
-        Composite filters require parenthesis:
+        Composite filters require parenthesis and symbols for logical operands (e.g. `&`, `|`, ...):
         ```python
         query.filter((fg.feature1 == 1) | (fg.feature2 >= 2))
         ```

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -380,7 +380,7 @@ class FeatureGroupBase:
             fg.filter(fg.feature1 == 1).show(10)
             ```
 
-        Composite filters require parenthesis:
+        Composite filters require parenthesis and symbols for logical operands (e.g. `&`, `|`, ...):
         !!! example
             ```python
             fg.filter((fg.feature1 == 1) | (fg.feature2 >= 2))


### PR DESCRIPTION
Documentation for the filter has been expended by adding a reminder that logical operands must be used with symbols and not in written form