### PR TITLE
[FSTORE-1186] Polars Integration into Hopsworks - Writing and Reading DataFrames 

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -30,6 +30,7 @@ from hsfs.core.variable_api import VariableApi
 from hsfs import util
 from hsfs.storage_connector import StorageConnector
 from retrying import retry
+import polars as pl
 
 _arrow_flight_instance = None
 
@@ -215,21 +216,29 @@ class ArrowFlightClient:
     def get_flight_info(self, descriptor):
         return self._connection.get_flight_info(descriptor)
 
-    def _get_dataset(self, descriptor, timeout=DEFAULT_TIMEOUT):
+    def _get_dataset(
+        self, descriptor, timeout=DEFAULT_TIMEOUT, dataframe_type="default"
+    ):
         info = self.get_flight_info(descriptor)
         options = pyarrow.flight.FlightCallOptions(timeout=timeout)
         reader = self._connection.do_get(self._info_to_ticket(info), options)
-        return reader.read_pandas()
+        if dataframe_type.lower() == "polars":
+            return pl.from_arrow(reader.read_all())
+        else:
+            return reader.read_pandas()
 
     @_handle_afs_exception(user_message=READ_ERROR)
-    def read_query(self, query_object, arrow_flight_config):
+    def read_query(self, query_object, arrow_flight_config, dataframe_type):
         query_encoded = json.dumps(query_object).encode("ascii")
         descriptor = pyarrow.flight.FlightDescriptor.for_command(query_encoded)
         return self._get_dataset(
             descriptor,
-            arrow_flight_config.get("timeout")
-            if arrow_flight_config
-            else self.DEFAULT_TIMEOUT,
+            (
+                arrow_flight_config.get("timeout")
+                if arrow_flight_config
+                else self.DEFAULT_TIMEOUT
+            ),
+            dataframe_type,
         )
 
     @_handle_afs_exception(user_message=READ_ERROR)

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -520,10 +520,20 @@ class FeatureViewEngine:
             )
 
             df = self._drop_helper_columns(
-                df, feature_view_features, with_primary_keys, primary_keys, False
+                df,
+                feature_view_features,
+                with_primary_keys,
+                primary_keys,
+                False,
+                dataframe_type,
             )
             df = self._drop_helper_columns(
-                df, feature_view_features, with_event_time, event_time, False
+                df,
+                feature_view_features,
+                with_event_time,
+                event_time,
+                False,
+                dataframe_type,
             )
             df = self._drop_helper_columns(
                 df,
@@ -531,6 +541,7 @@ class FeatureViewEngine:
                 with_training_helper_columns,
                 training_helper_columns,
                 True,
+                dataframe_type,
             )
             return df
 
@@ -544,10 +555,19 @@ class FeatureViewEngine:
                 raise e
 
     def _drop_helper_columns(
-        self, df, feature_view_features, with_columns, columns, training_helper
+        self,
+        df,
+        feature_view_features,
+        with_columns,
+        columns,
+        training_helper,
+        dataframe_type,
     ):
         if not with_columns:
-            if engine.get_type().startswith("spark"):
+            if (
+                engine.get_type().startswith("spark")
+                and dataframe_type.lower() == "spark"
+            ):
                 existing_cols = [field.name for field in df.schema.fields]
             else:
                 existing_cols = df.columns

--- a/python/hsfs/core/feature_view_engine.py
+++ b/python/hsfs/core/feature_view_engine.py
@@ -338,7 +338,9 @@ class FeatureViewEngine:
                     feature.name for feature in feature_view_obj.features
                 ],
                 # forcing dataframe type to default here since dataframe operations are required for training data split.
-                dataframe_type="default" if dataframe_type.lower() in ["numpy", "python"] else dataframe_type  # forcing dataframe type to default here since dataframe operations are required for training data split.
+                dataframe_type="default"
+                if dataframe_type.lower() in ["numpy", "python"]
+                else dataframe_type,  # forcing dataframe type to default here since dataframe operations are required for training data split.
             )
         else:
             self._check_feature_group_accessibility(feature_view_obj)

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -301,7 +301,7 @@ class VectorServer:
             return polars_df
         else:
             raise Exception(
-                "Unknown return type. Supported return types are 'list', 'pandas' and 'numpy'"
+                "Unknown return type. Supported return types are 'list', 'polars', 'pandas' and 'numpy'"
             )
 
     def get_feature_vectors(
@@ -351,7 +351,7 @@ class VectorServer:
             return polars_df
         else:
             raise Exception(
-                "Unknown return type. Supported return types are 'list', 'pandas' and 'numpy'"
+                "Unknown return type. Supported return types are 'list', 'polars', 'pandas' and 'numpy'"
             )
 
     def get_inference_helper(self, entry, return_type):

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -20,6 +20,7 @@ import avro.io
 from sqlalchemy import sql, bindparam, exc, text
 import numpy as np
 import pandas as pd
+import polars as pl
 from hsfs import util
 from hsfs import training_dataset, feature_view, client
 from hsfs.serving_key import ServingKey
@@ -292,6 +293,12 @@ class VectorServer:
             pandas_df = pd.DataFrame(vector).transpose()
             pandas_df.columns = self._feature_vector_col_name
             return pandas_df
+        elif return_type.lower() == "polars":
+            # Polar considers one dimensional list as a single columns so passed vector as 2d list
+            polars_df = pl.DataFrame(
+                [vector], schema=self._feature_vector_col_name, orient="row"
+            )
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'list', 'pandas' and 'numpy'"
@@ -337,6 +344,11 @@ class VectorServer:
             pandas_df = pd.DataFrame(vectors)
             pandas_df.columns = self._feature_vector_col_name
             return pandas_df
+        elif return_type.lower() == "polars":
+            polars_df = pl.DataFrame(
+                vectors, schema=self._feature_vector_col_name, orient="row"
+            )
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'list', 'pandas' and 'numpy'"
@@ -353,6 +365,12 @@ class VectorServer:
             return pd.DataFrame([serving_vector])
         elif return_type.lower() == "dict":
             return serving_vector
+        elif return_type.lower() == "polars":
+            # Polar considers one dimensional list as a single columns so passed vector as 2d list
+            polars_df = pl.DataFrame(
+                [serving_vector], schema=self._feature_vector_col_name, orient="row"
+            )
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'pandas' and 'dict'"
@@ -386,6 +404,11 @@ class VectorServer:
             return batch_results
         elif return_type.lower() == "pandas":
             return pd.DataFrame(batch_results)
+        elif return_type.lower() == "polars":
+            polars_df = pl.DataFrame(
+                batch_results, schema=self._feature_vector_col_name, orient="row"
+            )
+            return polars_df
         else:
             raise Exception(
                 "Unknown return type. Supported return types are 'dict' and 'pandas'"

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -604,7 +604,9 @@ class Engine:
         # This conversion might cause a bottleneck in performance when using polars with greater expectations.
         # This patch is done becuase currently great_expecatations does not support polars, would need to be made proper when support added.
         if isinstance(dataframe, pl.DataFrame):
-            warnings.warn("Great Expectations does not support Polars dataframes directly using Great Expectations with Polars datarames can be slow.")
+            warnings.warn(
+                "Great Expectations does not support Polars dataframes directly using Great Expectations with Polars datarames can be slow."
+            )
             dataframe = dataframe.to_pandas()
         report = ge.from_pandas(
             dataframe, expectation_suite=expectation_suite

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -604,6 +604,7 @@ class Engine:
         # This conversion might cause a bottleneck in performance when using polars with greater expectations.
         # This patch is done becuase currently great_expecatations does not support polars, would need to be made proper when support added.
         if isinstance(dataframe, pl.DataFrame):
+            warnings.warn("Great Expectations does not support Polars dataframes directly using Great Expectations with Polars datarames can be slow.")
             dataframe = dataframe.to_pandas()
         report = ge.from_pandas(
             dataframe, expectation_suite=expectation_suite

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -490,7 +490,7 @@ class Engine:
         exact_uniqueness=True,
     ):
         # TODO: add statistics for correlations, histograms and exact_uniqueness
-        if isinstance(df, pl.Dataframe) or isinstance(df, pl.dataframe.frame.DataFrame):
+        if isinstance(df, pl.DataFrame) or isinstance(df, pl.dataframe.frame.DataFrame):
             arrow_schema = df.to_arrow().schema
         else:
             arrow_schema = pa.Schema.from_pandas(df, preserve_index=False)
@@ -502,7 +502,7 @@ class Engine:
                 or pa.types.is_large_list(field.type)
                 or pa.types.is_struct(field.type)
             ) and PYARROW_HOPSWORKS_DTYPE_MAPPING[field.type] in ["timestamp", "date"]:
-                if isinstance(df, pl.Dataframe) or isinstance(
+                if isinstance(df, pl.DataFrame) or isinstance(
                     df, pl.dataframe.frame.DataFrame
                 ):
                     df = df.with_columns(pl.col(field.name).cast(pl.String))
@@ -525,7 +525,7 @@ class Engine:
         final_stats = []
         for col in relevant_columns:
 
-            if isinstance(df, pl.Dataframe) or isinstance(
+            if isinstance(df, pl.DataFrame) or isinstance(
                 df, pl.dataframe.frame.DataFrame
             ):
                 stats[col] = dict(zip(stats["statistic"], stats[col]))
@@ -606,7 +606,7 @@ class Engine:
     ):
         # This conversion might cause a bottleneck in performance when using polars with greater expectations.
         # This patch is done becuase currently great_expecatations does not support polars, would need to be made proper when support added.
-        if isinstance(dataframe, pl.Dataframe) or isinstance(
+        if isinstance(dataframe, pl.DataFrame) or isinstance(
             dataframe, pl.dataframe.frame.DataFrame
         ):
             warnings.warn(
@@ -626,7 +626,7 @@ class Engine:
     ):
         if (
             isinstance(dataframe, pd.DataFrame)
-            or isinstance(dataframe, pl.Dataframe)
+            or isinstance(dataframe, pl.DataFrame)
             or isinstance(dataframe, pl.dataframe.frame.DataFrame)
         ):
             upper_case_features = [
@@ -675,7 +675,7 @@ class Engine:
     ):
         if isinstance(dataframe, pd.DataFrame):
             arrow_schema = pa.Schema.from_pandas(dataframe, preserve_index=False)
-        elif isinstance(dataframe, pl.Dataframe) or isinstance(
+        elif isinstance(dataframe, pl.DataFrame) or isinstance(
             dataframe, pl.dataframe.frame.DataFrame
         ):
             arrow_schema = dataframe.to_arrow().schema
@@ -883,12 +883,12 @@ class Engine:
             groups += [i] * int(df_size * split.percentage)
         groups += [len(splits) - 1] * (df_size - len(groups))
         random.shuffle(groups)
-        if isinstance(df, pl.Dataframe) or isinstance(df, pl.dataframe.frame.DataFrame):
+        if isinstance(df, pl.DataFrame) or isinstance(df, pl.dataframe.frame.DataFrame):
             df = df.with_columns(pl.Series(name=split_column, values=groups))
         else:
             df[split_column] = groups
         for i, split in enumerate(splits):
-            if isinstance(df, pl.Dataframe) or isinstance(
+            if isinstance(df, pl.DataFrame) or isinstance(
                 df, pl.dataframe.frame.DataFrame
             ):
                 split_df = df.filter(pl.col(split_column) == i).drop(split_column)
@@ -1093,7 +1093,7 @@ class Engine:
             feature_name,
             transformation_fn,
         ) in transformation_functions.items():
-            if isinstance(dataset, pl.Dataframe) or isinstance(
+            if isinstance(dataset, pl.DataFrame) or isinstance(
                 dataset, pl.dataframe.frame.DataFrame
             ):
                 dataset = dataset.with_columns(
@@ -1106,9 +1106,9 @@ class Engine:
                     transformation_fn.transformation_fn
                 )
             # The below functions is not required for Polars since polars does have object types like pandas
-            if not isinstance(dataset, pl.Dataframe) or isinstance(
+            if not (isinstance(dataset, pl.DataFrame) or isinstance(
                 dataset, pl.dataframe.frame.DataFrame
-            ):
+            )):
                 offline_type = Engine.convert_spark_type_to_offline_type(
                     transformation_fn.output_type
                 )

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -39,7 +39,6 @@ import great_expectations as ge
 
 from io import BytesIO
 from pyhive import hive
-from urllib.parse import urlparse
 from typing import TypeVar, Optional, Dict, Any, Union
 from confluent_kafka import Consumer, Producer, TopicPartition, KafkaError
 from tqdm.auto import tqdm

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1106,9 +1106,10 @@ class Engine:
                     transformation_fn.transformation_fn
                 )
             # The below functions is not required for Polars since polars does have object types like pandas
-            if not (isinstance(dataset, pl.DataFrame) or isinstance(
-                dataset, pl.dataframe.frame.DataFrame
-            )):
+            if not (
+                isinstance(dataset, pl.DataFrame)
+                or isinstance(dataset, pl.dataframe.frame.DataFrame)
+            ):
                 offline_type = Engine.convert_spark_type_to_offline_type(
                     transformation_fn.output_type
                 )

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -561,9 +561,7 @@ class Engine:
 
     def _convert_pandas_statistics(self, stat, dataType):
         # For now transformation only need 25th, 50th, 75th percentiles
-        # TODO: calculate properly all percentiles
-
-        # TODO : Add proper conditions
+        # TODO: calculate properly all percentiles    
         content_dict = {"dataType": dataType}
         if "count" in stat:
             content_dict["count"] = stat["count"]
@@ -846,7 +844,6 @@ class Engine:
         return result_dfs
 
     def _random_split(self, df, training_dataset_obj):
-        # TODO : Clean up this function
         split_column = f"_SPLIT_INDEX_{uuid.uuid1()}"
         result_dfs = {}
         splits = training_dataset_obj.splits

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -610,7 +610,7 @@ class Engine:
             dataframe, pl.dataframe.frame.DataFrame
         ):
             warnings.warn(
-                "Great Expectations does not support Polars dataframes directly using Great Expectations with Polars datarames can be slow."
+                "Currently Great Expectations does not support Polars dataframes. This operation will convert to Pandas dataframe that can be slow."
             )
             dataframe = dataframe.to_pandas()
         report = ge.from_pandas(

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -542,7 +542,7 @@ class Engine:
             else:
                 print(
                     "Data type could not be inferred for column '"
-                    + stat["column"]
+                    + col.split(".")[-1]
                     + "'. Defaulting to 'String'",
                     file=sys.stderr,
                 )

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -561,7 +561,7 @@ class Engine:
 
     def _convert_pandas_statistics(self, stat, dataType):
         # For now transformation only need 25th, 50th, 75th percentiles
-        # TODO: calculate properly all percentiles    
+        # TODO: calculate properly all percentiles
         content_dict = {"dataType": dataType}
         if "count" in stat:
             content_dict["count"] = stat["count"]
@@ -777,9 +777,10 @@ class Engine:
         if labels:
             labels_df = df[labels]
             df_new = df.drop(columns=labels)
-            return self._return_dataframe_type(
-                df_new, dataframe_type
-            ), self._return_dataframe_type(labels_df, dataframe_type)
+            return (
+                self._return_dataframe_type(df_new, dataframe_type),
+                self._return_dataframe_type(labels_df, dataframe_type),
+            )
         else:
             return self._return_dataframe_type(df, dataframe_type), None
 
@@ -1416,10 +1417,10 @@ class Engine:
             struct_schema = {}
             for index in range(arrow_type.num_fields):
                 sub_arrow_type = arrow_type.field(index).type
-                struct_schema[arrow_type.field(index).name] = (
-                    Engine._convert_pandas_dtype_to_offline_type(
-                        arrow_type.field(index).type
-                    )
+                struct_schema[
+                    arrow_type.field(index).name
+                ] = Engine._convert_pandas_dtype_to_offline_type(
+                    arrow_type.field(index).type
                 )
             return (
                 "struct<"

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -510,7 +510,12 @@ class Engine:
         )
 
     def get_training_data(
-        self, training_dataset, feature_view_obj, query_obj, read_options
+        self,
+        training_dataset,
+        feature_view_obj,
+        query_obj,
+        read_options,
+        dataframe_type,
     ):
         return self.write_training_dataset(
             training_dataset,
@@ -522,13 +527,15 @@ class Engine:
             feature_view_obj=feature_view_obj,
         )
 
-    def split_labels(self, df, labels):
+    def split_labels(self, df, labels, dataframe_type):
         if labels:
             labels_df = df.select(*labels)
             df_new = df.drop(*labels)
-            return df_new, labels_df
+            return self._return_dataframe_type(
+                df_new, dataframe_type
+            ), self._return_dataframe_type(labels_df, dataframe_type)
         else:
-            return df, None
+            return self._return_dataframe_type(df, dataframe_type), None
 
     def drop_columns(self, df, drop_cols):
         return df.drop(*drop_cols)
@@ -693,7 +700,9 @@ class Engine:
 
         feature_dataframe.unpersist()
 
-    def read(self, storage_connector, data_format, read_options, location):
+    def read(
+        self, storage_connector, data_format, read_options, location, dataframe_type
+    ):
         if not data_format:
             raise FeatureStoreException("data_format is not specified")
 
@@ -714,10 +723,11 @@ class Engine:
 
         path = self.setup_storage_connector(storage_connector, path)
 
-        return (
+        return self._return_dataframe_type(
             self._spark_session.read.format(data_format)
             .options(**(read_options if read_options else {}))
-            .load(path)
+            .load(path),
+            dataframe_type=dataframe_type,
         )
 
     def read_stream(

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -531,9 +531,10 @@ class Engine:
         if labels:
             labels_df = df.select(*labels)
             df_new = df.drop(*labels)
-            return self._return_dataframe_type(
-                df_new, dataframe_type
-            ), self._return_dataframe_type(labels_df, dataframe_type)
+            return (
+                self._return_dataframe_type(df_new, dataframe_type),
+                self._return_dataframe_type(labels_df, dataframe_type),
+            )
         else:
             return self._return_dataframe_type(df, dataframe_type), None
 

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -206,12 +206,17 @@ class Engine:
     def _return_dataframe_type(self, dataframe, dataframe_type):
         if dataframe_type.lower() in ["default", "spark"]:
             return dataframe
-        if dataframe_type.lower() == "pandas" and isinstance(dataframe, DataFrame):
-            return dataframe.toPandas()
+
+        # Converting to pandas dataframe if return type is not spark
+        if isinstance(dataframe, DataFrame):
+            dataframe = dataframe.toPandas()
+
+        if dataframe_type.lower() == "pandas":
+            return dataframe
         if dataframe_type.lower() == "numpy":
-            return dataframe.toPandas().values
+            return dataframe.values
         if dataframe_type.lower() == "python":
-            return dataframe.toPandas().values.tolist()
+            return dataframe.values.tolist()
 
         raise TypeError(
             "Dataframe type `{}` not supported on this platform.".format(dataframe_type)

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -206,7 +206,7 @@ class Engine:
     def _return_dataframe_type(self, dataframe, dataframe_type):
         if dataframe_type.lower() in ["default", "spark"]:
             return dataframe
-        if dataframe_type.lower() == "pandas":
+        if dataframe_type.lower() == "pandas" and isinstance(dataframe, DataFrame):
             return dataframe.toPandas()
         if dataframe_type.lower() == "numpy":
             return dataframe.toPandas().values

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -30,6 +30,7 @@ from hsfs.constructor.filter import Filter, Logic
 from typing import Optional, Union, Any, Dict, List, TypeVar, Tuple
 
 from datetime import datetime, date
+import polars as pl
 
 from hsfs import (
     util,
@@ -2049,7 +2050,7 @@ class FeatureGroup(FeatureGroupBase):
             online: bool, optional. If `True` read from online feature store, defaults
                 to `False`.
             dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
             read_options: Additional options as key/value pairs to pass to the execution engine.
                 For spark engine: Dictionary of read options for Spark.
                 For python engine:
@@ -2068,6 +2069,7 @@ class FeatureGroup(FeatureGroupBase):
             `DataFrame`: The spark dataframe containing the feature data.
             `pyspark.DataFrame`. A Spark DataFrame.
             `pandas.DataFrame`. A Pandas DataFrame.
+            `polars.DataFrame`. A Polars DataFrame.
             `numpy.ndarray`. A two-dimensional Numpy array.
             `list`. A two-dimensional Python list.
 
@@ -2247,6 +2249,7 @@ class FeatureGroup(FeatureGroupBase):
         self,
         features: Union[
             pd.DataFrame,
+            pl.DataFrame,
             TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
             TypeVar("pyspark.RDD"),  # noqa: F821
             np.ndarray,
@@ -2263,14 +2266,14 @@ class FeatureGroup(FeatureGroupBase):
             To achieve the old behaviour, set `wait` argument to `True`.
 
         Calling `save` creates the metadata for the feature group in the feature store.
-        If a DataFrame, RDD or Ndarray is provided, the data is written to the
+        If a Pandas DataFrame, Polars DatFrame, RDD or Ndarray is provided, the data is written to the
         online/offline feature store as specified.
         By default, this writes the feature group to the offline storage, and if
         `online_enabled` for the feature group, also to the online feature store.
         The `features` dataframe can be a Spark DataFrame or RDD, a Pandas DataFrame,
         or a two-dimensional Numpy array or a two-dimensional Python nested list.
         # Arguments
-            features: DataFrame, RDD, Ndarray or a list of features. Features to be saved.
+            features: Pandas DataFrame, Polars DataFrame, RDD, Ndarray or a list of features. Features to be saved.
                 This argument is optional if the feature list is provided in the create_feature_group or
                 in the get_or_create_feature_group method invokation.
             write_options: Additional write options as key-value pairs, defaults to `{}`.
@@ -2371,6 +2374,7 @@ class FeatureGroup(FeatureGroupBase):
         self,
         features: Union[
             pd.DataFrame,
+            pl.DataFrame,
             TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
             TypeVar("pyspark.RDD"),  # noqa: F821
             np.ndarray,
@@ -2391,7 +2395,7 @@ class FeatureGroup(FeatureGroupBase):
         default, the data is inserted into the offline storage as well as the online storage if the feature group is
         `online_enabled=True`.
 
-        The `features` dataframe can be a Spark DataFrame or RDD, a Pandas DataFrame,
+        The `features` dataframe can be a Spark DataFrame or RDD, a Pandas DataFrame, a Polars DataFrame
         or a two-dimensional Numpy array or a two-dimensional Python nested list.
         If statistics are enabled, statistics are recomputed for the entire feature
         group.
@@ -2450,7 +2454,7 @@ class FeatureGroup(FeatureGroupBase):
             ```
 
         # Arguments
-            features: DataFrame, RDD, Ndarray, list. Features to be saved.
+            features: Pandas DataFrame, Polars DataFrame, RDD, Ndarray, list. Features to be saved.
             overwrite: Drop all data in the feature group before
                 inserting new data. This does not affect metadata, defaults to False.
             operation: Apache Hudi operation type `"insert"` or `"upsert"`.
@@ -2543,6 +2547,7 @@ class FeatureGroup(FeatureGroupBase):
         self,
         features: Union[
             pd.DataFrame,
+            pl.DataFrame,
             TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
             TypeVar("pyspark.RDD"),  # noqa: F821
             np.ndarray,
@@ -2613,7 +2618,7 @@ class FeatureGroup(FeatureGroupBase):
             ```
 
         # Arguments
-            features: DataFrame, RDD, Ndarray, list. Features to be saved.
+            features: Pandas DataFrame, Polars DataFrame, RDD, Ndarray, list. Features to be saved.
             overwrite: Drop all data in the feature group before
                 inserting new data. This does not affect metadata, defaults to False.
             operation: Apache Hudi operation type `"insert"` or `"upsert"`.

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2049,8 +2049,9 @@ class FeatureGroup(FeatureGroupBase):
                 or `%Y-%m-%d %H:%M:%S.%f`.
             online: bool, optional. If `True` read from online feature store, defaults
                 to `False`.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                 Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
             read_options: Additional options as key/value pairs to pass to the execution engine.
                 For spark engine: Dictionary of read options for Spark.
                 For python engine:
@@ -3527,8 +3528,9 @@ class ExternalFeatureGroup(FeatureGroupBase):
             Feature Groups.
 
         # Arguments
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
             online: bool, optional. If `True` read from online feature store, defaults
                 to `False`.
             read_options: Additional options as key/value pairs to pass to the spark engine.

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -408,8 +408,9 @@ class FeatureStore:
 
         # Arguments
             query: The SQL query to execute.
-            dataframe_type: The type of the returned dataframe. Defaults to "default".
-                which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Hive engine.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
             online: Set to true to execute the query against the online feature store.
                 Defaults to False.
             read_options: Additional options as key/value pairs to pass to the execution engine.

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -450,13 +450,13 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"list"`, `"pandas"` or `"numpy"`. Defaults to `"list"`.
+            return_type: `"list"`, `"pandas"`, `"polars"` or `"numpy"`. Defaults to `"list"`.
             allow_missing: Setting to `True` returns feature vectors with missing values.
 
         # Returns
-            `list`, `pd.DataFrame` or `np.ndarray` if `return type` is set to `"list"`, `"pandas"` or `"numpy"`
+            `list`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` if `return type` is set to `"list"`, `"pandas"`, `"polars"` or `"numpy"`
             respectively. Defaults to `list`.
-            Returned `list`, `pd.DataFrame` or `np.ndarray` contains feature values related to provided primary keys,
+            Returned `list`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` contains feature values related to provided primary keys,
             ordered according to positions of this features in the feature view query.
 
         # Raises
@@ -544,14 +544,14 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"list"`, `"pandas"` or `"numpy"`. Defaults to `"list"`.
+            return_type: `"list"`, `"pandas"`, `"polars"` or `"numpy"`. Defaults to `"list"`.
             allow_missing: Setting to `True` returns feature vectors with missing values.
 
         # Returns
-            `List[list]`, `pd.DataFrame` or `np.ndarray` if `return type` is set to `"list", `"pandas"` or `"numpy"`
+            `List[list]`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` if `return type` is set to `"list", `"pandas"`,`"polars"` or `"numpy"`
             respectively. Defaults to `List[list]`.
 
-            Returned `List[list]`, `pd.DataFrame` or `np.ndarray` contains feature values related to provided primary
+            Returned `List[list]`, `pd.DataFrame`, `polars.DataFrame` or `np.ndarray` contains feature values related to provided primary
             keys, ordered according to positions of this features in the feature view query.
 
         # Raises
@@ -603,10 +603,10 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"pandas"` or `"dict"`. Defaults to `"pandas"`.
+            return_type: `"pandas"`, `"polars"` or `"dict"`. Defaults to `"pandas"`.
 
         # Returns
-            `pd.DataFrame` or `dict`. Defaults to `pd.DataFrame`.
+            `pd.DataFrame`, `polars.DataFrame` or `dict`. Defaults to `pd.DataFrame`.
 
         # Raises
             `Exception`. When primary key entry cannot be found in one or more of the feature groups used by this
@@ -657,10 +657,10 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"pandas"` or `"dict"`. Defaults to `"dict"`.
+            return_type: `"pandas"`, `"polars"` or `"dict"`. Defaults to `"dict"`.
 
         # Returns
-            `pd.DataFrame` or `List[dict]`.  Defaults to `pd.DataFrame`.
+            `pd.DataFrame`, `polars.DataFrame` or `List[dict]`.  Defaults to `pd.DataFrame`.
 
             Returned `pd.DataFrame` or `List[dict]`  contains feature values related to provided primary
             keys, ordered according to positions of this features in the feature view query.
@@ -804,6 +804,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         inference_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """Get a batch of data from an event time interval from the offline feature store.
 
@@ -859,8 +860,15 @@ class FeatureView:
                 that may not be used in training the model itself but can be used during batch or online inference
                 for extra information. If inference helper columns were not defined in the feature view
                 `inference_helper_columns=True` will not any effect. Defaults to `False`, no helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
-            `DataFrame`: A dataframe
+            `DataFrame`: The spark dataframe containing the feature data.
+            `pyspark.DataFrame`. A Spark DataFrame.
+            `pandas.DataFrame`. A Pandas DataFrame.
+            `polars.DataFrame`. A Polars DataFrame.
+            `numpy.ndarray`. A two-dimensional Numpy array.
+            `list`. A two-dimensional Python list.
         """
 
         if self._batch_scoring_server is None:
@@ -877,6 +885,7 @@ class FeatureView:
             primary_keys,
             event_time,
             inference_helper_columns,
+            dataframe_type,
         )
 
     def add_tag(self, name: str, value):
@@ -1916,6 +1925,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Create the metadata for a training dataset and get the corresponding training data from the offline feature store.
@@ -2012,6 +2022,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X, y): Tuple of dataframe of features and labels. If there are no labels, y returns `None`.
         """
@@ -2038,6 +2050,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type,
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2070,6 +2083,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Create the metadata for a training dataset and get the corresponding training data from the offline feature store.
@@ -2176,6 +2190,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
@@ -2211,6 +2227,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type,
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2255,6 +2272,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Create the metadata for a training dataset and get the corresponding training data from the offline feature store.
@@ -2374,6 +2392,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
@@ -2422,6 +2442,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type,
         )
         warnings.warn(
             "Incremented version to `{}`.".format(td.version),
@@ -2458,6 +2479,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Get training data created by `feature_view.create_training_data`
@@ -2502,6 +2524,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X, y): Tuple of dataframe of features and labels
         """
@@ -2512,6 +2536,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type,
         )
         return df
 
@@ -2523,6 +2548,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Get training data created by `feature_view.create_train_test_split`
@@ -2562,6 +2588,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
@@ -2574,6 +2602,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type,
         )
         return df
 
@@ -2585,6 +2614,7 @@ class FeatureView:
         primary_keys=False,
         event_time=False,
         training_helper_columns=False,
+        dataframe_type: Optional[str] = "default",
     ):
         """
         Get training data created by `feature_view.create_train_validation_test_split`
@@ -2624,6 +2654,8 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
         # Returns
             (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
@@ -2640,6 +2672,7 @@ class FeatureView:
             primary_keys=primary_keys,
             event_time=event_time,
             training_helper_columns=training_helper_columns,
+            dataframe_type=dataframe_type,
         )
         return df
 

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -860,8 +860,9 @@ class FeatureView:
                 that may not be used in training the model itself but can be used during batch or online inference
                 for extra information. If inference helper columns were not defined in the feature view
                 `inference_helper_columns=True` will not any effect. Defaults to `False`, no helper columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             `DataFrame`: The spark dataframe containing the feature data.
             `pyspark.DataFrame`. A Spark DataFrame.
@@ -2022,8 +2023,9 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             (X, y): Tuple of dataframe of features and labels. If there are no labels, y returns `None`.
         """
@@ -2190,8 +2192,9 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
@@ -2392,8 +2395,9 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view
                 then`training_helper_columns=True` will not have any effect. Defaults to `False`, no training helper
                 columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels
@@ -2524,8 +2528,9 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             (X, y): Tuple of dataframe of features and labels
         """
@@ -2588,8 +2593,9 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             (X_train, X_test, y_train, y_test):
                 Tuple of dataframe of features and labels
@@ -2654,8 +2660,9 @@ class FeatureView:
                 extra information. If training helper columns were not defined in the feature view or during
                 materializing training dataset in the file system then`training_helper_columns=True` will not have
                 any effect. Defaults to `False`, no training helper columns.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Returns
             (X_train, X_val, X_test, y_train, y_val, y_test):
                 Tuple of dataframe of features and labels

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -657,7 +657,7 @@ class FeatureView:
                 If set to False, the online feature store storage connector is used
                 which relies on the private IP. Defaults to True if connection to Hopsworks is established from
                 external environment (e.g AWS Sagemaker or Google Colab), otherwise to False.
-            return_type: `"pandas"`, `"polars"` or `"dict"`. Defaults to `"dict"`.
+            return_type: `"pandas"`, `"polars"` or `"dict"`. Defaults to `"pandas"`.
 
         # Returns
             `pd.DataFrame`, `polars.DataFrame` or `List[dict]`.  Defaults to `pd.DataFrame`.

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -119,8 +119,9 @@ class StorageConnector(ABC):
             options: Any additional key/value options to be passed to the connector.
             path: Path to be read from within the bucket of the storage connector. Not relevant
                 for JDBC or database based connectors such as Snowflake, JDBC or Redshift.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Returns
             `DataFrame`.
@@ -294,8 +295,9 @@ class S3Connector(StorageConnector):
             data_format: The file format of the files to be read, e.g. `csv`, `parquet`.
             options: Any additional key/value options to be passed to the S3 connector.
             path: Path within the bucket to be read.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Returns
             `DataFrame`.
@@ -482,8 +484,9 @@ class RedshiftConnector(StorageConnector):
             data_format: Not relevant for JDBC based connectors such as Redshift.
             options: Any additional key/value options to be passed to the JDBC connector.
             path: Not relevant for JDBC based connectors such as Redshift.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Returns
             `DataFrame`.
@@ -627,8 +630,9 @@ class AdlsConnector(StorageConnector):
             options: Any additional key/value options to be passed to the ADLS connector.
             path: Path within the bucket to be read. For example, path=`path` will read directly from the container specified on connector by constructing the URI as 'abfss://[container-name]@[account_name].dfs.core.windows.net/[path]'.
             If no path is specified default container path will be used from connector.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Returns
             `DataFrame`.
@@ -823,8 +827,9 @@ class SnowflakeConnector(StorageConnector):
             data_format: Not relevant for Snowflake connectors.
             options: Any additional key/value options to be passed to the engine.
             path: Not relevant for Snowflake connectors.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Returns
             `DataFrame`.
@@ -906,8 +911,9 @@ class JdbcConnector(StorageConnector):
             data_format: Not relevant for JDBC based connectors.
             options: Any additional key/value options to be passed to the JDBC connector.
             path: Not relevant for JDBC based connectors.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Returns
             `DataFrame`.
@@ -1332,8 +1338,9 @@ class GcsConnector(StorageConnector):
             data_format: Spark data format. Defaults to `None`.
             options: Spark options. Defaults to `None`.
             path: GCS path. Defaults to `None`.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas", `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
         # Raises
             `ValueError`: Malformed arguments.
 
@@ -1516,8 +1523,9 @@ class BigQueryConnector(StorageConnector):
             data_format: Spark data format. Defaults to `None`.
             options: Spark options. Defaults to `None`.
             path: BigQuery table path. Defaults to `None`.
-            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
-                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
+            dataframe_type: str, optional. The type of the returned dataframe.
+                Possible values are `"default"`, `"spark"`,`"pandas"`, `"polars"`, `"numpy"` or `"python"`.
+                Defaults to "default", which maps to Spark dataframe for the Spark Engine and Pandas dataframe for the Python engine.
 
         # Raises
             `ValueError`: Malformed arguments.

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -103,6 +103,7 @@ class StorageConnector(ABC):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a query or a path into a dataframe using the storage connector.
 
@@ -118,11 +119,15 @@ class StorageConnector(ABC):
             options: Any additional key/value options to be passed to the connector.
             path: Path to be read from within the bucket of the storage connector. Not relevant
                 for JDBC or database based connectors such as Snowflake, JDBC or Redshift.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
         """
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
     def refetch(self):
         """
@@ -277,6 +282,7 @@ class S3Connector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = "",
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a query or a path into a dataframe using the storage connector.
 
@@ -288,6 +294,8 @@ class S3Connector(StorageConnector):
             data_format: The file format of the files to be read, e.g. `csv`, `parquet`.
             options: Any additional key/value options to be passed to the S3 connector.
             path: Path within the bucket to be read.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, "polars"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -306,7 +314,9 @@ class S3Connector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
     def _get_path(self, sub_path: str):
         return os.path.join(self.path, sub_path)
@@ -461,6 +471,7 @@ class RedshiftConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a table or query into a dataframe using the storage connector.
 
@@ -471,6 +482,8 @@ class RedshiftConnector(StorageConnector):
             data_format: Not relevant for JDBC based connectors such as Redshift.
             options: Any additional key/value options to be passed to the JDBC connector.
             path: Not relevant for JDBC based connectors such as Redshift.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -487,7 +500,9 @@ class RedshiftConnector(StorageConnector):
             # if table also specified we override to use query
             options.pop("dbtable", None)
 
-        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None)
+        return engine.get_instance().read(
+            self, self.JDBC_FORMAT, options, None, dataframe_type
+        )
 
     def refetch(self):
         """
@@ -603,6 +618,7 @@ class AdlsConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = "",
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a path into a dataframe using the storage connector.
         # Arguments
@@ -611,6 +627,8 @@ class AdlsConnector(StorageConnector):
             options: Any additional key/value options to be passed to the ADLS connector.
             path: Path within the bucket to be read. For example, path=`path` will read directly from the container specified on connector by constructing the URI as 'abfss://[container-name]@[account_name].dfs.core.windows.net/[path]'.
             If no path is specified default container path will be used from connector.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -624,7 +642,9 @@ class AdlsConnector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
 
 class SnowflakeConnector(StorageConnector):
@@ -792,6 +812,7 @@ class SnowflakeConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a table or query into a dataframe using the storage connector.
 
@@ -802,6 +823,8 @@ class SnowflakeConnector(StorageConnector):
             data_format: Not relevant for Snowflake connectors.
             options: Any additional key/value options to be passed to the engine.
             path: Not relevant for Snowflake connectors.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -816,7 +839,9 @@ class SnowflakeConnector(StorageConnector):
             # if table also specified we override to use query
             options.pop("dbtable", None)
 
-        return engine.get_instance().read(self, self.SNOWFLAKE_FORMAT, options, None)
+        return engine.get_instance().read(
+            self, self.SNOWFLAKE_FORMAT, options, None, dataframe_type
+        )
 
 
 class JdbcConnector(StorageConnector):
@@ -872,6 +897,7 @@ class JdbcConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads a query into a dataframe using the storage connector.
 
@@ -880,6 +906,8 @@ class JdbcConnector(StorageConnector):
             data_format: Not relevant for JDBC based connectors.
             options: Any additional key/value options to be passed to the JDBC connector.
             path: Not relevant for JDBC based connectors.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Returns
             `DataFrame`.
@@ -893,7 +921,9 @@ class JdbcConnector(StorageConnector):
         if query:
             options["query"] = query
 
-        return engine.get_instance().read(self, self.JDBC_FORMAT, options, None)
+        return engine.get_instance().read(
+            self, self.JDBC_FORMAT, options, None, dataframe_type
+        )
 
 
 class KafkaConnector(StorageConnector):
@@ -992,9 +1022,9 @@ class KafkaConnector(StorageConnector):
         )
 
         # set ssl
-        config[
-            "ssl.endpoint.identification.algorithm"
-        ] = self._ssl_endpoint_identification_algorithm
+        config["ssl.endpoint.identification.algorithm"] = (
+            self._ssl_endpoint_identification_algorithm
+        )
 
         # Here we cannot use `not self._external_kafka` as for normal kafka connectors
         # this option is not set and so the `not self._external_kafka` would return true
@@ -1140,6 +1170,7 @@ class KafkaConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """NOT SUPPORTED."""
         raise NotImplementedError(
@@ -1279,6 +1310,7 @@ class GcsConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = "",
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads GCS path into a dataframe using the storage connector.
 
@@ -1300,6 +1332,8 @@ class GcsConnector(StorageConnector):
             data_format: Spark data format. Defaults to `None`.
             options: Spark options. Defaults to `None`.
             path: GCS path. Defaults to `None`.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas", `"numpy"` or `"python"`, defaults to `"default"`.
         # Raises
             `ValueError`: Malformed arguments.
 
@@ -1321,7 +1355,9 @@ class GcsConnector(StorageConnector):
                 )
             )
 
-        return engine.get_instance().read(self, data_format, options, path)
+        return engine.get_instance().read(
+            self, data_format, options, path, dataframe_type
+        )
 
     def prepare_spark(self, path: Optional[str] = None):
         """Prepare Spark to use this Storage Connector.
@@ -1451,6 +1487,7 @@ class BigQueryConnector(StorageConnector):
         data_format: str = None,
         options: dict = {},
         path: str = None,
+        dataframe_type: Optional[str] = "default",
     ):
         """Reads results from BigQuery into a spark dataframe using the storage connector.
 
@@ -1479,6 +1516,8 @@ class BigQueryConnector(StorageConnector):
             data_format: Spark data format. Defaults to `None`.
             options: Spark options. Defaults to `None`.
             path: BigQuery table path. Defaults to `None`.
+            dataframe_type: str, optional. Possible values are `"default"`, `"spark"`,
+                `"pandas"`, `"numpy"` or `"python"`, defaults to `"default"`.
 
         # Raises
             `ValueError`: Malformed arguments.
@@ -1518,4 +1557,6 @@ class BigQueryConnector(StorageConnector):
                 "or Query Project,Dataset and Table should be set"
             )
 
-        return engine.get_instance().read(self, self.BIGQUERY_FORMAT, options, path)
+        return engine.get_instance().read(
+            self, self.BIGQUERY_FORMAT, options, path, dataframe_type
+        )

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1022,9 +1022,9 @@ class KafkaConnector(StorageConnector):
         )
 
         # set ssl
-        config["ssl.endpoint.identification.algorithm"] = (
-            self._ssl_endpoint_identification_algorithm
-        )
+        config[
+            "ssl.endpoint.identification.algorithm"
+        ] = self._ssl_endpoint_identification_algorithm
 
         # Here we cannot use `not self._external_kafka` as for normal kafka connectors
         # this option is not set and so the `not self._external_kafka` would return true

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,7 @@ setup(
         "fsspec",
         "retrying",
         "aiomysql",
+        "polars",
         "opensearch-py>=1.1.0,<=2.4.2",
     ],
     extras_require={

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -1134,6 +1134,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=None,
             training_helper_columns=None,
             feature_view_features=[],
+            dataframe_type="default"
         )
 
         # Assert
@@ -1186,6 +1187,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=None,
             training_helper_columns=None,
             feature_view_features=[],
+            dataframe_type="default"
         )
 
         # Assert
@@ -1231,6 +1233,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=False,
             training_helper_columns=[],
             feature_view_features=[],
+            dataframe_type="default"
         )
 
         # Assert
@@ -1272,6 +1275,7 @@ class TestFeatureViewEngine:
                 with_training_helper_columns=None,
                 training_helper_columns=None,
                 feature_view_features=[],
+                 dataframe_type="default"
             )
 
         # Assert

--- a/python/tests/core/test_feature_view_engine.py
+++ b/python/tests/core/test_feature_view_engine.py
@@ -1134,7 +1134,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=None,
             training_helper_columns=None,
             feature_view_features=[],
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -1187,7 +1187,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=None,
             training_helper_columns=None,
             feature_view_features=[],
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -1233,7 +1233,7 @@ class TestFeatureViewEngine:
             with_training_helper_columns=False,
             training_helper_columns=[],
             feature_view_features=[],
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -1275,7 +1275,7 @@ class TestFeatureViewEngine:
                 with_training_helper_columns=None,
                 training_helper_columns=None,
                 feature_view_features=[],
-                 dataframe_type="default"
+                dataframe_type="default",
             )
 
         # Assert

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2136,7 +2136,7 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pd.DataFrame) 
+        assert isinstance(result_df, pd.DataFrame)
         assert result_df_split == None
 
     def test_split_labels_dataframe_type_pandas(self):
@@ -2152,7 +2152,7 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pd.DataFrame) 
+        assert isinstance(result_df, pd.DataFrame)
         assert result_df_split == None
 
     def test_split_labels_dataframe_type_polars(self):
@@ -2167,7 +2167,7 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pl.DataFrame) 
+        assert isinstance(result_df, pl.DataFrame)
         assert result_df_split == None
 
     def test_split_labels_dataframe_type_python(self):
@@ -2182,7 +2182,7 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, list) 
+        assert isinstance(result_df, list)
         assert result_df_split == None
 
     def test_split_labels_dataframe_type_numpy(self):
@@ -2197,8 +2197,8 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, np.ndarray) 
-        assert result_df_split == None   
+        assert isinstance(result_df, np.ndarray)
+        assert result_df_split == None
 
     def test_split_labels_labels(self):
         # Arrange
@@ -2229,8 +2229,8 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pd.DataFrame) 
-        assert isinstance(result_df_split, pd.Series) 
+        assert isinstance(result_df, pd.DataFrame)
+        assert isinstance(result_df_split, pd.Series)
 
     def test_split_labels_labels_dataframe_type_pandas(self):
         # Arrange
@@ -2245,8 +2245,8 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pd.DataFrame) 
-        assert isinstance(result_df_split, pd.Series) 
+        assert isinstance(result_df, pd.DataFrame)
+        assert isinstance(result_df_split, pd.Series)
 
     def test_split_labels_labels_dataframe_type_polars(self):
         # Arrange
@@ -2261,8 +2261,8 @@ class TestPython:
         )
         print(type(result_df_split))
         # Assert
-        assert isinstance(result_df, pl.DataFrame) 
-        assert isinstance(result_df_split, pl.Series) 
+        assert isinstance(result_df, pl.DataFrame)
+        assert isinstance(result_df_split, pl.Series)
 
     def test_split_labels_labels_dataframe_type_python(self):
         # Arrange
@@ -2275,10 +2275,10 @@ class TestPython:
         result_df, result_df_split = python_engine.split_labels(
             df=df, dataframe_type="python", labels="col1"
         )
-    
+
         # Assert
-        assert isinstance(result_df, list) 
-        assert isinstance(result_df_split, list) 
+        assert isinstance(result_df, list)
+        assert isinstance(result_df_split, list)
 
     def test_split_labels_labels_dataframe_type_numpy(self):
         # Arrange
@@ -2293,8 +2293,8 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, np.ndarray) 
-        assert isinstance(result_df_split, np.ndarray) 
+        assert isinstance(result_df, np.ndarray)
+        assert isinstance(result_df_split, np.ndarray)
 
     def test_prepare_transform_split_df_random_split(self, mocker):
         # Arrange
@@ -2968,7 +2968,7 @@ class TestPython:
 
         # Assert
         assert str(result) == "   col1  col2\n0     1     3\n1     2     4"
-    
+
     def test_return_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -3053,7 +3053,7 @@ class TestPython:
         # Assert
         assert result == file
 
-    def test_apply_transformation_function(self, mocker):
+    def test_apply_transformation_function_pandas(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
 
@@ -3084,6 +3084,48 @@ class TestPython:
         )
 
         df = pd.DataFrame(data={"tf_name": [1, 2]})
+
+        # Act
+        result = python_engine._apply_transformation_function(
+            transformation_functions=td.transformation_functions, dataset=df
+        )
+
+        # Assert
+        assert len(result["tf_name"]) == 2
+        assert result["tf_name"][0] == 2
+        assert result["tf_name"][1] == 3
+
+    def test_apply_transformation_function_polars(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.client.get_instance")
+
+        python_engine = python.Engine()
+
+        def plus_one(a):
+            return a + 1
+
+        tf = transformation_function.TransformationFunction(
+            99,
+            transformation_fn=plus_one,
+            builtin_source_code="",
+            output_type="int",
+        )
+
+        transformation_fn_dict = dict()
+
+        transformation_fn_dict["tf_name"] = tf
+
+        td = training_dataset.TrainingDataset(
+            name="test",
+            version=1,
+            data_format="CSV",
+            featurestore_id=99,
+            splits={},
+            id=10,
+            transformation_functions=transformation_fn_dict,
+        )
+
+        df = pl.DataFrame(data={"tf_name": [1, 2]})
 
         # Act
         result = python_engine._apply_transformation_function(

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2137,7 +2137,7 @@ class TestPython:
 
         # Assert
         assert isinstance(result_df, pd.DataFrame)
-        assert result_df_split == None
+        assert result_df_split is None
 
     def test_split_labels_dataframe_type_pandas(self):
         # Arrange
@@ -2153,7 +2153,7 @@ class TestPython:
 
         # Assert
         assert isinstance(result_df, pd.DataFrame)
-        assert result_df_split == None
+        assert result_df_split is None
 
     def test_split_labels_dataframe_type_polars(self):
         # Arrange
@@ -2168,7 +2168,7 @@ class TestPython:
 
         # Assert
         assert isinstance(result_df, pl.DataFrame)
-        assert result_df_split == None
+        assert result_df_split is None
 
     def test_split_labels_dataframe_type_python(self):
         # Arrange
@@ -2183,7 +2183,7 @@ class TestPython:
 
         # Assert
         assert isinstance(result_df, list)
-        assert result_df_split == None
+        assert result_df_split is None
 
     def test_split_labels_dataframe_type_numpy(self):
         # Arrange
@@ -2198,7 +2198,7 @@ class TestPython:
 
         # Assert
         assert isinstance(result_df, np.ndarray)
-        assert result_df_split == None
+        assert result_df_split is None
 
     def test_split_labels_labels(self):
         # Arrange
@@ -2295,54 +2295,6 @@ class TestPython:
         # Assert
         assert isinstance(result_df, np.ndarray)
         assert isinstance(result_df_split, np.ndarray)
-
-    def test_prepare_transform_split_df_random_split(self, mocker):
-        # Arrange
-        mocker.patch("hsfs.client.get_instance")
-        mocker.patch("hsfs.engine.get_type")
-        mocker.patch("hsfs.constructor.query.Query.read")
-        mock_python_engine_random_split = mocker.patch(
-            "hsfs.engine.python.Engine._random_split"
-        )
-        mocker.patch(
-            "hsfs.core.transformation_function_engine.TransformationFunctionEngine"
-        )
-
-        python_engine = python.Engine()
-
-        d = {"col1": [1, 2], "col2": [3, 4]}
-        df = pd.DataFrame(data=d)
-
-        td = training_dataset.TrainingDataset(
-            name="test",
-            version=1,
-            data_format="CSV",
-            featurestore_id=99,
-            splits={"test_split1": 0.5, "test_split2": 0.5},
-            label=["f", "f_wrong"],
-            id=10,
-        )
-
-        q = query.Query(left_feature_group=None, left_features=None)
-
-        mock_python_engine_random_split.return_value = {
-            "train": df.loc[df["col1"] == 1],
-            "test": df.loc[df["col1"] == 2],
-        }
-
-        # Act
-        result = python_engine._prepare_transform_split_df(
-            query_obj=q,
-            training_dataset_obj=td,
-            feature_view_obj=None,
-            read_option=None,
-            dataframe_type="default",
-        )
-
-        # Assert
-        assert mock_python_engine_random_split.call_count == 1
-        assert isinstance(result["train"], pd.DataFrame)
-        assert isinstance(result["test"], pd.DataFrame)
 
     def test_prepare_transform_split_df_random_split(self, mocker):
         # Arrange

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2167,7 +2167,7 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pl.Dataframe) or isinstance(
+        assert isinstance(result_df, pl.DataFrame) or isinstance(
             result_df, pl.dataframe.frame.DataFrame
         )
         assert result_df_split is None
@@ -2263,7 +2263,7 @@ class TestPython:
         )
         print(type(result_df_split))
         # Assert
-        assert isinstance(result_df, pl.Dataframe) or isinstance(
+        assert isinstance(result_df, pl.DataFrame) or isinstance(
             result_df, pl.dataframe.frame.DataFrame
         )
         assert isinstance(result_df_split, pl.Series)
@@ -2938,7 +2938,7 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result, pl.Dataframe) or isinstance(
+        assert isinstance(result, pl.DataFrame) or isinstance(
             result, pl.dataframe.frame.DataFrame
         )
         assert df.equals(result)

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -198,7 +198,7 @@ class TestPython:
                 data_format=None,
                 read_options=None,
                 location=None,
-                dataframe_type="default"
+                dataframe_type="default",
             )
 
         # Assert
@@ -217,7 +217,7 @@ class TestPython:
                 data_format="",
                 read_options=None,
                 location=None,
-                dataframe_type="default"
+                dataframe_type="default",
             )
 
         # Assert
@@ -243,7 +243,7 @@ class TestPython:
             data_format="csv",
             read_options=None,
             location=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -270,7 +270,7 @@ class TestPython:
             data_format="csv",
             read_options=None,
             location=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -297,7 +297,7 @@ class TestPython:
                 data_format="csv",
                 read_options=None,
                 location=None,
-            dataframe_type="default"
+                dataframe_type="default",
             )
 
         # Assert
@@ -863,7 +863,8 @@ class TestPython:
         python_engine = python.Engine()
 
         mock_python_engine_convert_pandas_statistics.return_value = {
-            "dataType": "Integral", "test_key": "test_value"
+            "dataType": "Integral",
+            "test_key": "test_value",
         }
 
         d = {"col1": [1, 2], "col2": [0.1, 0.2], "col3": ["a", "b"]}
@@ -1049,7 +1050,7 @@ class TestPython:
             "minimum": 1,
             "stdDev": 33,
             "sum": 5000,
-            "count": 100
+            "count": 100,
         }
 
     def test_validate(self):
@@ -1964,7 +1965,7 @@ class TestPython:
             feature_view_obj=None,
             query_obj=mocker.Mock(),
             read_options=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -1998,7 +1999,7 @@ class TestPython:
             feature_view_obj=None,
             query_obj=mocker.Mock(),
             read_options=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2012,7 +2013,9 @@ class TestPython:
         df = pd.DataFrame(data=d)
 
         # Act
-        result_df, result_df_split = python_engine.split_labels(df=df, dataframe_type="default", labels=None)
+        result_df, result_df_split = python_engine.split_labels(
+            df=df, dataframe_type="default", labels=None
+        )
 
         # Assert
         assert str(result_df) == "   Col1  col2\n0     1     3\n1     2     4"
@@ -2026,7 +2029,9 @@ class TestPython:
         df = pd.DataFrame(data=d)
 
         # Act
-        result_df, result_df_split = python_engine.split_labels(df=df, dataframe_type="default", labels="col1")
+        result_df, result_df_split = python_engine.split_labels(
+            df=df, dataframe_type="default", labels="col1"
+        )
 
         # Assert
         assert str(result_df) == "   col2\n0     3\n1     4"
@@ -2072,7 +2077,7 @@ class TestPython:
             training_dataset_obj=td,
             feature_view_obj=None,
             read_option=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2138,7 +2143,7 @@ class TestPython:
             training_dataset_obj=td,
             feature_view_obj=None,
             read_option=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2203,7 +2208,7 @@ class TestPython:
             training_dataset_obj=td,
             feature_view_obj=None,
             read_option=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -2167,7 +2167,9 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result_df, pl.DataFrame)
+        assert isinstance(result_df, pl.Dataframe) or isinstance(
+            result_df, pl.dataframe.frame.DataFrame
+        )
         assert result_df_split is None
 
     def test_split_labels_dataframe_type_python(self):
@@ -2261,7 +2263,9 @@ class TestPython:
         )
         print(type(result_df_split))
         # Assert
-        assert isinstance(result_df, pl.DataFrame)
+        assert isinstance(result_df, pl.Dataframe) or isinstance(
+            result_df, pl.dataframe.frame.DataFrame
+        )
         assert isinstance(result_df_split, pl.Series)
 
     def test_split_labels_labels_dataframe_type_python(self):
@@ -2934,7 +2938,9 @@ class TestPython:
         )
 
         # Assert
-        assert isinstance(result, pl.DataFrame)
+        assert isinstance(result, pl.Dataframe) or isinstance(
+            result, pl.dataframe.frame.DataFrame
+        )
         assert df.equals(result)
 
     def test_return_dataframe_type_numpy(self):

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -1699,6 +1699,7 @@ class TestSpark:
             feature_view_obj=None,
             query_obj=None,
             read_options=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -1715,6 +1716,7 @@ class TestSpark:
         result = spark_engine.split_labels(
             df=df,
             labels=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2809,6 +2811,7 @@ class TestSpark:
                 data_format=None,
                 read_options=None,
                 location=None,
+                dataframe_type="default"
             )
 
         # Assert
@@ -2827,6 +2830,7 @@ class TestSpark:
                 data_format="",
                 read_options=None,
                 location=None,
+                dataframe_type="default"
             )
 
         # Assert
@@ -2849,6 +2853,7 @@ class TestSpark:
             data_format="csv",
             read_options={"name": "value"},
             location=None,
+            dataframe_type="default"
         )
 
         # Assert
@@ -2881,6 +2886,7 @@ class TestSpark:
             data_format="delta",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2910,6 +2916,7 @@ class TestSpark:
             data_format="parquet",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2940,6 +2947,7 @@ class TestSpark:
             data_format="hudi",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2969,6 +2977,7 @@ class TestSpark:
             data_format="orc",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -2998,6 +3007,7 @@ class TestSpark:
             data_format="bigquery",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -3028,6 +3038,7 @@ class TestSpark:
             data_format="csv",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert
@@ -3058,6 +3069,7 @@ class TestSpark:
             data_format="csv",
             read_options=None,
             location="test_location",
+            dataframe_type="default"
         )
 
         # Assert

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -35,6 +35,7 @@ from pyspark.sql.types import (
     MapType,
     ArrayType,
 )
+from pyspark.sql import DataFrame
 
 from hsfs import (
     feature_group,
@@ -287,22 +288,31 @@ class TestSpark:
         # Arrange
         spark_engine = spark.Engine()
 
-        mock_df = mocker.Mock()
+        mock_df = mocker.Mock(spec=DataFrame)
 
         # Act
         result = spark_engine._return_dataframe_type(
             dataframe=mock_df,
             dataframe_type="pandas",
         )
-
         # Assert
         assert result == mock_df.toPandas()
+
+        mock_df = mocker.Mock(spec=pd.DataFrame)
+
+        # Act
+        result = spark_engine._return_dataframe_type(
+            dataframe=mock_df,
+            dataframe_type="pandas",
+        )
+        # Assert
+        assert result == mock_df
 
     def test_return_dataframe_type_numpy(self, mocker):
         # Arrange
         spark_engine = spark.Engine()
 
-        mock_df = mocker.Mock()
+        mock_df = mocker.Mock(spec=DataFrame)
 
         # Act
         result = spark_engine._return_dataframe_type(
@@ -313,11 +323,21 @@ class TestSpark:
         # Assert
         assert result == mock_df.toPandas().values
 
+        mock_df = mocker.Mock(spec=pd.DataFrame)
+
+        # Act
+        result = spark_engine._return_dataframe_type(
+            dataframe=mock_df,
+            dataframe_type="numpy",
+        )
+        # Assert
+        assert result == mock_df.values
+
     def test_return_dataframe_type_python(self, mocker):
         # Arrange
         spark_engine = spark.Engine()
 
-        mock_df = mocker.Mock()
+        mock_df = mocker.Mock(spec=DataFrame)
 
         # Act
         result = spark_engine._return_dataframe_type(
@@ -327,6 +347,16 @@ class TestSpark:
 
         # Assert
         assert result == mock_df.toPandas().values.tolist()
+
+        mock_df = mocker.Mock(spec=pd.DataFrame)
+
+        # Act
+        result = spark_engine._return_dataframe_type(
+            dataframe=mock_df,
+            dataframe_type="python",
+        )
+        # Assert
+        assert result == mock_df.values.tolist()
 
     def test_return_dataframe_type_other(self, mocker):
         # Arrange

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -1732,8 +1732,7 @@ class TestSpark:
 
         # Act
         df_new, labels_df = spark_engine.split_labels(
-            df=spark_df,
-            labels=["col_0"],
+            df=spark_df, labels=["col_0"], dataframe_type="default"
         )
 
         # Assert

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -1699,7 +1699,7 @@ class TestSpark:
             feature_view_obj=None,
             query_obj=None,
             read_options=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -1713,11 +1713,7 @@ class TestSpark:
         df = pd.DataFrame(data=d)
 
         # Act
-        result = spark_engine.split_labels(
-            df=df,
-            labels=None,
-            dataframe_type="default"
-        )
+        result = spark_engine.split_labels(df=df, labels=None, dataframe_type="default")
 
         # Assert
         assert result == (df, None)
@@ -2811,7 +2807,7 @@ class TestSpark:
                 data_format=None,
                 read_options=None,
                 location=None,
-                dataframe_type="default"
+                dataframe_type="default",
             )
 
         # Assert
@@ -2830,7 +2826,7 @@ class TestSpark:
                 data_format="",
                 read_options=None,
                 location=None,
-                dataframe_type="default"
+                dataframe_type="default",
             )
 
         # Assert
@@ -2853,7 +2849,7 @@ class TestSpark:
             data_format="csv",
             read_options={"name": "value"},
             location=None,
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2886,7 +2882,7 @@ class TestSpark:
             data_format="delta",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2916,7 +2912,7 @@ class TestSpark:
             data_format="parquet",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2947,7 +2943,7 @@ class TestSpark:
             data_format="hudi",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -2977,7 +2973,7 @@ class TestSpark:
             data_format="orc",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -3007,7 +3003,7 @@ class TestSpark:
             data_format="bigquery",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -3038,7 +3034,7 @@ class TestSpark:
             data_format="csv",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert
@@ -3069,7 +3065,7 @@ class TestSpark:
             data_format="csv",
             read_options=None,
             location="test_location",
-            dataframe_type="default"
+            dataframe_type="default",
         )
 
         # Assert


### PR DESCRIPTION
This PR adds support for Polars, specifically writing  and reading polars dataframes to a feature store.

**Changes:**

1. **Write Support for Polars**

- Added support for pyarrow types : large_list, large_string and large_binary - Since lists, string and binary types are converted into large_list, large_string and large_binary formats when a polars dataframe is created from a pandas dataframe.
- Also added support for pyarrow dictionary types that has value_type which can be any strings type and index_type that can be any integer type. This done because category types are in Polars are represented as a dictionary value_type string and index_type integer
- Modified function for convert_to_default_dataframe, _write_dataframe_kafka and parse_schema_feature_group to perform same functionality using polars.
- In function _write_dataframe_kafka conversion of return types of dataframe iterators to native python types are not performed for polars since iter_rows in polars already return data as python types. (https://docs.pola.rs/py-polars/html/reference/dataframe/api/polars.DataFrame.iter_rows.html)
- validate_with_great_expectations function has a patch that converts dataframe to pandas when validating since expectations does not currently support polars.

2. **Read Support for Polars**

- Added support for reading dataframes as list, pandas dataframe, polars dataframe, and numpy arrays from feature group using both Hive and ArrowFlight.
- Arrow flight client modified to add support for reading polars dataframes directly.
- Storage connectors for AWS S3 and HopsFS modified to add support for reading dataframes as list, pandas dataframe, polars dataframe, and numpy arrays. Other storage connectors modified to add support for reading dataframes as list, pandas dataframe, and numpy arrays, polars dataframe support not added since these storage connectors are not supported in Python.
- Added support for reading training data, training - test data, training - validation - test data as a list, pandas dataframe, polars dataframe, and numpy arrays.
- Vector server modified to allow reading vector and inference helpers as list, pandas dataframe, polars dataframe, and numpy arrays.
- Training Dataset is not modified since the class is deprecated.
- Feature View read_changes function not modified since it is deprecated.

3. Spark Engine also has been modified so that it has the same function signature as python engine for common functions.


LoadTest - https://github.com/logicalclocks/loadtest/pull/286

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1186

**How Has This Been Tested?**

- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
