### PR TITLE
[FSTORE-1253] Adding support for all datatype during statistic computation

### DIFF
--- a/python/hsfs/core/feature_monitoring_result_engine.py
+++ b/python/hsfs/core/feature_monitoring_result_engine.py
@@ -382,9 +382,10 @@ class FeatureMonitoringResultEngine:
             )
 
         # sort by feature name
-        sorted_det_stats, sorted_ref_stats = sorted(
-            detection_statistics, key=lambda fds: fds.feature_name
-        ), sorted(reference_statistics, key=lambda fds: fds.feature_name)
+        sorted_det_stats, sorted_ref_stats = (
+            sorted(detection_statistics, key=lambda fds: fds.feature_name),
+            sorted(reference_statistics, key=lambda fds: fds.feature_name),
+        )
 
         fm_results = []
         for det_fds, ref_fds in zip(sorted_det_stats, sorted_ref_stats):


### PR DESCRIPTION
This PR fixes the issue in which creation of training test split without materialization feailing when during computing statistics when Feature Group contains certain date time types.

**Changes Done**

- Used pyarrow schema to compare type instead of using pandas types. This is done because pandas has multiple type classes that represent a single data type while `pyarrow.Schema.from_pandas` does the mapping and converts it to a single pyarrow type making it easier for type checking. 
- Added support to check all possible types and map them to corresponding datatypes.


JIRA Issue: - https://hopsworks.atlassian.net/browse/FSTORE-1253

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
