### PR TITLE
[FSTORE-1247] Raise DataValidationError on validation failure if ingestion set to strict

### DIFF
--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.7.0-RC3</version>
+    <version>3.7.0-RC4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.7.0-RC3</version>
+    <version>3.7.0-RC4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.7.0-RC3</version>
+    <version>3.7.0-RC4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.7.0-RC3</version>
+    <version>3.7.0-RC4</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>3.7.0-RC3</version>
+        <version>3.7.0-RC4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/python/hsfs/client/exceptions.py
+++ b/python/hsfs/client/exceptions.py
@@ -62,6 +62,13 @@ class FeatureStoreException(Exception):
     """Generic feature store exception"""
 
 
+class DataValidationException(FeatureStoreException):
+    """Raised when data validation fails only when using "STRICT" validation ingestion policy."""
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
 class ExternalClientError(TypeError):
     """Raised when external client cannot be initialized due to missing arguments."""
 

--- a/python/hsfs/core/external_feature_group_engine.py
+++ b/python/hsfs/core/external_feature_group_engine.py
@@ -15,7 +15,7 @@
 
 from hsfs import engine, util
 from hsfs import feature_group as fg
-from hsfs.client.exceptions import FeatureStoreException
+from hsfs.client.exceptions import FeatureStoreException, DataValidationException
 from hsfs.core import feature_group_base_engine
 
 
@@ -80,7 +80,15 @@ class ExternalFeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngin
         )
 
         if ge_report is not None and ge_report.ingestion_result == "REJECTED":
-            return None, ge_report
+            feature_group_url = util.get_feature_group_url(
+                feature_store_id=feature_group.feature_store_id,
+                feature_group_id=feature_group.id,
+            )
+            raise DataValidationException(
+                "Data validation failed while validation ingestion policy set to strict, "
+                + f"insertion to {feature_group.name} was aborted.\n"
+                + f"You can check a summary or download your report at {feature_group_url}"
+            )
 
         return (
             engine.get_instance().save_dataframe(

--- a/python/hsfs/core/feature_group_engine.py
+++ b/python/hsfs/core/feature_group_engine.py
@@ -14,7 +14,7 @@
 #
 import warnings
 
-from hsfs import engine, client, util
+from hsfs import engine, util
 from hsfs import feature_group as fg
 from hsfs.client import exceptions
 from hsfs.core import feature_group_base_engine, hudi_engine
@@ -107,7 +107,15 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
         )
 
         if ge_report is not None and ge_report.ingestion_result == "REJECTED":
-            return None, ge_report
+            feature_group_url = util.get_feature_group_url(
+                feature_store_id=feature_group.feature_store_id,
+                feature_group_id=feature_group.id,
+            )
+            raise exceptions.DataValidationException(
+                "Data validation failed while validation ingestion policy set to strict, "
+                + f"insertion to {feature_group.name} was aborted.\n"
+                + f"You can check a summary or download your report at {feature_group_url}."
+            )
 
         offline_write_options = write_options
         online_write_options = write_options
@@ -353,16 +361,8 @@ class FeatureGroupEngine(feature_group_base_engine.FeatureGroupBaseEngine):
         self._feature_group_api.save(feature_group)
         print(
             "Feature Group created successfully, explore it at \n"
-            + self._get_feature_group_url(feature_group)
+            + util.get_feature_group_url(
+                feature_store_id=feature_group.feature_store_id,
+                feature_group_id=feature_group.id,
+            )
         )
-
-    def _get_feature_group_url(self, feature_group):
-        sub_path = (
-            "/p/"
-            + str(client.get_instance()._project_id)
-            + "/fs/"
-            + str(feature_group.feature_store_id)
-            + "/fg/"
-            + str(feature_group.id)
-        )
-        return util.get_hostname_replaced_url(sub_path)

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -422,6 +422,18 @@ def run_with_loading_animation(message, func, *args, **kwargs):
             print(f"\rFinished: {message} ({(end-start):.2f}s) ", end="\n")
 
 
+def get_feature_group_url(feature_store_id: int, feature_group_id: int):
+    sub_path = (
+        "/p/"
+        + str(client.get_instance()._project_id)
+        + "/fs/"
+        + str(feature_store_id)
+        + "/fg/"
+        + str(feature_group_id)
+    )
+    return get_hostname_replaced_url(sub_path)
+
+
 class VersionWarning(Warning):
     pass
 

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.7.0rc3"
+__version__ = "3.7.0rc4"

--- a/python/tests/core/test_feature_group_engine.py
+++ b/python/tests/core/test_feature_group_engine.py
@@ -201,6 +201,10 @@ class TestFeatureGroupEngine:
             "hsfs.core.great_expectation_engine.GreatExpectationEngine"
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
+        mocker.patch(
+            "hsfs.util.get_feature_group_url",
+            return_value="url",
+        )
 
         fg_engine = feature_group_engine.FeatureGroupEngine(
             feature_store_id=feature_store_id
@@ -225,14 +229,15 @@ class TestFeatureGroupEngine:
         mock_ge_engine.return_value.validate.return_value = vr
 
         # Act
-        fg_engine.insert(
-            feature_group=fg,
-            feature_dataframe=None,
-            overwrite=None,
-            operation=None,
-            storage=None,
-            write_options=None,
-        )
+        with pytest.raises(exceptions.DataValidationException):
+            fg_engine.insert(
+                feature_group=fg,
+                feature_dataframe=None,
+                overwrite=None,
+                operation=None,
+                storage=None,
+                write_options=None,
+            )
 
         # Assert
         assert mock_fg_api.return_value.delete_content.call_count == 0
@@ -1056,7 +1061,7 @@ class TestFeatureGroupEngine:
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mocker.patch(
-            "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
+            "hsfs.util.get_feature_group_url",
             return_value=feature_group_url,
         )
         mock_print = mocker.patch("builtins.print")
@@ -1104,7 +1109,7 @@ class TestFeatureGroupEngine:
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mocker.patch(
-            "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
+            "hsfs.util.get_feature_group_url",
             return_value=feature_group_url,
         )
         mock_print = mocker.patch("builtins.print")
@@ -1153,7 +1158,7 @@ class TestFeatureGroupEngine:
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mocker.patch(
-            "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
+            "hsfs.util.get_feature_group_url",
             return_value=feature_group_url,
         )
         mock_print = mocker.patch("builtins.print")
@@ -1204,7 +1209,7 @@ class TestFeatureGroupEngine:
         )
 
         mocker.patch(
-            "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
+            "hsfs.util.get_feature_group_url",
             return_value=feature_group_url,
         )
 
@@ -1309,7 +1314,7 @@ class TestFeatureGroupEngine:
         )
         mock_fg_api = mocker.patch("hsfs.core.feature_group_api.FeatureGroupApi")
         mocker.patch(
-            "hsfs.core.feature_group_engine.FeatureGroupEngine._get_feature_group_url",
+            "hsfs.util.get_feature_group_url",
             return_value=feature_group_url,
         )
         mock_print = mocker.patch("builtins.print")
@@ -1345,38 +1350,4 @@ class TestFeatureGroupEngine:
             0
         ] == "Feature Group created successfully, explore it at \n{}".format(
             feature_group_url
-        )
-
-    def test_get_feature_group_url(self, mocker):
-        # Arrange
-        feature_store_id = 99
-
-        mocker.patch("hsfs.engine.get_type")
-        mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
-        mock_util_get_hostname_replaced_url = mocker.patch(
-            "hsfs.util.get_hostname_replaced_url"
-        )
-
-        fg_engine = feature_group_engine.FeatureGroupEngine(
-            feature_store_id=feature_store_id
-        )
-
-        fg = feature_group.FeatureGroup(
-            name="test",
-            version=1,
-            featurestore_id=feature_store_id,
-            primary_key=[],
-            partition_key=[],
-            id=10,
-        )
-
-        mock_client_get_instance.return_value._project_id = 50
-
-        # Act
-        fg_engine._get_feature_group_url(feature_group=fg)
-
-        # Assert
-        assert mock_util_get_hostname_replaced_url.call_count == 1
-        assert (
-            mock_util_get_hostname_replaced_url.call_args[0][0] == "/p/50/fs/99/fg/10"
         )

--- a/python/tests/test_util.py
+++ b/python/tests/test_util.py
@@ -123,3 +123,24 @@ class TestUtil:
             ].path
             == "p/5/jobs/named/7/executions"
         )
+
+    def test_get_feature_group_url(self, mocker):
+        # Arrange
+        feature_store_id = 99
+        feature_group_id = 10
+        mock_client_get_instance = mocker.patch("hsfs.client.get_instance")
+        mock_util_get_hostname_replaced_url = mocker.patch(
+            "hsfs.util.get_hostname_replaced_url"
+        )
+        mock_client_get_instance.return_value._project_id = 50
+
+        # Act
+        util.get_feature_group_url(
+            feature_group_id=feature_group_id, feature_store_id=feature_store_id
+        )
+
+        # Assert
+        assert mock_util_get_hostname_replaced_url.call_count == 1
+        assert (
+            mock_util_get_hostname_replaced_url.call_args[0][0] == "/p/50/fs/99/fg/10"
+        )

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.7.0-RC3</version>
+    <version>3.7.0-RC4</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>


### PR DESCRIPTION
…a dataframe if the validation ingestion policy is set to strict (#1226)

* Add DataValidationException class

* Raise DataValidationException on validation failure if validation ignestion policy set to strict

* Fix associated unit test

* Append to insert documentation

* Raise exception also when inserting only in the online Feature Store for External FG

* Add documentation to insert for External FG

* Refactor get_feature_group_url and improve DataValidationException message

* Remove pytest bigquery.json

---------

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
