### PR TITLE
[FSTORE-1186][APPEND] Polars Integration into Hopsworks - Writing and Reading DataFrames

### DIFF
--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -242,9 +242,11 @@ class ArrowFlightClient:
         )
 
     @_handle_afs_exception(user_message=READ_ERROR)
-    def read_path(self, path, arrow_flight_config):
+    def read_path(self, path, arrow_flight_config, dataframe_type):
         descriptor = pyarrow.flight.FlightDescriptor.for_path(path)
-        return self._get_dataset(descriptor, arrow_flight_config)
+        return self._get_dataset(
+            descriptor, arrow_flight_config, dataframe_type=dataframe_type
+        )
 
     @_handle_afs_exception(user_message=WRITE_ERROR)
     def create_training_dataset(

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -60,11 +60,6 @@ class VectorServer:
             if features
             else []
         )
-        self._inference_helper_col_name = (
-            [feat.name for feat in features if feat.inference_helper_column]
-            if features
-            else []
-        )
         self._skip_fg_ids = skip_fg_ids or set()
         self._prepared_statement_engine = None
         self._prepared_statements = None
@@ -378,7 +373,7 @@ class VectorServer:
         elif return_type.lower() == "polars":
             # Polar considers one dimensional list as a single columns so passed vector as 2d list
             polars_df = pl.DataFrame(
-                [serving_vector], schema=self._inference_helper_col_name, orient="row"
+                [serving_vector], schema=serving_vector.keys(), orient="row"
             )
             return polars_df
         else:
@@ -416,7 +411,9 @@ class VectorServer:
             return pd.DataFrame(batch_results)
         elif return_type.lower() == "polars":
             polars_df = pl.DataFrame(
-                batch_results, schema=self._inference_helper_col_name, orient="row"
+                batch_results,
+                schema=feature_view_object.inference_helper_columns,
+                orient="row",
             )
             return polars_df
         else:

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -60,6 +60,11 @@ class VectorServer:
             if features
             else []
         )
+        self._inference_helper_col_name = (
+            [feat.name for feat in features if feat.inference_helper_column]
+            if features
+            else []
+        )
         self._skip_fg_ids = skip_fg_ids or set()
         self._prepared_statement_engine = None
         self._prepared_statements = None
@@ -373,7 +378,7 @@ class VectorServer:
         elif return_type.lower() == "polars":
             # Polar considers one dimensional list as a single columns so passed vector as 2d list
             polars_df = pl.DataFrame(
-                [serving_vector], schema=self._feature_vector_col_name, orient="row"
+                [serving_vector], schema=self._inference_helper_col_name, orient="row"
             )
             return polars_df
         else:
@@ -411,7 +416,7 @@ class VectorServer:
             return pd.DataFrame(batch_results)
         elif return_type.lower() == "polars":
             polars_df = pl.DataFrame(
-                batch_results, schema=self._feature_vector_col_name, orient="row"
+                batch_results, schema=self._inference_helper_col_name, orient="row"
             )
             return polars_df
         else:

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -351,7 +351,7 @@ class Engine:
     # To read the training dataset content, this to avoid the pydoop dependency
     # requirement and allow users to read Hopsworks training dataset from outside
     def _read_hopsfs_remote(
-        self, location, data_format, read_options={}, dataframe_type="default"
+        self, location, data_format, read_options=None, dataframe_type="default"
     ):
         total_count = 10000
         offset = 0

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -329,7 +329,7 @@ class Engine:
             from pydoop import hdfs
         except ModuleNotFoundError:
             return self._read_hopsfs_remote(
-                location, data_format, read_options, dataframe_type
+                location, data_format, read_options or {}, dataframe_type
             )
         util.setup_pydoop()
         path_list = hdfs.ls(location, recursive=True)

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -532,8 +532,12 @@ class Engine:
 
     def split_labels(self, df, labels, dataframe_type):
         if labels:
-            labels_df = df.select(*labels)
-            df_new = df.drop(*labels)
+            if isinstance(df, pd.DataFrame):
+                labels_df = df[labels]
+                df_new = df.drop(columns=labels)
+            else:
+                labels_df = df.select(*labels)
+                df_new = df.drop(*labels)
             return (
                 self._return_dataframe_type(df_new, dataframe_type),
                 self._return_dataframe_type(labels_df, dataframe_type),

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -249,6 +249,68 @@ class TestPython:
         assert mock_python_engine_read_hopsfs.call_count == 1
         assert mock_python_engine_read_s3.call_count == 0
 
+    def test_read_hopsfs_connector_empty_dataframe(self, mocker):
+        # Arrange
+
+        # Setting list of empty dataframes as return value from _read_hopsfs
+        mock_python_engine_read_hopsfs = mocker.patch(
+            "hsfs.engine.python.Engine._read_hopsfs",
+            return_value=[pd.DataFrame(), pd.DataFrame()],
+        )
+        mock_python_engine_read_s3 = mocker.patch("hsfs.engine.python.Engine._read_s3")
+
+        python_engine = python.Engine()
+
+        connector = storage_connector.HopsFSConnector(
+            id=1, name="test_connector", featurestore_id=1
+        )
+
+        # Act
+        dataframe = python_engine.read(
+            storage_connector=connector,
+            data_format="csv",
+            read_options=None,
+            location=None,
+            dataframe_type="default",
+        )
+
+        # Assert
+        assert mock_python_engine_read_hopsfs.call_count == 1
+        assert mock_python_engine_read_s3.call_count == 0
+        assert isinstance(dataframe, pd.DataFrame)
+        assert len(dataframe) == 0
+
+    def test_read_hopsfs_connector_empty_dataframe_polars(self, mocker):
+        # Arrange
+
+        # Setting empty list as return value from _read_hopsfs
+        mock_python_engine_read_hopsfs = mocker.patch(
+            "hsfs.engine.python.Engine._read_hopsfs",
+            return_value=[pl.DataFrame(), pl.DataFrame()],
+        )
+        mock_python_engine_read_s3 = mocker.patch("hsfs.engine.python.Engine._read_s3")
+
+        python_engine = python.Engine()
+
+        connector = storage_connector.HopsFSConnector(
+            id=1, name="test_connector", featurestore_id=1
+        )
+
+        # Act
+        dataframe = python_engine.read(
+            storage_connector=connector,
+            data_format="csv",
+            read_options=None,
+            location=None,
+            dataframe_type="polars",
+        )
+
+        # Assert
+        assert mock_python_engine_read_hopsfs.call_count == 1
+        assert mock_python_engine_read_s3.call_count == 0
+        assert isinstance(dataframe, pl.DataFrame)
+        assert len(dataframe) == 0
+
     def test_read_s3_connector(self, mocker):
         # Arrange
         mocker.patch("pandas.concat")

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -257,7 +257,6 @@ class TestPython:
             "hsfs.engine.python.Engine._read_hopsfs",
             return_value=[pd.DataFrame(), pd.DataFrame()],
         )
-        mock_python_engine_read_s3 = mocker.patch("hsfs.engine.python.Engine._read_s3")
 
         python_engine = python.Engine()
 
@@ -276,7 +275,6 @@ class TestPython:
 
         # Assert
         assert mock_python_engine_read_hopsfs.call_count == 1
-        assert mock_python_engine_read_s3.call_count == 0
         assert isinstance(dataframe, pd.DataFrame)
         assert len(dataframe) == 0
 
@@ -288,7 +286,6 @@ class TestPython:
             "hsfs.engine.python.Engine._read_hopsfs",
             return_value=[pl.DataFrame(), pl.DataFrame()],
         )
-        mock_python_engine_read_s3 = mocker.patch("hsfs.engine.python.Engine._read_s3")
 
         python_engine = python.Engine()
 
@@ -307,7 +304,6 @@ class TestPython:
 
         # Assert
         assert mock_python_engine_read_hopsfs.call_count == 1
-        assert mock_python_engine_read_s3.call_count == 0
         assert isinstance(dataframe, pl.DataFrame)
         assert len(dataframe) == 0
 


### PR DESCRIPTION
This PR fixes two issue present in the integration of Polars to Hopsworks

1. **Helper Columns** - When reading helper columns as a polars dataframe incorrect columns with empty data was obatined.

- _Root Cause_: Issue caused due to incorrect schema being used to create the polars dataframe. Polars dataframe was created using schema extracted from feature vectors.
- _Fix done_ : Corrected the schema used by extracting the inference helper columns.

3. **Training Data** - When creating training data from a feature group with very little data, an exception is encountered sporadically.

- _Root Cause_ : Issue caused due to the very little data being available in the feature group. When very little training data is present in the feature group there is a possibility that one of the training data split (train, test or validation) can be empty. Spark writes an empty file in this case. When reading from polars empty file were not read into a list since it causes an exception to be throw while merging into a single dataframe due to schema mismatch. Hence a empty list would be obtained if the entire split is empty which causes an exception when trying to merge with split.
- _Fix done_ : Check added to see if df list is empty and return an empty polars dataframe with column names in that usecase.

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
