### PR TITLE
[FSTORE-1316] Catch early failure to read from online storage via query.read if not all FG are online enabled

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -15,6 +15,7 @@
 #
 
 import json
+import warnings
 from datetime import date, datetime
 from typing import List, Optional, Union
 
@@ -146,6 +147,12 @@ class Query:
         # Returns
             `DataFrame`: DataFrame depending on the chosen type.
         """
+        if not isinstance(online, bool):
+            warnings.warn(
+                f"Passed {online} as value to online kwarg for `read` method. The `online` parameter is expected to be a boolean"
+                + " to specify whether to read from the Online Feature Store.",
+                stacklevel=1,
+            )
         if not read_options:
             read_options = {}
         self._check_read_supported(online)
@@ -503,6 +510,13 @@ class Query:
                 raise FeatureStoreException(
                     "Reading from query containing embedding is not supported."
                     " Use `feature_view.get_feature_vector(s) instead."
+                )
+            elif fg.online_enabled is False:
+                raise FeatureStoreException(
+                    f"Found {fg.name} in query Feature Groups which is not `online_enabled`."
+                    + "If you intend to use the Online Feature Store, please enable the Feature Group"
+                    + " for online serving by setting `online=True` on creation. Otherwise, set online=False"
+                    + " when using the `read` method."
                 )
 
     @classmethod


### PR DESCRIPTION
I will add a corresponding test in integration tests.

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
