### PR TITLE
[FSTORE-1316] Catch early failure to read from online storage via query.read if not all FG are online enabled

### DIFF
--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -70,6 +70,7 @@ class Query:
         self._storage_connector_api = storage_connector_api.StorageConnectorApi()
 
     def _prep_read(self, online, read_options):
+        self._check_read_supported(online)
         fs_query = self._query_constructor_api.construct_query(self)
 
         if online:
@@ -155,7 +156,6 @@ class Query:
             )
         if not read_options:
             read_options = {}
-        self._check_read_supported(online)
         sql_query, online_conn = self._prep_read(online, read_options)
 
         schema = None
@@ -495,6 +495,12 @@ class Query:
     def _check_read_supported(self, online):
         if not online:
             return
+        if not isinstance(online, bool):
+            warnings.warn(
+                f"Passed {online} as value to online kwarg for `read` method. The `online` parameter is expected to be a boolean"
+                + " to specify whether to read from the Online Feature Store.",
+                stacklevel=1,
+            )
         for fg in self.featuregroups:
             if fg.embedding_index:
                 raise FeatureStoreException(

--- a/python/hsfs/constructor/query.py
+++ b/python/hsfs/constructor/query.py
@@ -16,6 +16,7 @@
 
 import json
 import humps
+import warnings
 from typing import Optional, List, Union
 from datetime import datetime, date
 
@@ -146,6 +147,12 @@ class Query:
         # Returns
             `DataFrame`: DataFrame depending on the chosen type.
         """
+        if not isinstance(online, bool):
+            warnings.warn(
+                f"Passed {online} as value to online kwarg for `read` method. The `online` parameter is expected to be a boolean"
+                + " to specify whether to read from the Online Feature Store.",
+                stacklevel=1,
+            )
         if not read_options:
             read_options = {}
         self._check_read_supported(online)
@@ -493,6 +500,13 @@ class Query:
                 raise FeatureStoreException(
                     "Reading from query containing embedding is not supported."
                     " Use `feature_view.get_feature_vector(s) instead."
+                )
+            elif fg.online_enabled is False:
+                raise FeatureStoreException(
+                    f"Found {fg.name} in query Feature Groups which is not `online_enabled`."
+                    + "If you intend to use the Online Feature Store, please enable the Feature Group"
+                    + " for online serving by setting `online=True` on creation. Otherwise, set online=False"
+                    + " when using the `read` method."
                 )
 
     @classmethod

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -2074,12 +2074,24 @@ class FeatureGroup(FeatureGroupBase):
         # Raises
             `hsfs.client.exceptions.RestAPIError`. No data is available for feature group with this commit date, If time travel enabled.
         """
+        if wallclock_time and self._time_travel_format is None:
+            raise FeatureStoreException(
+                "Time travel format is not set for the feature group, cannot read as of specific point in time."
+            )
+        elif wallclock_time and engine.get_type() == "python":
+            raise FeatureStoreException(
+                "Python environments does not support incremental queries. "
+                + "Read feature group without timestamp to retrieve latest snapshot or switch to "
+                + "environment with Spark Engine."
+            )
+
         engine.get_instance().set_job_group(
             "Fetching Feature group",
             "Getting feature group: {} from the featurestore {}".format(
                 self._name, self._feature_store_name
             ),
         )
+
         if wallclock_time:
             return (
                 self.select_all()


### PR DESCRIPTION
This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
