### PR TITLE
[FSTORE-1334] Pin Polars Version and supress polars CPU warning

### DIFF
--- a/python/hsfs/__init__.py
+++ b/python/hsfs/__init__.py
@@ -13,12 +13,23 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
-
+import os
 import warnings
 
 import nest_asyncio
-from hsfs import usage, util, version
-from hsfs.connection import Connection
+
+
+# Setting polars skip cpu flag to suppress CPU false positive warning messages printed while importing hsfs
+os.environ["POLARS_SKIP_CPU_CHECK"] = "1"
+
+from hsfs import (  # noqa: E402,  Module level import not at top of file because os.environ must be set before importing hsfs
+    usage,
+    util,
+    version,
+)
+from hsfs.connection import (  # noqa: E402,  Module level import not at top of file because os.environ must be set before importing hsfs
+    Connection,
+)
 
 
 __version__ = version.__version__

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(
         "fsspec",
         "retrying",
         "aiomysql",
-        "polars",
+        "polars==0.20.0",
         "opensearch-py>=1.1.0,<=2.4.2",
     ],
     extras_require={

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(
         "fsspec",
         "retrying",
         "aiomysql",
-        "polars==0.20.18",
+        "polars>=0.20.18,<0.21.0",
         "opensearch-py>=1.1.0,<=2.4.2",
     ],
     extras_require={

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(
         "fsspec",
         "retrying",
         "aiomysql",
-        "polars==0.20.0",
+        "polars==0.20.18",
         "opensearch-py>=1.1.0,<=2.4.2",
     ],
     extras_require={


### PR DESCRIPTION
- This PR suppresses the CPU check warning printed while importing hsfs. These warnings are suppressed since they are largely false positives.
- The version of polars is also pinned to the last stable release polars has very high frequency releases.

JIRA Issue: - https://hopsworks.atlassian.net/browse/FSTORE-1334?atlOrigin=eyJpIjoiY2FiZGU2MzM1ZWIzNGYwZGI1ZTNhOGRlMGM2OGY5NDMiLCJwIjoiaiJ9

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
