### PR TITLE
[FSTORE-1330] Autofix feature names which contains spaces (#1292)

### DIFF
--- a/python/hsfs/core/feature_descriptive_statistics.py
+++ b/python/hsfs/core/feature_descriptive_statistics.py
@@ -13,11 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import json
 import humps
 from typing import Optional, Union, Mapping
-from hsfs.util import FeatureStoreEncoder
+from hsfs import util
 
 
 class FeatureDescriptiveStatistics:
@@ -65,9 +66,8 @@ class FeatureDescriptiveStatistics:
         **kwargs,
     ):
         self._id = id
-        self._feature_name = feature_name
         self._feature_type = feature_type
-        self._feature_name = feature_name
+        self._feature_name = util.autofix_feature_name(feature_name)
         self._count = count
         self._completeness = completeness
         self._num_non_null_values = num_non_null_values
@@ -200,7 +200,7 @@ class FeatureDescriptiveStatistics:
         return _dict
 
     def json(self) -> str:
-        return json.dumps(self, cls=FeatureStoreEncoder)
+        return json.dumps(self, cls=util.FeatureStoreEncoder)
 
     def __str__(self):
         return self.json()

--- a/python/hsfs/core/feature_group_base_engine.py
+++ b/python/hsfs/core/feature_group_base_engine.py
@@ -13,8 +13,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 from hsfs.core import feature_group_api, storage_connector_api, tags_api, kafka_api
+from hsfs import util
 from hsfs.client.exceptions import FeatureStoreException
 
 
@@ -103,21 +105,26 @@ class FeatureGroupBaseEngine:
         new_features = []
         for feature in feature_group.features:
             if not any(
-                updated.name.lower() == feature.name for updated in updated_features
+                util.autofix_feature_name(updated.name) == feature.name
+                for updated in updated_features
             ):
                 new_features.append(feature)
         return new_features + updated_features
 
     def _verify_schema_compatibility(self, feature_group_features, dataframe_features):
         err = []
-        feature_df_dict = {feat.name: feat.type for feat in dataframe_features}
+        feature_df_dict = {
+            util.autofix_feature_name(feat.name): feat.type
+            for feat in dataframe_features
+        }
         for feature_fg in feature_group_features:
+            name = util.autofix_feature_name(feature_fg.name)
             fg_type = feature_fg.type.lower().replace(" ", "")
             # check if feature exists dataframe
-            if feature_fg.name in feature_df_dict:
-                df_type = feature_df_dict[feature_fg.name].lower().replace(" ", "")
+            if name in feature_df_dict:
+                df_type = feature_df_dict[name].lower().replace(" ", "")
                 # remove match from lookup table
-                del feature_df_dict[feature_fg.name]
+                del feature_df_dict[name]
 
                 # check if types match
                 if fg_type != df_type:
@@ -126,21 +133,20 @@ class FeatureGroupBaseEngine:
                         continue
 
                     err += [
-                        f"{feature_fg.name} ("
-                        f"expected type: '{fg_type}', "
+                        f"{name} (expected type: '{fg_type}', "
                         f"derived from input: '{df_type}') has the wrong type."
                     ]
 
             else:
                 err += [
-                    f"{feature_fg.name} (type: '{feature_fg.type}') is missing from "
+                    f"{name} (type: '{feature_fg.type}') is missing from "
                     f"input dataframe."
                 ]
 
         # any features that are left in lookup table are superfluous
         for feature_df_name, feature_df_type in feature_df_dict.items():
             err += [
-                f"{feature_df_name} (type: '{feature_df_type}') does not exist "
+                f"{util.autofix_feature_name(feature_df_name)} (type: '{feature_df_type}') does not exist "
                 f"in feature group."
             ]
 
@@ -149,6 +155,8 @@ class FeatureGroupBaseEngine:
             raise FeatureStoreException(
                 "Features are not compatible with Feature Group schema: "
                 + "".join(["\n - " + e for e in err])
+                + "\nNote that feature (or column) names are case insensitive and "
+                "spaces are automatically replaced with underscores."
             )
 
     def get_subject(self, feature_group):

--- a/python/hsfs/core/feature_monitoring_config.py
+++ b/python/hsfs/core/feature_monitoring_config.py
@@ -13,13 +13,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import json
 import humps
 from enum import Enum
 from datetime import datetime, date
 from typing import Any, Dict, List, Optional, Union
-from hsfs.util import FeatureStoreEncoder
+from hsfs import util
 from hsfs.client.exceptions import FeatureStoreException
 
 from hsfs.core import monitoring_window_config as mwc
@@ -205,7 +206,7 @@ class FeatureMonitoringConfig:
         return the_dict
 
     def json(self) -> str:
-        return json.dumps(self, cls=FeatureStoreEncoder)
+        return json.dumps(self, cls=util.FeatureStoreEncoder)
 
     def __str__(self):
         return self.json()

--- a/python/hsfs/core/monitoring_window_config.py
+++ b/python/hsfs/core/monitoring_window_config.py
@@ -17,7 +17,7 @@
 import json
 import humps
 from typing import List, Optional, Union
-from hsfs.util import FeatureStoreEncoder
+from hsfs import util
 from enum import Enum
 
 from hsfs.core import monitoring_window_config_engine
@@ -176,7 +176,7 @@ class MonitoringWindowConfig:
         return the_dict
 
     def json(self) -> str:
-        return json.dumps(self, cls=FeatureStoreEncoder)
+        return json.dumps(self, cls=util.FeatureStoreEncoder)
 
     def __str__(self):
         return self.json()

--- a/python/hsfs/core/monitoring_window_config_engine.py
+++ b/python/hsfs/core/monitoring_window_config_engine.py
@@ -23,7 +23,7 @@ from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistic
 from hsfs.core import statistics_engine
 from hsfs.training_dataset_split import TrainingDatasetSplit
 from hsfs.client.exceptions import RestAPIError
-from hsfs.util import convert_event_time_to_timestamp
+from hsfs import util
 
 
 class MonitoringWindowConfigEngine:
@@ -429,4 +429,4 @@ class MonitoringWindowConfigEngine:
         Returns:
             datetime: Rounded and converted event time.
         """
-        return convert_event_time_to_timestamp(event_time)
+        return util.convert_event_time_to_timestamp(event_time)

--- a/python/hsfs/core/statistics_engine.py
+++ b/python/hsfs/core/statistics_engine.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import json
 import warnings
@@ -23,7 +24,7 @@ from datetime import datetime, date
 from hsfs import engine, statistics, util, split_statistics
 from hsfs.client import exceptions
 from hsfs.core import statistics_api, job
-from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
+from hsfs.core import feature_descriptive_statistics as fds_mod
 
 
 class StatisticsEngine:
@@ -432,7 +433,9 @@ class StatisticsEngine:
             )
         return stats
 
-    def _parse_deequ_statistics(self, stats) -> List[FeatureDescriptiveStatistics]:
+    def _parse_deequ_statistics(
+        self, stats
+    ) -> List[fds_mod.FeatureDescriptiveStatistics]:
         if stats is None:
             warnings.warn(
                 "There is no Deequ statistics to deserialize. A possible cause might be that Deequ did not succeed in the statistics computation.",
@@ -442,6 +445,6 @@ class StatisticsEngine:
         if isinstance(stats, str):
             stats = json.loads(stats)
         return [
-            FeatureDescriptiveStatistics.from_deequ_json(col_stats)
+            fds_mod.FeatureDescriptiveStatistics.from_deequ_json(col_stats)
             for col_stats in stats["columns"]
         ]

--- a/python/hsfs/core/validation_result_engine.py
+++ b/python/hsfs/core/validation_result_engine.py
@@ -13,11 +13,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 from typing import Union, List, Dict
 from hsfs.core import validation_result_api
 from datetime import datetime, date
-from hsfs.util import convert_event_time_to_timestamp
+from hsfs import util
 
 from hsfs.ge_validation_result import ValidationResult
 from great_expectations.core import ExpectationValidationResult
@@ -108,9 +109,9 @@ class ValidationResultEngine:
         query_params["filter_by"].extend(ingestion_filters)
 
         if start_validation_time and end_validation_time:
-            if convert_event_time_to_timestamp(
+            if util.convert_event_time_to_timestamp(
                 start_validation_time
-            ) > convert_event_time_to_timestamp(end_validation_time):
+            ) > util.convert_event_time_to_timestamp(end_validation_time):
                 raise ValueError(
                     f"start_validation_time : {start_validation_time} is posterior to end_validation_time : {end_validation_time}"
                 )
@@ -118,12 +119,12 @@ class ValidationResultEngine:
         if start_validation_time:
             query_params["filter_by"].append(
                 "validation_time_gte:"
-                + str(convert_event_time_to_timestamp(start_validation_time))
+                + str(util.convert_event_time_to_timestamp(start_validation_time))
             )
         if end_validation_time:
             query_params["filter_by"].append(
                 "validation_time_lte:"
-                + str(convert_event_time_to_timestamp(end_validation_time))
+                + str(util.convert_event_time_to_timestamp(end_validation_time))
             )
 
         return query_params

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import os
 import shutil
@@ -75,7 +76,7 @@ except ImportError:
     pass
 
 from hsfs import feature, training_dataset_feature, client, util
-from hsfs.feature_group import ExternalFeatureGroup, SpineGroup
+from hsfs import feature_group as fg_mod
 from hsfs.storage_connector import StorageConnector
 from hsfs.client.exceptions import FeatureStoreException
 from hsfs.client import hopsworks
@@ -154,7 +155,7 @@ class Engine:
         self._spark_session.sparkContext.setJobGroup(group_id, description)
 
     def register_external_temporary_table(self, external_fg, alias):
-        if not isinstance(external_fg, SpineGroup):
+        if not isinstance(external_fg, fg_mod.SpineGroup):
             external_dataset = external_fg.storage_connector.read(
                 external_fg.query,
                 external_fg.data_format,
@@ -259,6 +260,7 @@ class Engine:
             upper_case_features = [
                 c for c in dataframe.columns if any(re.finditer("[A-Z]", c))
             ]
+            space_features = [c for c in dataframe.columns if " " in c]
             if len(upper_case_features) > 0:
                 warnings.warn(
                     "The ingested dataframe contains upper case letters in feature names: `{}`. "
@@ -267,9 +269,18 @@ class Engine:
                     ),
                     util.FeatureGroupWarning,
                 )
+            if len(space_features) > 0:
+                warnings.warn(
+                    "The ingested dataframe contains feature names with spaces: `{}`. "
+                    "Feature names are sanitized to use underscore '_' in the feature store.".format(
+                        space_features
+                    ),
+                    util.FeatureGroupWarning,
+                    stacklevel=1,
+                )
 
             lowercase_dataframe = dataframe.select(
-                [col(x).alias(x.lower()) for x in dataframe.columns]
+                [col(x).alias(util.autofix_feature_name(x)) for x in dataframe.columns]
             )
             # for streaming dataframes this will be handled in DeltaStreamerTransformer.java class
             if not lowercase_dataframe.isStreaming:
@@ -304,7 +315,7 @@ class Engine:
     ):
         try:
             if (
-                isinstance(feature_group, ExternalFeatureGroup)
+                isinstance(feature_group, fg_mod.ExternalFeatureGroup)
                 and feature_group.online_enabled
             ) or feature_group.stream:
                 self._save_online_dataframe(
@@ -915,13 +926,13 @@ class Engine:
         features = []
         using_hudi = time_travel_format == "HUDI"
         for feat in dataframe.schema:
-            name = feat.name.lower()
+            name = util.autofix_feature_name(feat.name)
             try:
                 converted_type = Engine.convert_spark_type_to_offline_type(
                     feat.dataType, using_hudi
                 )
             except ValueError as e:
-                raise FeatureStoreException(f"Feature '{name}': {str(e)}")
+                raise FeatureStoreException(f"Feature '{feat.name}': {str(e)}") from e
             features.append(
                 feature.Feature(
                     name, converted_type, feat.metadata.get("description", None)
@@ -932,7 +943,7 @@ class Engine:
     def parse_schema_training_dataset(self, dataframe):
         return [
             training_dataset_feature.TrainingDatasetFeature(
-                feat.name.lower(), feat.dataType.simpleString()
+                util.autofix_feature_name(feat.name), feat.dataType.simpleString()
             )
             for feat in dataframe.schema
         ]

--- a/python/hsfs/feature.py
+++ b/python/hsfs/feature.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import humps
 import json
@@ -43,8 +44,8 @@ class Feature:
         feature_group_id=None,
         feature_group=None,
         **kwargs,
-    ):
-        self._name = name.lower()
+    ) -> None:
+        self._name = util.autofix_feature_name(name)
         self._type = type
         self._description = description
         self._primary = primary or False

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import json
 import warnings
@@ -44,7 +45,7 @@ from hsfs.core import (
     feature_monitoring_config_engine,
     feature_monitoring_result_engine,
 )
-from hsfs.transformation_function import TransformationFunction
+from hsfs import transformation_function as tf_mod
 from hsfs.statistics_config import StatisticsConfig
 from hsfs.statistics import Statistics
 from hsfs.core.feature_view_api import FeatureViewApi
@@ -68,7 +69,9 @@ class FeatureView:
         labels: Optional[List[str]] = [],
         inference_helper_columns: Optional[List[str]] = [],
         training_helper_columns: Optional[List[str]] = [],
-        transformation_functions: Optional[Dict[str, TransformationFunction]] = {},
+        transformation_functions: Optional[
+            Dict[str, tf_mod.TransformationFunction]
+        ] = {},
         featurestore_name=None,
         serving_keys: Optional[List[ServingKey]] = None,
         **kwargs,
@@ -3488,8 +3491,8 @@ class FeatureView:
         return self._labels
 
     @labels.setter
-    def labels(self, labels):
-        self._labels = [lb.lower() for lb in labels]
+    def labels(self, labels: List[str]) -> None:
+        self._labels = [util.autofix_feature_name(lb) for lb in labels]
 
     @property
     def inference_helper_columns(self):
@@ -3502,7 +3505,7 @@ class FeatureView:
     @inference_helper_columns.setter
     def inference_helper_columns(self, inference_helper_columns):
         self._inference_helper_columns = [
-            exf.lower() for exf in inference_helper_columns
+            util.autofix_feature_name(exf) for exf in inference_helper_columns
         ]
 
     @property
@@ -3514,8 +3517,10 @@ class FeatureView:
         return self._training_helper_columns
 
     @training_helper_columns.setter
-    def training_helper_columns(self, training_helper_columns):
-        self._training_helper_columns = [exf.lower() for exf in training_helper_columns]
+    def training_helper_columns(self, training_helper_columns: List[str]) -> None:
+        self._training_helper_columns = [
+            util.autofix_feature_name(exf) for exf in training_helper_columns
+        ]
 
     @property
     def description(self):

--- a/python/hsfs/statistics.py
+++ b/python/hsfs/statistics.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import json
 import humps
@@ -20,7 +21,7 @@ from typing import Optional, List, Union
 
 from hsfs import util
 from hsfs.split_statistics import SplitStatistics
-from hsfs.core.feature_descriptive_statistics import FeatureDescriptiveStatistics
+from hsfs.core import feature_descriptive_statistics as fds_mod
 
 
 class Statistics:
@@ -66,25 +67,27 @@ class Statistics:
 
     def _parse_descriptive_statistics(
         self,
-        desc_statistics: Union[dict, FeatureDescriptiveStatistics],
-    ) -> Optional[List[FeatureDescriptiveStatistics]]:
+        desc_statistics: Union[dict, fds_mod.FeatureDescriptiveStatistics],
+    ) -> Optional[List[fds_mod.FeatureDescriptiveStatistics]]:
         if desc_statistics is None:
             return None
-        elif isinstance(desc_statistics, FeatureDescriptiveStatistics):
+        elif isinstance(desc_statistics, fds_mod.FeatureDescriptiveStatistics):
             return [desc_statistics]
         elif isinstance(desc_statistics, dict) and "items" not in desc_statistics:
-            return [FeatureDescriptiveStatistics.from_response_json(desc_statistics)]
+            return [
+                fds_mod.FeatureDescriptiveStatistics.from_response_json(desc_statistics)
+            ]
         elif isinstance(desc_statistics, dict) and "items" in desc_statistics:
             return [
-                FeatureDescriptiveStatistics.from_response_json(fds)
+                fds_mod.FeatureDescriptiveStatistics.from_response_json(fds)
                 for fds in desc_statistics["items"]
             ]
         elif isinstance(desc_statistics, list):
             return [
                 (
                     fds
-                    if isinstance(fds, FeatureDescriptiveStatistics)
-                    else FeatureDescriptiveStatistics.from_response_json(fds)
+                    if isinstance(fds, fds_mod.FeatureDescriptiveStatistics)
+                    else fds_mod.FeatureDescriptiveStatistics.from_response_json(fds)
                 )
                 for fds in desc_statistics
             ]
@@ -174,7 +177,7 @@ class Statistics:
     @property
     def feature_descriptive_statistics(
         self,
-    ) -> Optional[List[FeatureDescriptiveStatistics]]:
+    ) -> Optional[List[fds_mod.FeatureDescriptiveStatistics]]:
         """List of feature descriptive statistics."""
         return self._feature_descriptive_statistics
 

--- a/python/hsfs/statistics_config.py
+++ b/python/hsfs/statistics_config.py
@@ -13,6 +13,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import json
 import humps

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -13,6 +13,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
+
 import os
 import re
 from abc import ABC, abstractmethod

--- a/python/hsfs/training_dataset_feature.py
+++ b/python/hsfs/training_dataset_feature.py
@@ -13,12 +13,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import humps
 
-import hsfs.feature_group as feature_group
-from hsfs.feature import Feature
-from hsfs.transformation_function import TransformationFunction
+from hsfs import feature as feature_mod
+from hsfs import feature_group as feature_group_mod
+from hsfs import transformation_function as tf_mod
+from hsfs import util
 
 
 class TrainingDatasetFeature:
@@ -35,11 +37,11 @@ class TrainingDatasetFeature:
         transformation_function=None,
         **kwargs,
     ):
-        self._name = name.lower()
+        self._name = util.autofix_feature_name(name)
         self._type = type
         self._index = index
         self._feature_group = (
-            feature_group.FeatureGroup.from_response_json(featuregroup)
+            feature_group_mod.FeatureGroup.from_response_json(featuregroup)
             if isinstance(featuregroup, dict)
             else featuregroup
         )
@@ -48,7 +50,7 @@ class TrainingDatasetFeature:
         self._inference_helper_column = inference_helper_column
         self._training_helper_column = training_helper_column
         self._transformation_function = (
-            TransformationFunction.from_response_json(transformation_function)
+            tf_mod.TransformationFunction.from_response_json(transformation_function)
             if isinstance(transformation_function, dict)
             else transformation_function
         )
@@ -73,7 +75,9 @@ class TrainingDatasetFeature:
 
     def is_complex(self):
         """Returns true if the feature has a complex type."""
-        return any(map(self._type.upper().startswith, Feature.COMPLEX_TYPES))
+        return any(
+            map(self._type.upper().startswith, feature_mod.Feature.COMPLEX_TYPES)
+        )
 
     @property
     def name(self):

--- a/python/hsfs/transformation_function.py
+++ b/python/hsfs/transformation_function.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from __future__ import annotations
 
 import humps
 import json

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -13,9 +13,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+from __future__ import annotations
 
 import re
 import json
+from typing import Union
 import pandas as pd
 import numpy as np
 import time
@@ -28,6 +30,7 @@ from urllib.parse import urljoin, urlparse
 from sqlalchemy import create_engine
 
 from hsfs import client, feature
+from hsfs import feature_group as fg_mod
 from hsfs.client import exceptions
 from hsfs.core import variable_api
 from aiomysql.sa import create_engine as async_create_engine
@@ -63,7 +66,18 @@ def parse_features(feature_names):
         return []
 
 
-def feature_group_name(feature_group):
+def autofix_feature_name(name: str) -> str:
+    # replace spaces with underscores and enforce lower case
+    return name.lower().replace(" ", "_")
+
+
+def feature_group_name(
+    feature_group: Union[
+        fg_mod.FeatureGroup,
+        fg_mod.ExternalFeatureGroup,
+        fg_mod.SpineGroup,
+    ],
+) -> str:
     return feature_group.name + "_" + str(feature_group.version)
 
 

--- a/python/tests/core/test_feature_group_engine.py
+++ b/python/tests/core/test_feature_group_engine.py
@@ -960,6 +960,8 @@ class TestFeatureGroupEngine:
             == "Features are not compatible with Feature Group schema: \n"
             " - f (type: 'str') is missing from input dataframe.\n"
             " - f1 (type: 'int') is missing from input dataframe."
+            "\nNote that feature (or column) names are case insensitive and "
+            "spaces are automatically replaced with underscores."
         )
 
     def test_verify_schema_compatibility_dataframe_features(self):
@@ -990,6 +992,8 @@ class TestFeatureGroupEngine:
             == "Features are not compatible with Feature Group schema: \n"
             " - f (type: 'str') does not exist in feature group.\n"
             " - f1 (type: 'int') does not exist in feature group."
+            "\nNote that feature (or column) names are case insensitive and "
+            "spaces are automatically replaced with underscores."
         )
 
     def test_verify_schema_compatibility_feature_group_features_dataframe_features(
@@ -1048,6 +1052,8 @@ class TestFeatureGroupEngine:
             str(e_info.value)
             == "Features are not compatible with Feature Group schema: \n"
             " - f1 (expected type: 'int', derived from input: 'bool') has the wrong type."
+            "\nNote that feature (or column) names are case insensitive and "
+            "spaces are automatically replaced with underscores."
         )
 
     def test_save_feature_group_metadata(self, mocker):

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -1065,7 +1065,27 @@ class TestPython:
             == "The ingested dataframe contains upper case letters in feature names: `['Col1']`. Feature names are sanitized to lower case in the feature store."
         )
 
-    def test_parse_schema_feature_group(self, mocker):
+    def test_convert_to_default_dataframe_pandas_with_spaces(self, mocker):
+        # Arrange
+        mock_warnings = mocker.patch("warnings.warn")
+
+        python_engine = python.Engine()
+
+        d = {"col 1": [1, 2], "co 2 co": [3, 4]}
+        df = pd.DataFrame(data=d)
+
+        # Act
+        result = python_engine.convert_to_default_dataframe(dataframe=df)
+
+        # Assert
+        assert result.columns.values.tolist() == ["col_1", "co_2_co"]
+        assert (
+            mock_warnings.call_args[0][0]
+            == "The ingested dataframe contains feature names with spaces: `['col 1', 'co 2 co']`. "
+            "Feature names are sanitized to use underscore '_' in the feature store."
+        )
+
+    def test_parse_schema_feature_group_pandas(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.python.Engine._convert_pandas_dtype_to_offline_type")
 

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -45,6 +45,7 @@ from hsfs import (
     expectation_suite,
     training_dataset_feature,
     engine,
+    util,
 )
 from hsfs.core import training_dataset_engine
 from hsfs.engine import spark
@@ -478,7 +479,9 @@ class TestSpark:
         result_df = result.toPandas()
         assert list(result_df) != list(expected)
         for column in list(result_df):
-            assert result_df[column.lower()].equals(result_df[column])
+            assert result_df[util.autofix_feature_name(column)].equals(
+                result_df[column]
+            )
 
     def test_convert_to_default_dataframe_wrong_type(self):
         # Arrange
@@ -534,18 +537,18 @@ class TestSpark:
         assert original_schema == original_df.schema
         assert result_schema == result_df.schema
 
-    def test_convert_to_default_dataframe_nullable_uppercase(self):
+    def test_convert_to_default_dataframe_nullable_uppercase_and_spaced(self):
         # Arrange
         spark_engine = spark.Engine()
 
-        d = {"COL_0": [1, 2], "COL_1": ["test_1", "test_2"], "COL_2": [None, "test_2"]}
+        d = {"COL_0": [1, 2], "COL_1": ["test_1", "test_2"], "COL 2": [None, "test_2"]}
         data = pd.DataFrame(data=d)
 
         schema = StructType(
             [
                 StructField("COL_0", IntegerType(), nullable=False),
                 StructField("COL_1", StringType(), nullable=False),
-                StructField("COL_2", StringType(), nullable=True),
+                StructField("COL 2", StringType(), nullable=True),
             ]
         )
         original_df = spark_engine._spark_session.createDataFrame(data, schema=schema)
@@ -558,7 +561,7 @@ class TestSpark:
             [
                 StructField("COL_0", IntegerType(), nullable=False),
                 StructField("COL_1", StringType(), nullable=False),
-                StructField("COL_2", StringType(), nullable=True),
+                StructField("COL 2", StringType(), nullable=True),
             ]
         )
         result_schema = StructType(

--- a/python/tests/fixtures/dataframe_fixtures.py
+++ b/python/tests/fixtures/dataframe_fixtures.py
@@ -55,3 +55,20 @@ def dataframe_fixture_times():
     }
 
     return pd.DataFrame(data)
+
+
+@pytest.fixture
+def dataframe_fixtures_column_spaced():
+    data = {
+        "Primary Key": [1, 2, 3, 4],
+        "Event date": [
+            datetime(2022, 7, 3).date(),
+            datetime(2022, 1, 5).date(),
+            datetime(2022, 1, 6).date(),
+            datetime(2022, 1, 7).date(),
+        ],
+        "staTe 1": ["nevada", None, "nevada", None],
+        "Measure ment taken": [12.4, 32.5, 342.6, 43.7],
+    }
+
+    return pd.DataFrame(data)

--- a/python/tests/test_feature.py
+++ b/python/tests/test_feature.py
@@ -55,14 +55,30 @@ class TestFeature:
         assert f.default_value is None
         assert f._feature_group_id is None
 
-    def test_like(self, backend_fixtures):
+    def test_like(self):
         # Arrange
         f = feature.Feature("feature_name")
 
         # Act
-        filter = f.like("max%")
+        filter_obj = f.like("max%")
 
         # Assert
-        assert filter._feature == f
-        assert filter._condition == filter.LK
-        assert filter._value == "max%"
+        assert filter_obj._feature == f
+        assert filter_obj._condition == filter_obj.LK
+        assert filter_obj._value == "max%"
+
+    def test_name_sanitizing(self):
+        # Arrange
+        spaced_name = "col 1"
+        upper_name = "Col1"
+        both = "Bravo Col"
+
+        # Act
+        spaced_feature = feature.Feature(name=spaced_name)
+        upper_feature = feature.Feature(name=upper_name)
+        both_feature = feature.Feature(name=both)
+
+        # Assert
+        assert spaced_feature.name == "col_1"
+        assert upper_feature.name == "col1"
+        assert both_feature.name == "bravo_col"

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -488,7 +488,7 @@ class TestFeatureGroup:
         mock_writer.insert.assert_called_once()
         assert fg._multi_part_insert is True
 
-    def test_save_feature_list(self, mocker, dataframe_fixture_basic):
+    def test_save_feature_list(self, mocker):
         mock_save_metadata = mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.save_feature_group_metadata",
             return_value=None,
@@ -511,7 +511,7 @@ class TestFeatureGroup:
         fg.save(features)
         mock_save_metadata.assert_called_once_with(fg, None, {})
 
-    def test_save_feature_in_create(self, mocker, dataframe_fixture_basic):
+    def test_save_feature_in_create(self, mocker):
         mock_save_metadata = mocker.patch(
             "hsfs.core.feature_group_engine.FeatureGroupEngine.save_feature_group_metadata",
             return_value=None,
@@ -535,7 +535,7 @@ class TestFeatureGroup:
         fg.save()
         mock_save_metadata.assert_called_once_with(fg, None, {})
 
-    def test_save_exception_empty_input(self, mocker, dataframe_fixture_basic):
+    def test_save_exception_empty_input(self):
         fg = feature_group.FeatureGroup(
             name="test_fg",
             version=2,
@@ -549,7 +549,7 @@ class TestFeatureGroup:
 
         assert "Feature list not provided" in str(e.value)
 
-    def test_save_with_non_feature_list(self, mocker, dataframe_fixture_basic):
+    def test_save_with_non_feature_list(self, mocker):
         engine = python.Engine()
         mocker.patch("hsfs.engine.get_instance", return_value=engine)
         mocker.patch("hsfs.engine.get_type", return_value="python")


### PR DESCRIPTION
Cherry-pick lead to circular import which lead to lots of file being touched but not really affected

*Autofix feature names which contains spaces

* Update python/hsfs/engine/python.py



* Update python/hsfs/engine/python.py



* Update python/hsfs/engine/spark.py



* Update python/hsfs/engine/spark.py



* Code review

* Fix error messages in unit tests

---------

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
