### PR TITLE
[FSTORE-1317] Hanlde opensearch timeout parameter

### DIFF
--- a/python/hsfs/core/opensearch.py
+++ b/python/hsfs/core/opensearch.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 import re
 from functools import wraps
+import opensearchpy
 
 import urllib3
 from hsfs import client
@@ -56,9 +57,17 @@ def _handle_opensearch_exception(func):
 
 
 class OpensearchRequestOption:
-    DEFAULT_OPTION_MAP = {
+    DEFAULT_OPTION_MAP_V1 = {
+        "timeout": "30s",  # opensearch client v1 requires timeout as str
+    }
+
+    DEFAULT_OPTION_MAP_V2 = {
         "timeout": 30,
     }
+
+    @classmethod
+    def get_version(cls):
+        return opensearchpy.__version__[0]
 
     @classmethod
     def get_options(cls, options: dict):
@@ -74,18 +83,27 @@ class OpensearchRequestOption:
             attribute values of the OpensearchRequestOption class, and values are obtained
             either from the provided options or default values if not available.
         """
+        default_option = (cls.DEFAULT_OPTION_MAP_V1
+                          if cls.get_version() == 1
+                          else cls.DEFAULT_OPTION_MAP_V2)
         if options:
             # make lower case to avoid issues with cases
             options = {k.lower(): v for k, v in options.items()}
             new_options = {}
-            for option, value in cls.DEFAULT_OPTION_MAP.items():
+            for option, value in default_option.items():
                 if option in options:
-                    new_options[option] = options[option]
+                    if (option == "timeout"
+                        and cls.get_version() == 1
+                        and isinstance(options[option], int)
+                    ):
+                        new_options[option] = f"{options[option]}s"
+                    else:
+                        new_options[option] = options[option]
                 else:
                     new_options[option] = value
             return new_options
         else:
-            return cls.DEFAULT_OPTION_MAP
+            return default_option
 
 
 class OpenSearchClientSingleton:

--- a/python/hsfs/core/opensearch.py
+++ b/python/hsfs/core/opensearch.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 import logging
 import re
 from functools import wraps
-import opensearchpy
 
+import opensearchpy
 import urllib3
 from hsfs import client
 from hsfs.client.exceptions import FeatureStoreException, VectorDatabaseException

--- a/python/hsfs/core/opensearch.py
+++ b/python/hsfs/core/opensearch.py
@@ -57,17 +57,19 @@ def _handle_opensearch_exception(func):
 
 
 class OpensearchRequestOption:
-    DEFAULT_OPTION_MAP_V1 = {
-        "timeout": "30s",  # opensearch client v1 requires timeout as str
+    DEFAULT_OPTION_MAP = {
+        "timeout": "30s",
     }
 
-    DEFAULT_OPTION_MAP_V2 = {
+    DEFAULT_OPTION_MAP_V2_3 = {
+        # starting from opensearch client v2.3, timeout should be in int/float
+        # https://github.com/opensearch-project/opensearch-py/pull/394
         "timeout": 30,
     }
 
     @classmethod
     def get_version(cls):
-        return opensearchpy.__version__[0]
+        return opensearchpy.__version__[0:2]
 
     @classmethod
     def get_options(cls, options: dict):
@@ -83,9 +85,9 @@ class OpensearchRequestOption:
             attribute values of the OpensearchRequestOption class, and values are obtained
             either from the provided options or default values if not available.
         """
-        default_option = (cls.DEFAULT_OPTION_MAP_V1
-                          if cls.get_version() == 1
-                          else cls.DEFAULT_OPTION_MAP_V2)
+        default_option = (cls.DEFAULT_OPTION_MAP
+                          if cls.get_version() < (2, 3)
+                          else cls.DEFAULT_OPTION_MAP_V2_3)
         if options:
             # make lower case to avoid issues with cases
             options = {k.lower(): v for k, v in options.items()}
@@ -93,7 +95,7 @@ class OpensearchRequestOption:
             for option, value in default_option.items():
                 if option in options:
                     if (option == "timeout"
-                        and cls.get_version() == 1
+                        and cls.get_version() < (2, 3)
                         and isinstance(options[option], int)
                     ):
                         new_options[option] = f"{options[option]}s"

--- a/python/tests/core/test_opensearch.py
+++ b/python/tests/core/test_opensearch.py
@@ -15,7 +15,7 @@
 #
 import pytest
 from hsfs.client.exceptions import VectorDatabaseException
-from hsfs.core.opensearch import OpenSearchClientSingleton
+from hsfs.core.opensearch import OpenSearchClientSingleton, OpensearchRequestOption
 
 
 class TestOpenSearchClientSingleton:
@@ -66,3 +66,26 @@ class TestOpenSearchClientSingleton:
         assert isinstance(exception, VectorDatabaseException)
         assert exception.reason == expected_reason
         assert exception.info == expected_info
+
+
+class TestOpensearchRequestOption:
+
+    def test_version_1_no_options(self):
+        OpensearchRequestOption.get_version = lambda: 1
+        options = OpensearchRequestOption.get_options({})
+        assert options == {"timeout": "30s"}
+
+    def test_version_1_with_options_timeout_int(self):
+        OpensearchRequestOption.get_version = lambda: 1
+        options = OpensearchRequestOption.get_options({"timeout": 45})
+        assert options == {"timeout": "45s"}
+
+    def test_version_2_no_options(self):
+        OpensearchRequestOption.get_version = lambda: 2
+        options = OpensearchRequestOption.get_options({})
+        assert options == {"timeout": 30}
+
+    def test_version_2_with_options(self):
+        OpensearchRequestOption.get_version = lambda: 2
+        options = OpensearchRequestOption.get_options({"timeout": 50})
+        assert options == {"timeout": 50}

--- a/python/tests/core/test_opensearch.py
+++ b/python/tests/core/test_opensearch.py
@@ -71,21 +71,21 @@ class TestOpenSearchClientSingleton:
 class TestOpensearchRequestOption:
 
     def test_version_1_no_options(self):
-        OpensearchRequestOption.get_version = lambda: 1
+        OpensearchRequestOption.get_version = lambda: (1, 1)
         options = OpensearchRequestOption.get_options({})
         assert options == {"timeout": "30s"}
 
     def test_version_1_with_options_timeout_int(self):
-        OpensearchRequestOption.get_version = lambda: 1
+        OpensearchRequestOption.get_version = lambda: (1, 1)
         options = OpensearchRequestOption.get_options({"timeout": 45})
         assert options == {"timeout": "45s"}
 
-    def test_version_2_no_options(self):
-        OpensearchRequestOption.get_version = lambda: 2
+    def test_version_2_3_no_options(self):
+        OpensearchRequestOption.get_version = lambda: (2, 3)
         options = OpensearchRequestOption.get_options({})
         assert options == {"timeout": 30}
 
-    def test_version_2_with_options(self):
-        OpensearchRequestOption.get_version = lambda: 2
+    def test_version_2_3_with_options(self):
+        OpensearchRequestOption.get_version = lambda: (2, 3)
         options = OpensearchRequestOption.get_options({"timeout": 50})
         assert options == {"timeout": 50}


### PR DESCRIPTION
In opensearch-py client before 2.3, it requires timeout parameter to be a string with unit.
`opensearchpy.exceptions.RequestError: RequestError(400, 'illegal_argument_exception', 'failed to parse setting [timeout] with value [30] as a time value: unit is missing or unrecognized')`


JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
