### PR TITLE
[FSTORE-1402][APPEND] Always provide offsets for the first execution of materialization job

### DIFF
--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -1439,7 +1439,8 @@ class Engine:
         elif not isinstance(
             feature_group, ExternalFeatureGroup
         ) and self._start_offline_materialization(offline_write_options):
-            if not offline_write_options.get("skip_offsets", False):
+            if (not offline_write_options.get("skip_offsets", False)
+                and self._job_api.last_execution(feature_group.materialization_job)): # always skip offsets if executing job for the first time
                 # don't provide the current offsets (read from where the job last left off)
                 initial_check_point = ""
             # provide the initial_check_point as it will reduce the read amplification of materialization job

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -3668,6 +3668,10 @@ class TestPython:
             "hsfs.engine.python.Engine._kafka_get_offsets",
             return_value=" tests_offsets",
         )
+        mocker.patch(
+            "hsfs.core.job_api.JobApi.last_execution",
+            return_value=["", ""],
+        )
 
         python_engine = python.Engine()
 
@@ -3702,6 +3706,61 @@ class TestPython:
         assert mock_python_engine_kafka_produce.call_count == 4
         job_mock.run.assert_called_once_with(
             args="defaults",
+            await_termination=False,
+        )
+
+    def test_materialization_kafka_first_job_execution(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.engine.python.Engine._get_kafka_config", return_value={})
+        mocker.patch("hsfs.feature_group.FeatureGroup._get_encoded_avro_schema")
+        mocker.patch("hsfs.engine.python.Engine._get_encoder_func")
+        mocker.patch("hsfs.engine.python.Engine._encode_complex_features")
+        mock_python_engine_kafka_produce = mocker.patch(
+            "hsfs.engine.python.Engine._kafka_produce"
+        )
+        mocker.patch("hsfs.util.get_job_url")
+        mocker.patch(
+            "hsfs.engine.python.Engine._kafka_get_offsets",
+            return_value=" tests_offsets",
+        )
+        mocker.patch(
+            "hsfs.core.job_api.JobApi.last_execution",
+            return_value=[],
+        )
+
+        python_engine = python.Engine()
+
+        fg = feature_group.FeatureGroup(
+            name="test",
+            version=1,
+            featurestore_id=99,
+            primary_key=[],
+            partition_key=[],
+            id=10,
+            stream=False,
+            time_travel_format="HUDI",
+        )
+
+        mocker.patch.object(fg, "commit_details", return_value={"commit1": 1})
+
+        fg._online_topic_name = "test_topic"
+        job_mock = mocker.MagicMock()
+        job_mock.config = {"defaultArgs": "defaults"}
+        fg._materialization_job = job_mock
+
+        df = pd.DataFrame(data={"col1": [1, 2, 2, 3]})
+
+        # Act
+        python_engine._write_dataframe_kafka(
+            feature_group=fg,
+            dataframe=df,
+            offline_write_options={"start_offline_materialization": True},
+        )
+
+        # Assert
+        assert mock_python_engine_kafka_produce.call_count == 4
+        job_mock.run.assert_called_once_with(
+            args="defaults tests_offsets",
             await_termination=False,
         )
     


### PR DESCRIPTION
This is meant to allow for concurrent execution of materialization jobs. If offset is not explicitly stated then it is received from kafka and another job might have committed new one right before the concurrently running job has received it.

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
