### PR TITLE
[FSTORE-1459] Fix test_base_client.py

### DIFF
--- a/python/tests/client/test_base_client.py
+++ b/python/tests/client/test_base_client.py
@@ -15,25 +15,12 @@
 #
 
 import os
-from functools import wraps
 
 import pytest
 import requests
 from hsfs.client.base import Client
 from hsfs.client.exceptions import RestAPIError
-
-
-def changes_environ(f):
-    @wraps(f)
-    def g(*args, **kwds):
-        old_environ = os.environ.copy()
-        try:
-            return f(*args, **kwds)
-        finally:
-            os.environ.clear()
-            os.environ.update(old_environ)
-
-    return g
+from tests.util import changes_environ
 
 
 class TestBaseClient:

--- a/python/tests/util.py
+++ b/python/tests/util.py
@@ -1,0 +1,31 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import os
+from functools import wraps
+
+
+def changes_environ(f):
+    @wraps(f)
+    def g(*args, **kwds):
+        old_environ = os.environ.copy()
+        try:
+            return f(*args, **kwds)
+        finally:
+            os.environ.clear()
+            os.environ.update(old_environ)
+
+    return g


### PR DESCRIPTION
It was impure, changing environ variable and thereby messing other tests (for example, [test_login.py](https://github.com/logicalclocks/hopsworks-api/blob/main/python/tests/hopsworks/test_login.py) from hopsworks-api). This PR wraps the tests from this file in a decorator saving and restoring os.environ.

JIRA Issue: [FSTORE-1459](https://hopsworks.atlassian.net/browse/FSTORE-1459)

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```


[FSTORE-1459]: https://hopsworks.atlassian.net/browse/FSTORE-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ