### PR TITLE
[FSTORE-1459] Fix spark initialization in client/external.py

### DIFF
--- a/python/hsfs/client/external.py
+++ b/python/hsfs/client/external.py
@@ -111,7 +111,7 @@ class Client(base.Client):
             # are needed when the application starts (before user code is run)
             # So in this case, we can't materialize the certificates on the fly.
             _logger.debug("Running in Spark environment, initializing Spark session")
-            _spark_session = SparkSession.builder.enableHiveSupport.getOrCreate()
+            _spark_session = SparkSession.builder.enableHiveSupport().getOrCreate()
 
             self._validate_spark_configuration(_spark_session)
             with open(


### PR DESCRIPTION
`enableHiveSupport` on itself is a method, and has to be called to get a builder from it.

JIRA Issue: [FSTORE-1459](https://hopsworks.atlassian.net/browse/FSTORE-1459)

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```


[FSTORE-1459]: https://hopsworks.atlassian.net/browse/FSTORE-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ