### PR TITLE
[FSTORE-1533] Importing hopsworks fails due to core dump while importing polars

### DIFF
--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.8.0-RC0</version>
+    <version>“3.8.1-RC1”</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.8.1-RC1</version>
+    <version>3.8.0-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>“3.8.1-RC1”</version>
+    <version>3.8.1-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.8.0-RC0</version>
+    <version>“3.8.1-RC1”</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.8.1-RC1</version>
+    <version>3.8.0-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>“3.8.1-RC1”</version>
+    <version>3.8.1-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.8.0-RC0</version>
+    <version>“3.8.1-RC1”</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.8.1-RC1</version>
+    <version>3.8.0-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>“3.8.1-RC1”</version>
+    <version>3.8.1-RC1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>“3.8.1-RC1”</version>
+    <version>3.8.1-RC1</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.8.1-RC1</version>
+    <version>3.8.0-RC1</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.8.0-RC0</version>
+    <version>“3.8.1-RC1”</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>“3.8.1-RC1”</version>
+        <version>3.8.1-RC1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>3.8.0-RC0</version>
+        <version>“3.8.1-RC1”</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>3.8.1-RC1</version>
+        <version>3.8.0-RC1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -403,10 +403,9 @@ class ArrowFlightClient:
         reader = self._connection.do_get(info.endpoints[0].ticket, options)
         _logger.debug("Dataset fetched. Converting to dataframe %s.", dataframe_type)
         if dataframe_type.lower() == "polars":
-            if HAS_POLARS:
-                return pl.from_arrow(reader.read_all())
-            else:
+            if not HAS_POLARS:
                 raise ModuleNotFoundError(polars_not_installed_message)
+            return pl.from_arrow(reader.read_all())
         else:
             return reader.read_pandas()
 

--- a/python/hsfs/core/arrow_flight_client.py
+++ b/python/hsfs/core/arrow_flight_client.py
@@ -23,17 +23,21 @@ import warnings
 from functools import wraps
 from typing import Any, Dict, Optional, Union
 
-import polars as pl
 import pyarrow
 import pyarrow._flight
 import pyarrow.flight
 from hsfs import client, feature_group, util
 from hsfs.client.exceptions import FeatureStoreException
 from hsfs.constructor import query
+from hsfs.core.constants import HAS_POLARS, polars_not_installed_message
 from hsfs.core.variable_api import VariableApi
 from hsfs.storage_connector import StorageConnector
 from pyarrow.flight import FlightServerError
 from retrying import retry
+
+
+if HAS_POLARS:
+    import polars as pl
 
 
 _logger = logging.getLogger(__name__)
@@ -399,7 +403,10 @@ class ArrowFlightClient:
         reader = self._connection.do_get(info.endpoints[0].ticket, options)
         _logger.debug("Dataset fetched. Converting to dataframe %s.", dataframe_type)
         if dataframe_type.lower() == "polars":
-            return pl.from_arrow(reader.read_all())
+            if HAS_POLARS:
+                return pl.from_arrow(reader.read_all())
+            else:
+                raise ModuleNotFoundError(polars_not_installed_message)
         else:
             return reader.read_pandas()
 

--- a/python/hsfs/core/constants.py
+++ b/python/hsfs/core/constants.py
@@ -1,0 +1,28 @@
+#
+#   Copyright 2024 Hopsworks AB
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+import importlib.util
+
+
+polars_not_installed_message = (
+    "Polars package not found. "
+    "If you want to use Polars with Hopsworks you can install the corresponding extras "
+    """`pip install hopsworks[polars]` or `pip install "hopsworks[polars]"` if using zsh. """
+    "You can also install polars directly in your environment e.g `pip install polars`. "
+    "You will need to restart your kernel if applicable."
+)
+
+HAS_POLARS: bool = importlib.util.find_spec("polars") is not None

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -21,7 +21,6 @@ from base64 import b64decode
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -70,7 +69,7 @@ try:
 except ImportError:
     from avro.io import BinaryDecoder
 
-if HAS_POLARS or TYPE_CHECKING:
+if HAS_POLARS or HAS_POLARS:
     import polars as pl
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -69,7 +69,7 @@ try:
 except ImportError:
     from avro.io import BinaryDecoder
 
-if HAS_POLARS or HAS_POLARS:
+if HAS_POLARS:
     import polars as pl
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/core/vector_server.py
+++ b/python/hsfs/core/vector_server.py
@@ -500,16 +500,14 @@ class VectorServer:
                 return pandas_df
         elif return_type.lower() == "polars":
             _logger.debug("Returning feature vector as polars dataframe")
-            if HAS_POLARS:
-                return pl.DataFrame(
-                    feature_vectorz if batch else [feature_vectorz],
-                    schema=self._feature_vector_col_name
-                    if not inference_helper
-                    else None,
-                    orient="row",
-                )
-            else:
+            if not HAS_POLARS:
                 raise ModuleNotFoundError(polars_not_installed_message)
+
+            return pl.DataFrame(
+                feature_vectorz if batch else [feature_vectorz],
+                schema=self._feature_vector_col_name if not inference_helper else None,
+                orient="row",
+            )
         else:
             raise ValueError(
                 f"""Unknown return type. Supported return types are {"'list', 'numpy'" if not inference_helper else "'dict'"}, 'polars' and 'pandas''"""

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -235,15 +235,15 @@ class Engine:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", UserWarning)
                     if dataframe_type.lower() == "polars":
-                        if HAS_POLARS:
-                            result_df = util.run_with_loading_animation(
-                                "Reading data from Hopsworks, using Hive",
-                                pl.read_database,
-                                sql_query,
-                                hive_conn,
-                            )
-                        else:
+                        if not HAS_POLARS:
                             raise ModuleNotFoundError(polars_not_installed_message)
+
+                        result_df = util.run_with_loading_animation(
+                            "Reading data from Hopsworks, using Hive",
+                            pl.read_database,
+                            sql_query,
+                            hive_conn,
+                        )
                     else:
                         result_df = util.run_with_loading_animation(
                             "Reading data from Hopsworks, using Hive",
@@ -278,10 +278,10 @@ class Engine:
             if "sqlalchemy" in str(type(mysql_conn)):
                 sql_query = sql.text(sql_query)
             if dataframe_type.lower() == "polars":
-                if HAS_POLARS:
-                    result_df = pl.read_database(sql_query, mysql_conn)
-                else:
+                if not HAS_POLARS:
                     raise ModuleNotFoundError(polars_not_installed_message)
+
+                result_df = pl.read_database(sql_query, mysql_conn)
             else:
                 result_df = pd.read_sql(sql_query, mysql_conn)
             if schema:

--- a/python/hsfs/engine/python.py
+++ b/python/hsfs/engine/python.py
@@ -31,7 +31,6 @@ from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
@@ -94,7 +93,7 @@ from tqdm.auto import tqdm
 # Disable pyhive INFO logging
 logging.getLogger("pyhive").setLevel(logging.WARNING)
 
-if HAS_POLARS or TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
 HAS_FAST = False

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -21,7 +21,7 @@ import logging
 import time
 import warnings
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 import avro.schema
 import confluent_kafka
@@ -29,7 +29,6 @@ import great_expectations as ge
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hsfs import (
     engine,
     feature,
@@ -77,6 +76,9 @@ from hsfs.statistics import Statistics
 from hsfs.statistics_config import StatisticsConfig
 from hsfs.validation_report import ValidationReport
 
+
+if TYPE_CHECKING:
+    import polars as pl
 
 _logger = logging.getLogger(__name__)
 
@@ -543,8 +545,13 @@ class FeatureGroupBase:
         """
         storage_connector_provenance = self.get_storage_connector_provenance()
 
-        if storage_connector_provenance.inaccessible or storage_connector_provenance.deleted:
-            _logger.info("The parent storage connector is deleted or inaccessible. For more details access `get_storage_connector_provenance`")
+        if (
+            storage_connector_provenance.inaccessible
+            or storage_connector_provenance.deleted
+        ):
+            _logger.info(
+                "The parent storage connector is deleted or inaccessible. For more details access `get_storage_connector_provenance`"
+            )
 
         if storage_connector_provenance.accessible:
             return storage_connector_provenance.accessible[0]

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -21,7 +21,7 @@ import logging
 import time
 import warnings
 from datetime import date, datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 import avro.schema
 import confluent_kafka
@@ -65,6 +65,7 @@ from hsfs.core import (
 )
 from hsfs.core import feature_monitoring_config as fmc
 from hsfs.core import feature_monitoring_result as fmr
+from hsfs.core.constants import HAS_POLARS
 from hsfs.core.job import Job
 from hsfs.core.variable_api import VariableApi
 from hsfs.core.vector_db_client import VectorDbClient
@@ -77,7 +78,7 @@ from hsfs.statistics_config import StatisticsConfig
 from hsfs.validation_report import ValidationReport
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import datetime
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import great_expectations as ge
 import humps
@@ -46,13 +46,14 @@ from hsfs.core import (
     training_dataset_api,
     transformation_function_engine,
 )
+from hsfs.core.constants import HAS_POLARS
 from hsfs.decorators import typechecked
 from hsfs.embedding import EmbeddingIndex
 from hsfs.statistics_config import StatisticsConfig
 from hsfs.transformation_function import TransformationFunction
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
 

--- a/python/hsfs/feature_store.py
+++ b/python/hsfs/feature_store.py
@@ -18,14 +18,13 @@ from __future__ import annotations
 
 import datetime
 import warnings
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
 
 import great_expectations as ge
 import humps
 import numpy
 import numpy as np
 import pandas as pd
-import polars as pl
 from hsfs import (
     expectation_suite,
     feature,
@@ -51,6 +50,10 @@ from hsfs.decorators import typechecked
 from hsfs.embedding import EmbeddingIndex
 from hsfs.statistics_config import StatisticsConfig
 from hsfs.transformation_function import TransformationFunction
+
+
+if TYPE_CHECKING:
+    import polars as pl
 
 
 @typechecked

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -20,12 +20,22 @@ import json
 import logging
 import warnings
 from datetime import date, datetime
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hsfs import (
     feature_group,
     storage_connector,
@@ -61,25 +71,29 @@ from hsfs.statistics_config import StatisticsConfig
 from hsfs.training_dataset_split import TrainingDatasetSplit
 
 
+if TYPE_CHECKING:
+    import polars as pl
+
+    TrainingDatasetDataFrameTypes = Union[
+        pd.DataFrame,
+        TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+        TypeVar("pyspark.RDD"),  # noqa: F821
+        np.ndarray,
+        List[List[Any]],
+        pl.DataFrame,
+    ]
+
+    SplineDataFrameTypes = Union[
+        pd.DataFrame,
+        TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
+        TypeVar("pyspark.RDD"),  # noqa: F821
+        np.ndarray,
+        List[List[Any]],
+        TypeVar("SplineGroup"),  # noqa: F821
+    ]
+
+
 _logger = logging.getLogger(__name__)
-
-TrainingDatasetDataFrameTypes = Union[
-    pd.DataFrame,
-    TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
-    TypeVar("pyspark.RDD"),  # noqa: F821
-    np.ndarray,
-    List[List[Any]],
-    pl.DataFrame,
-]
-
-SplineDataFrameTypes = Union[
-    pd.DataFrame,
-    TypeVar("pyspark.sql.DataFrame"),  # noqa: F821
-    TypeVar("pyspark.RDD"),  # noqa: F821
-    np.ndarray,
-    List[List[Any]],
-    TypeVar("SplineGroup"),  # noqa: F821
-]
 
 
 @typechecked

--- a/python/hsfs/feature_view.py
+++ b/python/hsfs/feature_view.py
@@ -21,7 +21,6 @@ import logging
 import warnings
 from datetime import date, datetime
 from typing import (
-    TYPE_CHECKING,
     Any,
     Dict,
     List,
@@ -62,6 +61,7 @@ from hsfs.core import (
 )
 from hsfs.core import feature_monitoring_config as fmc
 from hsfs.core import feature_monitoring_result as fmr
+from hsfs.core.constants import HAS_POLARS
 from hsfs.core.feature_view_api import FeatureViewApi
 from hsfs.core.vector_db_client import VectorDbClient
 from hsfs.decorators import typechecked
@@ -71,7 +71,7 @@ from hsfs.statistics_config import StatisticsConfig
 from hsfs.training_dataset_split import TrainingDatasetSplit
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
     TrainingDatasetDataFrameTypes = Union[

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -21,15 +21,17 @@ import os
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
 
 import humps
 import numpy as np
 import pandas as pd
-import polars as pl
 from hsfs import client, engine
 from hsfs.core import storage_connector_api
 
+
+if TYPE_CHECKING:
+    import polars as pl
 
 _logger = logging.getLogger(__name__)
 
@@ -211,7 +213,9 @@ class StorageConnector(ABC):
         feature_groups_provenance = self.get_feature_groups_provenance()
 
         if feature_groups_provenance.inaccessible or feature_groups_provenance.deleted:
-            _logger.info("There are deleted or inaccessible feature groups. For more details access `get_feature_groups_provenance`")
+            _logger.info(
+                "There are deleted or inaccessible feature groups. For more details access `get_feature_groups_provenance`"
+            )
 
         if feature_groups_provenance.accessible:
             return feature_groups_provenance.accessible

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -21,16 +21,17 @@ import os
 import re
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 import humps
 import numpy as np
 import pandas as pd
 from hsfs import client, engine
 from hsfs.core import storage_connector_api
+from hsfs.core.constants import HAS_POLARS
 
 
-if TYPE_CHECKING:
+if HAS_POLARS:
     import polars as pl
 
 _logger = logging.getLogger(__name__)

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.8.0rc0"
+__version__ = "3.8.0rc1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "fsspec",
     "retrying",
     "hopsworks_aiomysql[sa]==0.2.1",
-    "polars>=0.20.18,<=0.21.0",
     "opensearch-py>=1.1.0,<=2.4.2",
 ]
 
@@ -81,6 +80,7 @@ python = [
     "fastavro>=1.4.11,<=1.8.4",
     "tqdm",
 ]
+polars=["polars>=0.20.18,<=0.21.0"]
 
 [build-system]
 requires = ["setuptools", "wheel"]

--- a/python/tests/engine/test_python.py
+++ b/python/tests/engine/test_python.py
@@ -18,7 +18,6 @@ from datetime import date, datetime
 
 import numpy as np
 import pandas as pd
-import polars as pl
 import pyarrow as pa
 import pytest
 from confluent_kafka.admin import PartitionMetadata, TopicMetadata
@@ -35,9 +34,14 @@ from hsfs.client import exceptions
 from hsfs.constructor import query
 from hsfs.constructor.hudi_feature_group_alias import HudiFeatureGroupAlias
 from hsfs.core import inode, job
+from hsfs.core.constants import HAS_POLARS
 from hsfs.engine import python
 from hsfs.training_dataset_feature import TrainingDatasetFeature
-from polars.testing import assert_frame_equal as polars_assert_frame_equal
+
+
+if HAS_POLARS:
+    import polars as pl
+    from polars.testing import assert_frame_equal as polars_assert_frame_equal
 
 
 class TestPython:
@@ -278,6 +282,10 @@ class TestPython:
         assert isinstance(dataframe, pd.DataFrame)
         assert len(dataframe) == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_hopsfs_connector_empty_dataframe_polars(self, mocker):
         # Arrange
 
@@ -429,6 +437,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 0
         assert mock_pandas_read_parquet.call_count == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_csv(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -443,6 +455,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 1
         assert mock_pandas_read_parquet.call_count == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_tsv(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -457,6 +473,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 1
         assert mock_pandas_read_parquet.call_count == 0
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_parquet(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -474,6 +494,10 @@ class TestPython:
         assert mock_pandas_read_csv.call_count == 0
         assert mock_pandas_read_parquet.call_count == 1
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_read_polars_other(self, mocker):
         # Arrange
         mock_pandas_read_csv = mocker.patch("polars.read_csv")
@@ -1013,6 +1037,10 @@ class TestPython:
         )
         assert mock_python_engine_convert_pandas_statistics.call_count == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_profile_polars(self, mocker):
         # Arrange
         mock_python_engine_convert_pandas_statistics = mocker.patch(
@@ -1051,6 +1079,10 @@ class TestPython:
         )
         assert mock_python_engine_convert_pandas_statistics.call_count == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_profile_polars_with_null_column(self, mocker):
         # Arrange
         mock_python_engine_convert_pandas_statistics = mocker.patch(
@@ -1365,6 +1397,10 @@ class TestPython:
             "Feature names are sanitized to use underscore '_' in the feature store."
         )
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_convert_to_default_dataframe_polars(self, mocker):
         # Arrange
         mock_warnings = mocker.patch("warnings.warn")
@@ -1431,6 +1467,10 @@ class TestPython:
         assert result[0].name == "col1"
         assert result[1].name == "col2"
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_parse_schema_feature_group_polars(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.python.Engine._convert_pandas_dtype_to_offline_type")
@@ -2317,6 +2357,10 @@ class TestPython:
         assert isinstance(result_df, pd.DataFrame)
         assert result_df_split is None
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_split_labels_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()
@@ -2412,6 +2456,10 @@ class TestPython:
         assert isinstance(result_df, pd.DataFrame)
         assert isinstance(result_df_split, pd.Series)
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_split_labels_labels_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()
@@ -3093,6 +3141,10 @@ class TestPython:
         # Assert
         assert str(result) == "   col1  col2\n0     1     3\n1     2     4"
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_return_dataframe_type_polars(self):
         # Arrange
         python_engine = python.Engine()
@@ -3269,6 +3321,10 @@ class TestPython:
         assert result["tf_name"][0] == 2
         assert result["tf_name"][1] == 3
 
+    @pytest.mark.skipif(
+        not HAS_POLARS,
+        reason="Polars is not installed.",
+    )
     def test_apply_transformation_function_polars(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
@@ -3763,7 +3819,7 @@ class TestPython:
             args="defaults tests_offsets",
             await_termination=False,
         )
-    
+
     def test_materialization_kafka_skip_offsets(self, mocker):
         # Arrange
         mocker.patch("hsfs.engine.python.Engine._get_kafka_config", return_value={})
@@ -3805,7 +3861,10 @@ class TestPython:
         python_engine._write_dataframe_kafka(
             feature_group=fg,
             dataframe=df,
-            offline_write_options={"start_offline_materialization": True, "skip_offsets": True},
+            offline_write_options={
+                "start_offline_materialization": True,
+                "skip_offsets": True,
+            },
         )
 
         # Assert

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -9,3 +9,4 @@ markdown==3.6
 pymdown-extensions==10.7.1
 mkdocs-macros-plugin==1.0.4
 mkdocs-minify-plugin>=0.2.0
+polars==0.20.31

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.8.0-RC0</version>
+    <version>“3.8.1-RC1”</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.8.1-RC1</version>
+    <version>3.8.0-RC1</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>“3.8.1-RC1”</version>
+    <version>3.8.1-RC1</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>


### PR DESCRIPTION
This PR fixes an issue in which hopworks is not importable because Polars throws a "" due to AVX instructions being unavailable.

https://github.com/pola-rs/polars/issues/2922 
https://github.com/pola-rs/polars?tab=readme-ov-file#legacy 

Fix Done: 
Make polars a optional dependency. The changes being done closely resembles the changes done for 4.0 (https://github.com/logicalclocks/feature-store-api/pull/1363)


JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1533

Related PRs: 
https://github.com/logicalclocks/hopsworks-api/pull/318
https://github.com/logicalclocks/loadtest/pull/454


**How Has This Been Tested?**

- [x] Unit Tests
- [ ] Integration Tests
- [x] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
