### PR TITLE
[FSTORE-1724][3.9] Event time columns not casted to lower case before feature name validation

### DIFF
--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -308,9 +308,11 @@ class Engine:
 
         if isinstance(dataframe, DataFrame):
             upper_case_features = [
-                c for c in dataframe.columns if any(re.finditer("[A-Z]", c))
+                c for c in dataframe.columns if util.contains_uppercase(c)
             ]
-            space_features = [c for c in dataframe.columns if " " in c]
+            space_features = [
+                c for c in dataframe.columns if util.contains_whitespace(c)
+            ]
             if len(upper_case_features) > 0:
                 warnings.warn(
                     "The ingested dataframe contains upper case letters in feature names: `{}`. "

--- a/python/hsfs/feature.py
+++ b/python/hsfs/feature.py
@@ -55,7 +55,7 @@ class Feature:
         ] = None,
         **kwargs,
     ) -> None:
-        self._name = util.autofix_feature_name(name)
+        self._name = util.autofix_feature_name(name, warn=True)
         self._type = type
         self._description = description
         self._primary = primary

--- a/python/hsfs/feature_group.py
+++ b/python/hsfs/feature_group.py
@@ -1660,7 +1660,9 @@ class FeatureGroupBase:
 
     @primary_key.setter
     def primary_key(self, new_primary_key: List[str]) -> None:
-        self._primary_key = [util.autofix_feature_name(pk) for pk in new_primary_key]
+        self._primary_key = [
+            util.autofix_feature_name(pk, warn=True) for pk in new_primary_key
+        ]
 
     def get_statistics(
         self,
@@ -1798,7 +1800,7 @@ class FeatureGroupBase:
             self._event_time = None
             return
         elif isinstance(feature_name, str):
-            self._event_time = feature_name
+            self._event_time = util.autofix_feature_name(feature_name, warn=True)
             return
         elif isinstance(feature_name, list) and len(feature_name) == 1:
             if isinstance(feature_name[0], str):
@@ -1808,7 +1810,7 @@ class FeatureGroupBase:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-                self._event_time = feature_name[0]
+                self._event_time = util.autofix_feature_name(feature_name[0], warn=True)
                 return
 
         raise ValueError(
@@ -2128,7 +2130,7 @@ class FeatureGroup(FeatureGroupBase):
             self.primary_key = primary_key
             self.partition_key = partition_key
             self._hudi_precombine_key = (
-                util.autofix_feature_name(hudi_precombine_key)
+                util.autofix_feature_name(hudi_precombine_key, warn=True)
                 if hudi_precombine_key is not None
                 and (
                     self._time_travel_format is None
@@ -3440,12 +3442,14 @@ class FeatureGroup(FeatureGroupBase):
     @partition_key.setter
     def partition_key(self, new_partition_key: List[str]) -> None:
         self._partition_key = [
-            util.autofix_feature_name(pk) for pk in new_partition_key
+            util.autofix_feature_name(pk, warn=True) for pk in new_partition_key
         ]
 
     @hudi_precombine_key.setter
     def hudi_precombine_key(self, hudi_precombine_key: str) -> None:
-        self._hudi_precombine_key = util.autofix_feature_name(hudi_precombine_key)
+        self._hudi_precombine_key = util.autofix_feature_name(
+            hudi_precombine_key, warn=True
+        )
 
     @stream.setter
     def stream(self, stream: bool) -> None:

--- a/python/hsfs/util.py
+++ b/python/hsfs/util.py
@@ -22,6 +22,7 @@ import re
 import sys
 import threading
 import time
+import warnings
 from datetime import date, datetime, timezone
 from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union
 from urllib.parse import urljoin, urlparse
@@ -94,9 +95,33 @@ def parse_features(
         return []
 
 
-def autofix_feature_name(name: str) -> str:
+def autofix_feature_name(name: str, warn: bool = False) -> str:
     # replace spaces with underscores and enforce lower case
+    if warn and contains_uppercase(name):
+        warnings.warn(
+            "The feature name `{}` contains upper case letters. "
+            "Feature names are sanitized to lower case in the feature store.".format(
+                name
+            ),
+            stacklevel=1,
+        )
+    if warn and contains_whitespace(name):
+        warnings.warn(
+            "The feature name `{}` contains spaces. "
+            "Feature names are sanitized to use underscore '_' in the feature store.".format(
+                name
+            ),
+            stacklevel=1,
+        )
     return name.lower().replace(" ", "_")
+
+
+def contains_uppercase(name: str) -> bool:
+    return any(re.finditer("[A-Z]", name))
+
+
+def contains_whitespace(name: str) -> bool:
+    return " " in name
 
 
 def feature_group_name(

--- a/python/tests/test_feature_group.py
+++ b/python/tests/test_feature_group.py
@@ -941,3 +941,44 @@ class TestExternalFeatureGroup:
 
         # Assert
         engine_instance.assert_called_once()
+
+    def test_upper_case_primary_key_event_time(self, mocker, backend_fixtures, caplog):
+        # Arrange
+        mocker.patch("hsfs.client.get_instance")
+        mocker.patch("hsfs.engine.get_type")
+        json = backend_fixtures["feature_store"]["get"]["response"]
+
+        features = [
+            feature.Feature(name="PrimaryKey", type="int"),
+            feature.Feature(name="Event_Time", type="timestamp"),
+            feature.Feature(name="feat", type="int"),
+        ]
+
+        # Act
+        fs = feature_store.FeatureStore.from_response_json(json)
+        with warnings.catch_warnings(record=True) as warning_record:
+            new_fg = fs.create_feature_group(
+                name="fg_name",
+                version=1,
+                description="fg_description",
+                event_time="Event_Time",
+                primary_key=["PrimaryKey"],
+                features=features,
+            )
+
+        assert len(warning_record) == 2
+        assert (
+            "The feature name `Event_Time` contains upper case letters. Feature names are sanitized to lower case in the feature store."
+            == str(warning_record[0].message)
+        )
+        assert (
+            "The feature name `PrimaryKey` contains upper case letters. Feature names are sanitized to lower case in the feature store."
+            == str(warning_record[1].message)
+        )
+
+        # Assert
+        assert new_fg.event_time == "event_time"
+        assert new_fg.primary_key == ["primarykey"]
+        assert new_fg.features[0].name == "primarykey"
+        assert new_fg.features[1].name == "event_time"
+        assert new_fg.features[2].name == "feat"


### PR DESCRIPTION
This PR ports changes done by PR : https://github.com/logicalclocks/hopsworks-api/pull/531 to the 3.9 branckh.

JIRA Issue: https://hopsworks.atlassian.net/browse/FSTORE-1724

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
