### PR TITLE
Using multiple Kafka connectors from the same Spark session doesn't work

### DIFF
--- a/java/beam/pom.xml
+++ b/java/beam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.9.0-RC22</version>
+    <version>3.9.0-RC23</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/flink/pom.xml
+++ b/java/flink/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.9.0-RC22</version>
+    <version>3.9.0-RC23</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/hsfs/pom.xml
+++ b/java/hsfs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>hsfs-parent</artifactId>
     <groupId>com.logicalclocks</groupId>
-    <version>3.9.0-RC22</version>
+    <version>3.9.0-RC23</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.9.0-RC22</version>
+    <version>3.9.0-RC23</version>
     <modules>
         <module>hsfs</module>
         <module>spark</module>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>hsfs-parent</artifactId>
         <groupId>com.logicalclocks</groupId>
-        <version>3.9.0-RC22</version>
+        <version>3.9.0-RC23</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -1027,7 +1027,8 @@ class Engine:
             self._spark_context.addFile(file)
             return SparkFiles.get(file_name)
         else:
-            return file
+            # Remove the 'file://' prefix for local file paths
+            return file[7:]
 
     def profile(
         self,

--- a/python/hsfs/engine/spark.py
+++ b/python/hsfs/engine/spark.py
@@ -592,7 +592,8 @@ class Engine:
         Step 1: Deserializes 'value' column from binary using avro schema.
         """
         decoded_dataframe = dataframe.withColumn(
-            serialized_column, from_avro(serialized_column, feature_group._get_encoded_avro_schema())
+            serialized_column,
+            from_avro(serialized_column, feature_group._get_encoded_avro_schema()),
         )
 
         """
@@ -605,10 +606,12 @@ class Engine:
                 # re-apply from_avro on the nested field
                 decoded_field = from_avro(
                     col(f"{serialized_column}.{field_name}"),
-                    feature_group._get_feature_avro_schema(field_name)
+                    feature_group._get_feature_avro_schema(field_name),
                 ).alias(field_name)
             else:
-                decoded_field = col(f"{serialized_column}.{field_name}").alias(field_name)
+                decoded_field = col(f"{serialized_column}.{field_name}").alias(
+                    field_name
+                )
             new_value_fields.append(decoded_field)
 
         """
@@ -616,7 +619,10 @@ class Engine:
         """
         updated_value_col = struct(*new_value_fields).alias(serialized_column)
 
-        return decoded_dataframe.select(*[col(c) for c in decoded_dataframe.columns if c != serialized_column], updated_value_col)
+        return decoded_dataframe.select(
+            *[col(c) for c in decoded_dataframe.columns if c != serialized_column],
+            updated_value_col,
+        )
 
     def get_training_data(
         self,
@@ -994,7 +1000,7 @@ class Engine:
             return stream.load()
         return stream.load().select("key", "value")
 
-    def add_file(self, file):
+    def add_file(self, file, distribute=True):
         if not file:
             return file
 
@@ -1004,8 +1010,9 @@ class Engine:
 
         file_name = os.path.basename(file)
 
-        # for external clients, download the file
-        if isinstance(client.get_instance(), client.external.Client):
+        # for external clients, download the file using the dataset API
+        # also if the client is internal, but we only need the files on the driver
+        if isinstance(client.get_instance(), client.external.Client) or not distribute:
             tmp_file = f"/tmp/{file_name}"
             print("Reading key file from storage connector.")
             response = self._dataset_api.read_content(file, util.get_dataset_type(file))
@@ -1015,9 +1022,12 @@ class Engine:
 
             file = f"file://{tmp_file}"
 
-        self._spark_context.addFile(file)
-
-        return SparkFiles.get(file_name)
+        # If we need the files on the executors, then we should call addFile
+        if distribute:
+            self._spark_context.addFile(file)
+            return SparkFiles.get(file_name)
+        else:
+            return file
 
     def profile(
         self,

--- a/python/hsfs/storage_connector.py
+++ b/python/hsfs/storage_connector.py
@@ -1092,13 +1092,9 @@ class KafkaConnector(StorageConnector):
         # KAFKA
         self._bootstrap_servers = bootstrap_servers
         self._security_protocol = security_protocol
-        self._ssl_truststore_location = engine.get_instance().add_file(
-            ssl_truststore_location
-        )
+        self._ssl_truststore_location = ssl_truststore_location
         self._ssl_truststore_password = ssl_truststore_password
-        self._ssl_keystore_location = engine.get_instance().add_file(
-            ssl_keystore_location
-        )
+        self._ssl_keystore_location = ssl_keystore_location
         self._ssl_keystore_password = ssl_keystore_password
         self._ssl_key_password = ssl_key_password
         self._ssl_endpoint_identification_algorithm = (
@@ -1203,6 +1199,15 @@ class KafkaConnector(StorageConnector):
         Right now only producer values with Importance >= medium are implemented.
         https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html
         """
+
+        # Materialize the certificates to be converted to PEM files
+        self._ssl_truststore_location = engine.get_instance().add_file(
+            self._ssl_truststore_location
+        )
+        self._ssl_keystore_location = engine.get_instance().add_file(
+            self._ssl_keystore_location
+        )
+
         config = {}
         kafka_options = self.kafka_options()
         for key, value in kafka_options.items():
@@ -1303,20 +1308,32 @@ class KafkaConnector(StorageConnector):
         """
         from packaging import version
 
+        kafka_client_supports_pem = version.parse(
+            engine.get_instance().get_spark_version()
+        ) >= version.parse("3.2.0")
+
+        # Only distribute the files if the Kafka client does not support being configured with PEM content
+        self._ssl_truststore_location = engine.get_instance().add_file(
+            self._ssl_truststore_location, distribute=not kafka_client_supports_pem
+        )
+        self._ssl_keystore_location = engine.get_instance().add_file(
+            self._ssl_keystore_location, distribute=not kafka_client_supports_pem
+        )
+
         spark_config = {}
-
         kafka_options = self.kafka_options()
-
         for key, value in kafka_options.items():
-            if key in [
-                "ssl.truststore.location",
-                "ssl.truststore.password",
-                "ssl.keystore.location",
-                "ssl.keystore.password",
-                "ssl.key.password",
-            ] and version.parse(
-                engine.get_instance().get_spark_version()
-            ) >= version.parse("3.2.0"):
+            if (
+                key
+                in [
+                    "ssl.truststore.location",
+                    "ssl.truststore.password",
+                    "ssl.keystore.location",
+                    "ssl.keystore.password",
+                    "ssl.key.password",
+                ]
+                and kafka_client_supports_pem
+            ):
                 # We can only use this in the newer version of Spark which depend on Kafka > 2.7.0
                 # Kafka 2.7.0 adds support for providing the SSL credentials as PEM objects.
                 if not self._pem_files_created:

--- a/python/hsfs/version.py
+++ b/python/hsfs/version.py
@@ -14,4 +14,4 @@
 #   limitations under the License.
 #
 
-__version__ = "3.9.0rc22"
+__version__ = "3.9.0rc23"

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -3389,9 +3389,6 @@ class TestSpark:
         assert "name" in result.columns
         assert result.schema["name"].dataType == StringType()
 
-    @pytest.mark.skipif(
-        sys.platform.startswith("win"), reason="Skipping test on Windows"
-    )
     def test_add_file(self, mocker):
         # Arrange
         mock_pyspark_getOrCreate = mocker.patch(
@@ -3419,6 +3416,9 @@ class TestSpark:
         )
         assert mock_pyspark_files_get.call_args[0][0] == "test_file"
 
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="Skipping test on Windows"
+    )
     def test_add_file_do_not_distribute(self, mocker):
         # Arrange
         mocker.patch("hsfs.client.get_instance")

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -58,6 +58,7 @@ from pyspark.sql.types import (
     StructType,
     TimestampType,
 )
+from requests.models import Response
 
 
 engine._engine_type = "spark"
@@ -1607,7 +1608,7 @@ class TestSpark:
         data = []
         data.append((b"2121", b"21212121"))
         data.append((b"1212", b"12121212"))
-        pandas_df = pd.DataFrame(data, columns =["key", "value"])
+        pandas_df = pd.DataFrame(data, columns=["key", "value"])
 
         df = spark_engine._spark_session.createDataFrame(pandas_df)
 
@@ -1627,10 +1628,10 @@ class TestSpark:
             features=features,
         )
         fg._subject = {
-            'id': 1025,
-            'subject': 'fg_1',
-            'version': 1,
-            'schema': '{"type":"record","name":"fg_1","namespace":"test_featurestore.db","fields":[{"name":"account_id","type":["null","string"]},{"name":"last_played_games","type":["null",{"type":"array","items":["null","string"]}]},{"name":"event_time","type":["null",{"type":"long","logicalType":"timestamp-micros"}]}]}'
+            "id": 1025,
+            "subject": "fg_1",
+            "version": 1,
+            "schema": '{"type":"record","name":"fg_1","namespace":"test_featurestore.db","fields":[{"name":"account_id","type":["null","string"]},{"name":"last_played_games","type":["null",{"type":"array","items":["null","string"]}]},{"name":"event_time","type":["null",{"type":"long","logicalType":"timestamp-micros"}]}]}',
         }
 
         # Act
@@ -1640,7 +1641,7 @@ class TestSpark:
         )
 
         # Assert
-        expected_schema = json.loads('''{
+        expected_schema = json.loads("""{
             "fields": [
                 {"metadata": {}, "name": "key", "nullable": true, "type": "binary"},
                 {"metadata": {}, "name": "value", "nullable": false, "type": {
@@ -1654,7 +1655,7 @@ class TestSpark:
                 }}
             ],
             "type": "struct"
-        }''')
+        }""")
 
         actual_schema = json.loads(deserialized_df.schema.json())
         assert actual_schema == expected_schema
@@ -1666,9 +1667,15 @@ class TestSpark:
         now = datetime.datetime.now()
 
         fg_data = []
-        fg_data.append(("ekarson", ["GRAVITY RUSH 2", "KING'S QUEST"], pd.Timestamp(now)))
-        fg_data.append(("ratmilkdrinker", ["NBA 2K", "CALL OF DUTY"], pd.Timestamp(now)))
-        pandas_df = pd.DataFrame(fg_data, columns =["account_id", "last_played_games", "event_time"])
+        fg_data.append(
+            ("ekarson", ["GRAVITY RUSH 2", "KING'S QUEST"], pd.Timestamp(now))
+        )
+        fg_data.append(
+            ("ratmilkdrinker", ["NBA 2K", "CALL OF DUTY"], pd.Timestamp(now))
+        )
+        pandas_df = pd.DataFrame(
+            fg_data, columns=["account_id", "last_played_games", "event_time"]
+        )
 
         df = spark_engine._spark_session.createDataFrame(pandas_df)
 
@@ -1688,10 +1695,10 @@ class TestSpark:
             features=features,
         )
         fg._subject = {
-            'id': 1025,
-            'subject': 'fg_1',
-            'version': 1,
-            'schema': '{"type":"record","name":"fg_1","namespace":"test_featurestore.db","fields":[{"name":"account_id","type":["null","string"]},{"name":"last_played_games","type":["null",{"type":"array","items":["null","string"]}]},{"name":"event_time","type":["null",{"type":"long","logicalType":"timestamp-micros"}]}]}'
+            "id": 1025,
+            "subject": "fg_1",
+            "version": 1,
+            "schema": '{"type":"record","name":"fg_1","namespace":"test_featurestore.db","fields":[{"name":"account_id","type":["null","string"]},{"name":"last_played_games","type":["null",{"type":"array","items":["null","string"]}]},{"name":"event_time","type":["null",{"type":"long","logicalType":"timestamp-micros"}]}]}',
         }
 
         # Act
@@ -1706,7 +1713,10 @@ class TestSpark:
         )
 
         # Assert
-        assert serialized_df.schema.json() == '{"fields":[{"metadata":{},"name":"key","nullable":false,"type":"binary"},{"metadata":{},"name":"value","nullable":false,"type":"binary"}],"type":"struct"}'
+        assert (
+            serialized_df.schema.json()
+            == '{"fields":[{"metadata":{},"name":"key","nullable":false,"type":"binary"},{"metadata":{},"name":"value","nullable":false,"type":"binary"}],"type":"struct"}'
+        )
         assert df.schema == deserialized_df.schema["value"].dataType
         assert df.collect() == deserialized_df.select("value.*").collect()
 
@@ -3404,6 +3414,27 @@ class TestSpark:
             == "hdfs://test_file"
         )
         assert mock_pyspark_files_get.call_args[0][0] == "test_file"
+
+    def test_add_file_do_not_distribute(self, mocker):
+        # Arrange
+        mocker.patch("hsfs.client.get_instance")
+
+        response = Response()
+        response._content = b"test_content"
+        mocker.patch(
+            "hsfs.core.dataset_api.DatasetApi.read_content", return_value=response
+        )
+
+        spark_engine = spark.Engine()
+
+        # Act
+        file_path = spark_engine.add_file(
+            file="test_file",
+            distribute=False,
+        )
+
+        # Assert
+        assert file_path == "/tmp/test_file"
 
     def test_profile(self, mocker):
         # Arrange

--- a/python/tests/engine/test_spark.py
+++ b/python/tests/engine/test_spark.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import sys
 from unittest.mock import call
 
 import numpy
@@ -3388,6 +3389,9 @@ class TestSpark:
         assert "name" in result.columns
         assert result.schema["name"].dataType == StringType()
 
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="Skipping test on Windows"
+    )
     def test_add_file(self, mocker):
         # Arrange
         mock_pyspark_getOrCreate = mocker.patch(

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -548,12 +548,7 @@ class TestKafkaConnector:
 
     def test_kafka_options_external(self, mocker, backend_fixtures):
         # Arrange
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
         json = backend_fixtures["storage_connector"]["get_kafka_external"]["response"]
-
-        mock_engine_get_instance.return_value.add_file.return_value = (
-            "result_from_add_file"
-        )
 
         sc = storage_connector.StorageConnector.from_response_json(json)
 
@@ -566,9 +561,9 @@ class TestKafkaConnector:
             "bootstrap.servers": "test_bootstrap_servers",
             "security.protocol": "test_security_protocol",
             "ssl.endpoint.identification.algorithm": "test_ssl_endpoint_identification_algorithm",
-            "ssl.truststore.location": "result_from_add_file",
+            "ssl.truststore.location": "test_ssl_truststore_location",
             "ssl.truststore.password": "test_ssl_truststore_password",
-            "ssl.keystore.location": "result_from_add_file",
+            "ssl.keystore.location": "test_ssl_keystore_location",
             "ssl.keystore.password": "test_ssl_keystore_password",
             "ssl.key.password": "test_ssl_key_password",
         }

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -445,12 +445,7 @@ class TestJdbcConnector:
 class TestKafkaConnector:
     def test_from_response_json(self, mocker, backend_fixtures):
         # Arrange
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
         json = backend_fixtures["storage_connector"]["get_kafka_internal"]["response"]
-
-        mock_engine_get_instance.return_value.add_file.return_value = (
-            "result_from_add_file"
-        )
 
         # Act
         sc = storage_connector.StorageConnector.from_response_json(json)
@@ -462,9 +457,9 @@ class TestKafkaConnector:
         assert sc.description == "Kafka connector description"
         assert sc._bootstrap_servers == "test_bootstrap_servers"
         assert sc.security_protocol == "test_security_protocol"
-        assert sc.ssl_truststore_location == "result_from_add_file"
+        assert sc.ssl_truststore_location == "test_ssl_truststore_location"
         assert sc._ssl_truststore_password == "test_ssl_truststore_password"
-        assert sc.ssl_keystore_location == "result_from_add_file"
+        assert sc.ssl_keystore_location == "test_ssl_keystore_location"
         assert sc._ssl_keystore_password == "test_ssl_keystore_password"
         assert sc._ssl_key_password == "test_ssl_key_password"
         assert (
@@ -475,12 +470,7 @@ class TestKafkaConnector:
 
     def test_from_response_json_basic_info(self, mocker, backend_fixtures):
         # Arrange
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
         json = backend_fixtures["storage_connector"]["get_kafka_basic_info"]["response"]
-
-        mock_engine_get_instance.return_value.add_file.return_value = (
-            "result_from_add_file"
-        )
 
         # Act
         sc = storage_connector.StorageConnector.from_response_json(json)
@@ -492,9 +482,9 @@ class TestKafkaConnector:
         assert sc.description is None
         assert sc._bootstrap_servers is None
         assert sc.security_protocol is None
-        assert sc.ssl_truststore_location == "result_from_add_file"
+        assert sc.ssl_truststore_location is None
         assert sc._ssl_truststore_password is None
-        assert sc.ssl_keystore_location == "result_from_add_file"
+        assert sc.ssl_keystore_location is None
         assert sc._ssl_keystore_password is None
         assert sc._ssl_key_password is None
         assert sc.ssl_endpoint_identification_algorithm is None
@@ -504,12 +494,7 @@ class TestKafkaConnector:
     def test_kafka_options_user_sc(self, mocker, backend_fixtures):
         # Arrange
         mocker.patch("hsfs.client.get_instance")
-        mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")
         json = backend_fixtures["storage_connector"]["get_kafka"]["response"]
-
-        mock_engine_get_instance.return_value.add_file.return_value = (
-            "result_from_add_file"
-        )
 
         sc = storage_connector.StorageConnector.from_response_json(json)
 
@@ -522,14 +507,14 @@ class TestKafkaConnector:
             "bootstrap.servers": "test_bootstrap_servers",
             "security.protocol": "test_security_protocol",
             "ssl.endpoint.identification.algorithm": "test_ssl_endpoint_identification_algorithm",
-            "ssl.truststore.location": "result_from_add_file",
+            "ssl.truststore.location": "test_ssl_truststore_location",
             "ssl.truststore.password": "test_ssl_truststore_password",
-            "ssl.keystore.location": "result_from_add_file",
+            "ssl.keystore.location": "test_ssl_keystore_location",
             "ssl.keystore.password": "test_ssl_keystore_password",
             "ssl.key.password": "test_ssl_key_password",
         }
 
-    def test_kafka_options_intenral(self, mocker, backend_fixtures):
+    def test_kafka_options_internal(self, mocker, backend_fixtures):
         # Arrange
         mocker.patch("hsfs.engine.get_instance")
         mock_client_get_instance = mocker.patch("hsfs.client.get_instance")

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -637,6 +637,9 @@ class TestKafkaConnector:
         json = backend_fixtures["storage_connector"]["get_kafka_internal"]["response"]
 
         mock_engine_get_instance.return_value.get_spark_version.return_value = "3.5.0"
+        mock_engine_get_instance.return_value.add_file.return_value = (
+            "result_from_add_file"
+        )
 
         mock_client_get_instance.return_value._get_jks_trust_store_path.return_value = (
             "result_from_get_jks_trust_store_path"

--- a/python/tests/test_storage_connector.py
+++ b/python/tests/test_storage_connector.py
@@ -680,6 +680,13 @@ class TestKafkaConnector:
             "kafka.ssl.keystore.key": "test_ssl_key",
         }
 
+        mock_engine_get_instance.return_value.add_file.assert_any_call(
+            "test_ssl_truststore_location", distribute=False
+        )
+        mock_engine_get_instance.return_value.add_file.assert_any_call(
+            "test_ssl_keystore_location", distribute=False
+        )
+
     def test_confluent_options(self, mocker, backend_fixtures):
         # Arrange
         mock_engine_get_instance = mocker.patch("hsfs.engine.get_instance")

--- a/utils/java/pom.xml
+++ b/utils/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.logicalclocks</groupId>
     <artifactId>hsfs-utils</artifactId>
-    <version>3.9.0-RC22</version>
+    <version>3.9.0-RC23</version>
 
     <properties>
         <hops.version>3.2.0.0-SNAPSHOT</hops.version>


### PR DESCRIPTION
This is caused by the addFile method not overwriting the content of the file if the file name matches.
This PR addresses the issue for Spark versions > 3.2 where the addFile method is not needed as the Kafka client authenticates using the certificates in PEM format rather than the JKS format.

This PR adds/fixes/changes...
- please summarize your changes to the code 
- and make sure to include all changes to user-facing APIs

JIRA Issue: -

Priority for Review: -

Related PRs: -

**How Has This Been Tested?**

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests on VM


**Checklist For The Assigned Reviewer:**

```
- [ ] Checked if merge conflicts with master exist
- [ ] Checked if stylechecks for Java and Python pass
- [ ] Checked if all docstrings were added and/or updated appropriately
- [ ] Ran spellcheck on docstring
- [ ] Checked if guides & concepts need to be updated
- [ ] Checked if naming conventions for parameters and variables were followed
- [ ] Checked if private methods are properly declared and used
- [ ] Checked if hard-to-understand areas of code are commented
- [ ] Checked if tests are effective
- [ ] Built and deployed changes on dev VM and tested manually
- [x] (Checked if all type annotations were added and/or updated appropriately)
```
